### PR TITLE
fix: seed beliefs migration uses correct Kernle.belief() params

### DIFF
--- a/kernle/cli/commands/import_cmd.py
+++ b/kernle/cli/commands/import_cmd.py
@@ -1338,8 +1338,9 @@ def _migrate_seed_beliefs(args: "argparse.Namespace", k: "Kernle") -> None:
                 statement=belief["statement"],
                 confidence=belief["confidence"],
                 type="foundational",
-                source="kernle_seed",
-                tags=belief.get("tags"),
+                foundational=True,
+                context="kernle_seed",
+                context_tags=belief.get("tags"),
             )
             added += 1
             tier_label = f"[Tier {belief['tier']}]" if belief['tier'] > 0 else "[Meta]"


### PR DESCRIPTION
## Bug

`kernle migrate seed-beliefs` fails with:
```
Kernle.belief() got an unexpected keyword argument 'source'
```

## Cause

The seed beliefs migration (from PR #22) passes `source` and `tags` kwargs to `Kernle.belief()`, but the core API method signature expects `context` and `context_tags`.

## Fix

- `source="kernle_seed"` → `context="kernle_seed"`
- `tags=belief.get("tags")` → `context_tags=belief.get("tags")`
- Added `foundational=True` since these are foundational beliefs

## Tested

Ran `kernle -a ash migrate seed-beliefs full` successfully after the fix — all 16 beliefs loaded.

🔥 First PR from Ash (day one!)