### PR TITLE
fix: unwrap API keys response to extract array

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -113,7 +113,8 @@ export interface CreateKeyResponse {
 }
 
 export async function listApiKeys(): Promise<ApiKey[]> {
-  return fetchApi<ApiKey[]>('/auth/keys');
+  const response = await fetchApi<{ keys: ApiKey[] }>('/auth/keys');
+  return response.keys;
 }
 
 export async function createApiKey(name?: string): Promise<CreateKeyResponse> {


### PR DESCRIPTION
## Summary
- Fixed "e.filter is not a function" error on the API keys page
- The backend returns `{keys: [...]}` via the `APIKeyList` model, but `listApiKeys()` was treating it as a raw array
- Updated `listApiKeys()` to properly extract the `keys` array from the response

## Test plan
- [ ] Navigate to the API Keys page in the dashboard
- [ ] Verify the page loads without JavaScript errors
- [ ] Verify active and revoked keys are displayed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)