### PR TITLE
fix: handle empty API responses (204 No Content)

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -34,7 +34,17 @@ async function fetchApi<T>(
     throw new ApiError(response.status, error.detail || 'Request failed');
   }
 
-  return response.json();
+  // Handle 204 No Content or empty responses (common for DELETE)
+  if (response.status === 204 || response.headers.get('content-length') === '0') {
+    return undefined as T;
+  }
+
+  // Try to parse JSON, return undefined if body is empty
+  const text = await response.text();
+  if (!text) {
+    return undefined as T;
+  }
+  return JSON.parse(text);
 }
 
 // Auth


### PR DESCRIPTION
## Summary
- Fixed `fetchApi` to properly handle 204 No Content and empty response bodies
- DELETE operations like `revokeApiKey` were showing errors even though they succeeded

## Root Cause
`fetchApi` always called `response.json()` which throws a JSON parsing error when the backend returns:
- 204 No Content status
- Empty response body

The API call would succeed (key was revoked), but the JSON parsing failure caused an error to be displayed.

## Fix
Now handles empty responses by checking:
1. 204 status code
2. Content-length: 0 header
3. Empty response text

## Test plan
- [ ] Revoke an API key - should succeed without showing an error
- [ ] Other API operations should continue to work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)