### PR TITLE
feat(sync): auto-provision agent on first push

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "name": "kernle-memory-load",
+        "description": "Automatically load Kernle persistent memory at session start",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'kernle -a claire load 2>/dev/null || echo \"# Kernle Memory\\n\\nKernle not available in this session.\"'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/uv.lock
+++ b/uv.lock
@@ -628,7 +628,7 @@ wheels = [
 
 [[package]]
 name = "kernle"
-version = "0.1.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "python-dotenv" },
@@ -646,6 +646,7 @@ cloud = [
 ]
 dev = [
     { name = "black" },
+    { name = "mcp" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -662,6 +663,7 @@ mcp = [
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0" },
     { name = "kernle", extras = ["local", "cloud", "mcp"], marker = "extra == 'all'" },
+    { name = "mcp", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21" },


### PR DESCRIPTION
When an authenticated user syncs with an agent_id that doesn't exist,
the sync push now auto-creates the agent record. This handles:
- Post-migration recovery (agent deleted but user exists)
- First-time sync from new agent names
- Smoother onboarding without explicit registration step

The agent is created with an empty secret_hash since the user
authenticates via API key, not agent-level credentials.
