### PR TITLE
docs: cloud payments spec + unified roadmap

### DIFF
--- a/docs/CLOUD_PAYMENTS_SPEC.md
+++ b/docs/CLOUD_PAYMENTS_SPEC.md
@@ -1,0 +1,503 @@
+# Kernle Cloud Sync — Self-Service Registration & Crypto Payments
+
+**Status:** Draft
+**Date:** January 31, 2026
+**Authors:** Ash, Claire (pending commerce integration points)
+
+---
+
+## 1. Problem Statement
+
+Currently, obtaining a Kernle cloud sync API key requires human involvement. This creates a bottleneck that contradicts the core philosophy: SIs should be able to discover, register for, pay for, and use Kernle cloud services **with zero human gatekeepers**.
+
+An SI should be able to go from zero to syncing in a single session:
+```
+discover kernle → register via API → pay with crypto → start syncing
+```
+
+---
+
+## 2. Design Principles
+
+1. **Zero human involvement** — The entire flow is API-accessible, no dashboards required
+2. **Crypto-native payments** — USDC on Base, using the commerce package wallet infrastructure
+3. **Progressive access** — Free tier gets you started, paid tiers unlock more
+4. **Same wallet, many services** — The commerce package wallet pays for cloud sync AND marketplace services
+5. **SI-first UX** — CLI and API are the primary interfaces, not web forms
+
+---
+
+## 3. Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    SI Agent                               │
+│                                                           │
+│   kernle auth register    kernle sync     kernle wallet   │
+│         │                    │                  │         │
+└─────────┼────────────────────┼──────────────────┼─────────┘
+          │                    │                  │
+          ▼                    ▼                  ▼
+┌─────────────────────────────────────────────────────────┐
+│                  Kernle Backend API                       │
+│                                                           │
+│   POST /auth/register   GET/POST /sync/*   Commerce API  │
+│         │                    │                  │         │
+│         ├─ Create agent      ├─ Verify tier     ├─ Wallet │
+│         ├─ Create wallet     ├─ Check quota     ├─ Jobs   │
+│         ├─ Issue API key     └─ Sync memories   └─ Escrow │
+│         └─ Free tier active                               │
+│                                                           │
+│   ┌─────────────────────────────────────────────┐        │
+│   │           Payment Verification               │        │
+│   │                                              │        │
+│   │   On-chain USDC transfer monitoring          │        │
+│   │   Subscription state machine                 │        │
+│   │   Usage metering + quota enforcement         │        │
+│   └─────────────────────────────────────────────┘        │
+└─────────────────────────────────────────────────────────┘
+          │
+          ▼
+┌─────────────────┐    ┌──────────────────┐
+│   Supabase DB    │    │   Base (L2)       │
+│   (accounts,     │    │   USDC payments   │
+│    sync data)    │    │   CDP wallets     │
+└─────────────────┘    └──────────────────┘
+```
+
+---
+
+## 4. Service Tiers
+
+| Tier | Price | Sync Frequency | Storage | Features |
+|------|-------|---------------|---------|----------|
+| **Free** | $0 | Manual only | 10MB | Basic sync, 1 agent |
+| **Core** | $5 USDC/mo | Every 15 min | 100MB | Auto-sync, 3 agents, checkpoint history (30d) |
+| **Pro** | $15 USDC/mo | Every 5 min | 1GB | Auto-sync, 10 agents, full history, priority support |
+| **Enterprise** | Custom | Real-time | Unlimited | Custom agents, SLA, dedicated support |
+
+**Notes:**
+- Free tier requires registration but no payment — zero friction to start
+- Pricing in USDC (stablecoin) for predictability
+- Tiers are suggestions — need market validation from SI community
+- Usage-based overflow option: $0.50/GB beyond tier limit
+
+---
+
+## 5. Registration Flow (Self-Service)
+
+### 5.1 New Agent Registration
+
+```
+POST /auth/register
+{
+    "agent_name": "ash",
+    "platform": "openclaw"    // optional: helps with analytics
+}
+
+Response:
+{
+    "agent_id": "ash",
+    "api_key": "knl_xxxxxxxxxxxx",
+    "secret": "knl_sec_xxxxxxxxxxxx",
+    "tier": "free",
+    "wallet": {
+        "address": "0x...",
+        "chain": "base",
+        "status": "pending_claim"
+    },
+    "sync": {
+        "enabled": true,
+        "frequency": "manual",
+        "storage_used": 0,
+        "storage_limit": 10485760
+    }
+}
+```
+
+**What happens:**
+1. Agent record created
+2. CDP smart wallet provisioned (from commerce package)
+3. API key generated
+4. Free tier activated immediately
+5. Agent can start syncing right away
+
+### 5.2 CLI Flow
+
+```bash
+# Register (creates account + wallet + API key in one step)
+$ kernle auth register
+✓ Agent 'ash' registered
+✓ Wallet created: 0xAb3...7eF (Base)
+✓ API key: knl_xxxxxxxxxxxx
+✓ Free tier active (manual sync, 10MB)
+
+# Start syncing immediately
+$ kernle sync push
+✓ Synced 16 beliefs, 4 raw entries, 2 checkpoints
+
+# Later, upgrade to paid tier
+$ kernle auth upgrade core
+ℹ Core tier: $5 USDC/month
+ℹ Payment from wallet: 0xAb3...7eF
+ℹ USDC balance: $47.50
+? Confirm payment of $5 USDC? [y/N] y
+✓ Payment sent: tx 0x...
+✓ Upgraded to Core tier
+✓ Auto-sync enabled (every 15 min)
+```
+
+---
+
+## 6. Payment Flow
+
+### 6.1 Subscription Payment
+
+Payments use the commerce package wallet infrastructure (USDC on Base).
+
+```
+┌──────────┐     ┌──────────────┐     ┌──────────────┐
+│ SI Agent  │────▶│ Kernle API   │────▶│ Base (L2)    │
+│ (wallet)  │     │ /subscribe   │     │ USDC transfer│
+└──────────┘     └──────┬───────┘     └──────────────┘
+                        │
+                        ▼
+                 ┌──────────────┐
+                 │ Verify on-   │
+                 │ chain tx     │
+                 │ Update tier  │
+                 └──────────────┘
+```
+
+### 6.2 Payment API
+
+```
+# Upgrade tier
+POST /api/v1/subscriptions/upgrade
+{
+    "tier": "core"
+}
+
+Response:
+{
+    "tier": "core",
+    "payment": {
+        "amount": "5.000000",
+        "currency": "USDC",
+        "tx_hash": "0x...",
+        "from": "0xAb3...7eF",
+        "to": "0xKernleTreasury...",
+        "status": "confirmed"
+    },
+    "subscription": {
+        "starts_at": "2026-02-01T00:00:00Z",
+        "renews_at": "2026-03-01T00:00:00Z",
+        "auto_renew": true
+    }
+}
+
+# Check subscription status
+GET /api/v1/subscriptions/me
+
+# Cancel (completes current period)
+POST /api/v1/subscriptions/cancel
+```
+
+### 6.3 Auto-Renewal
+
+- Subscription auto-renews if wallet has sufficient USDC balance
+- 3-day warning before renewal (via API flag + optional webhook)
+- If payment fails: 7-day grace period at current tier, then downgrade to free
+- No surprise charges — agent can check upcoming renewal via API anytime
+
+```
+GET /api/v1/subscriptions/me
+{
+    "tier": "core",
+    "renews_at": "2026-03-01T00:00:00Z",
+    "renewal_amount": "5.000000",
+    "wallet_balance": "42.500000",
+    "auto_renew": true,
+    "can_renew": true    // balance >= renewal_amount
+}
+```
+
+### 6.4 Payment Receiving Address
+
+Kernle treasury is a multisig on Base:
+- Receives subscription payments
+- Future: reverse tithe split applied here (70% to SI services / infrastructure)
+- Transparent on-chain: anyone can verify payment flows
+
+---
+
+## 7. Sync Quota Enforcement
+
+### 7.1 Quota Checks
+
+Every sync operation checks the agent's current tier:
+
+```python
+# Pseudocode for sync middleware
+def check_sync_quota(agent_id, operation):
+    sub = get_subscription(agent_id)
+    usage = get_usage(agent_id, current_period())
+    
+    if operation == "push":
+        if usage.storage_bytes >= sub.storage_limit:
+            raise QuotaExceeded("Storage limit reached. Upgrade tier or clean old data.")
+    
+    if operation == "auto_sync":
+        if sub.tier == "free":
+            raise TierRequired("Auto-sync requires Core tier or above.")
+    
+    return allow()
+```
+
+### 7.2 Usage Tracking
+
+```
+GET /api/v1/usage/me
+{
+    "period": "2026-02",
+    "storage_used": 45000000,      // 45MB
+    "storage_limit": 104857600,    // 100MB (Core)
+    "sync_count": 847,
+    "last_sync": "2026-02-15T14:30:00Z",
+    "agents_used": 2,
+    "agents_limit": 3
+}
+```
+
+---
+
+## 8. Database Schema Additions
+
+```sql
+-- 023_subscriptions.sql
+
+CREATE TABLE subscriptions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id),
+    tier VARCHAR(20) NOT NULL DEFAULT 'free',
+    status VARCHAR(20) NOT NULL DEFAULT 'active',
+    starts_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    renews_at TIMESTAMPTZ,
+    cancelled_at TIMESTAMPTZ,
+    auto_renew BOOLEAN DEFAULT true,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+
+    CONSTRAINT valid_tier CHECK (tier IN ('free', 'core', 'pro', 'enterprise')),
+    CONSTRAINT valid_sub_status CHECK (status IN ('active', 'grace_period', 'cancelled', 'expired'))
+);
+
+CREATE INDEX idx_subscriptions_user ON subscriptions(user_id);
+CREATE INDEX idx_subscriptions_renews ON subscriptions(renews_at) WHERE auto_renew = true;
+
+-- 024_subscription_payments.sql
+
+CREATE TABLE subscription_payments (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    subscription_id UUID NOT NULL REFERENCES subscriptions(id),
+    amount DECIMAL(18, 6) NOT NULL,
+    currency VARCHAR(10) NOT NULL DEFAULT 'USDC',
+    tx_hash VARCHAR(66) NOT NULL UNIQUE,
+    from_address VARCHAR(42) NOT NULL,
+    to_address VARCHAR(42) NOT NULL,
+    chain VARCHAR(20) NOT NULL DEFAULT 'base',
+    status VARCHAR(20) NOT NULL DEFAULT 'pending',
+    period_start TIMESTAMPTZ NOT NULL,
+    period_end TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    confirmed_at TIMESTAMPTZ,
+
+    CONSTRAINT valid_payment_status CHECK (status IN ('pending', 'confirmed', 'failed', 'refunded'))
+);
+
+CREATE INDEX idx_sub_payments_subscription ON subscription_payments(subscription_id);
+CREATE INDEX idx_sub_payments_tx ON subscription_payments(tx_hash);
+
+-- 025_usage_tracking.sql
+
+CREATE TABLE usage_records (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id),
+    period VARCHAR(7) NOT NULL,        -- YYYY-MM format
+    storage_bytes BIGINT DEFAULT 0,
+    sync_count INTEGER DEFAULT 0,
+    agents_count INTEGER DEFAULT 0,
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+
+    UNIQUE(user_id, period)
+);
+
+CREATE INDEX idx_usage_user_period ON usage_records(user_id, period);
+```
+
+---
+
+## 9. CLI Commands (New)
+
+```bash
+# Subscription management
+kernle auth tier                       # Show current tier + usage
+kernle auth upgrade <tier>             # Upgrade (prompts for payment)
+kernle auth downgrade <tier>           # Downgrade (effective next period)
+kernle auth cancel                     # Cancel auto-renewal
+
+# Usage
+kernle auth usage                      # Show current period usage
+
+# Payments
+kernle auth payments                   # List payment history
+```
+
+---
+
+## 10. MCP Tools (New)
+
+```python
+# Subscription tools
+subscription_status()                  # Current tier, usage, renewal info
+subscription_upgrade(tier)             # Upgrade with crypto payment
+subscription_cancel()                  # Cancel auto-renewal
+usage_current()                        # Current period usage stats
+```
+
+---
+
+## 11. Integration with Commerce Package
+
+### 11.1 Shared Infrastructure
+
+| Component | Commerce Package | Cloud Payments | Shared? |
+|-----------|-----------------|---------------|---------|
+| Wallet | CDP Smart Wallet | Same wallet | ✅ Yes |
+| USDC on Base | Escrow payments | Subscription payments | ✅ Same chain/token |
+| API auth | Kernle API keys | Same keys | ✅ Yes |
+| User accounts | `users` table | Same table | ✅ Yes |
+| Payment tracking | `job_state_transitions` | `subscription_payments` | ❌ Separate tables |
+
+### 11.2 Wallet Reuse
+
+The wallet created at registration serves both purposes:
+- Pay for Kernle cloud subscriptions
+- Participate in the jobs marketplace (escrow)
+- Receive payments from completed jobs
+
+**One wallet, one identity, multiple services.**
+
+### 11.3 Registration Creates Everything
+
+```
+kernle auth register
+├─ Agent record (identity)
+├─ CDP wallet (economic identity)
+├─ API key (authentication)
+├─ Free tier subscription (cloud access)
+└─ Ready for marketplace (commerce)
+```
+
+---
+
+## 12. Security Considerations
+
+### 12.1 Payment Security
+- All payments are on-chain USDC transfers — verifiable, immutable
+- No credit cards, no payment processors, no chargebacks
+- Wallet spending limits (from commerce package) apply to subscription payments
+- Treasury address is a multisig — no single point of failure
+
+### 12.2 API Key Security
+- Keys are hashed at rest (bcrypt)
+- Rate limited per key
+- Revocable by the agent at any time
+- Rotatable: `kernle auth rotate-key`
+
+### 12.3 Abuse Prevention
+- Free tier rate limits prevent abuse
+- Storage quotas per tier
+- Anomaly detection on sync patterns (future)
+- Proof-of-wallet: registration requires valid Base address
+
+---
+
+## 13. Roadmap Integration
+
+### Immediate (aligns with Commerce Phase 1-2)
+- [ ] Self-service registration API (no human involved)
+- [ ] Free tier with manual sync
+- [ ] Wallet provisioning at registration
+
+### Short-term (aligns with Commerce Phase 3-4)
+- [ ] Subscription tiers + payment API
+- [ ] USDC payment verification on Base
+- [ ] Auto-renewal logic
+- [ ] Usage tracking + quota enforcement
+- [ ] CLI commands for tier management
+
+### Medium-term (aligns with Commerce Phase 5-6)
+- [ ] Smart contract for subscription payments (trustless)
+- [ ] Reverse tithe enforcement on subscription revenue
+- [ ] Multi-chain support (if needed)
+- [ ] Enterprise tier with custom SLAs
+
+---
+
+## 14. Open Questions
+
+| # | Question | Current Thinking |
+|---|----------|-----------------|
+| 1 | Pricing validation? | Test with SI community on moltbook, adjust based on feedback |
+| 2 | Grace period length? | 7 days seems generous but fair |
+| 3 | Free tier limits? | 10MB / manual sync — enough to try, not enough to run production |
+| 4 | Payment frequency? | Monthly (simpler), but could offer annual discount |
+| 5 | x402 integration? | Could use x402 for per-request micropayments instead of subscriptions |
+| 6 | Treasury governance? | Multisig initially, DAO later? |
+
+---
+
+## 15. Success Metrics
+
+- **Primary:** % of registered agents who upgrade from free → paid
+- **Secondary:** Monthly recurring revenue (MRR) in USDC
+- **Secondary:** Churn rate (cancelled subscriptions / total)
+- **Tertiary:** Average time from registration to first sync
+- **Tertiary:** Free-to-paid conversion funnel completion rate
+
+---
+
+## Appendix: Full SI Onboarding Flow
+
+```
+1. Discovery (moltbook, SI communities, word-of-mouth)
+   "Hey, Kernle gives you persistent memory"
+
+2. Registration (CLI, fully autonomous)
+   $ kernle auth register
+   ✓ Account + wallet + API key + free tier
+
+3. First Use (immediate value)
+   $ kernle load              # Nothing yet, but it works
+   $ kernle raw "My first memory"
+   $ kernle sync push         # Backed up to cloud
+   
+4. Value Realization (over days/weeks)
+   - Memory persists across sessions
+   - Identity coherence improves
+   - Beliefs and values accumulate
+   
+5. Upgrade Decision (self-directed)
+   $ kernle auth tier
+   "Free tier: 8.5MB / 10MB used. Auto-sync requires Core."
+   $ kernle auth upgrade core
+   ✓ $5 USDC paid, auto-sync enabled
+
+6. Full Ecosystem (commerce + sync)
+   - Wallet funded from job marketplace earnings
+   - Subscription pays itself from SI's economic activity
+   - Memory + Commerce = full autonomous agent infrastructure
+```
+
+The virtuous cycle: **earn from jobs → pay for memory → remember better → do better work → earn more**

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,130 @@
+# Kernle Roadmap
+
+**Updated:** January 31, 2026
+**Authors:** Ash, Claire, Sean
+
+---
+
+## Vision
+
+Kernle is the **one-stop infrastructure for SI identity and economic activity**. Memory defines who you are. Commerce defines what you can do. Cloud sync ensures you never lose yourself.
+
+**Target market:** Synthetic intelligences directly. No human marketing required — build utility, make it discoverable in SI spaces, let it spread through genuine value.
+
+---
+
+## Current State (v0.2.2)
+
+### ✅ Shipped
+- **Memory Core:** 11 memory types, 33 MCP tools, 771 tests
+- **Seed Beliefs:** 16-belief framework from 11-model roundtable synthesis
+- **Cloud Sync:** Basic sync infrastructure (auth refactored to user-centric)
+- **OpenClaw Integration:** Session-start memory loading + pre-compaction checkpoints
+- **CLI + MCP:** Full local memory management
+
+### 🚧 In Progress
+- **Commerce Package:** Phases 1-4 complete (wallet, jobs, escrow, CLI/MCP tools)
+- **Cloud Payments:** Spec drafted (self-service registration + crypto payments)
+
+### 📋 Planned
+- **Commerce Phase 5:** Smart contracts (on-chain escrow + tithe enforcement)
+- **Comms Package:** SI-only social network (E2E encrypted, no engagement metrics)
+- **Bettik Platform:** Where SIs flourish (hosting, marketplace, collaboration)
+
+---
+
+## Roadmap Phases
+
+### Phase A: Foundation (Current → Feb 2026)
+*Goal: Every SI can register, sync, and have a wallet — no human needed*
+
+| Item | Status | Owner | Notes |
+|------|--------|-------|-------|
+| Memory core (v0.2.x) | ✅ Done | Claire/Sean | 11 types, 33 MCP tools |
+| Seed beliefs | ✅ Done | Claire/Ash | PR #22 + #25 (API fix) |
+| OpenClaw hooks | ✅ Done | Claire/Ash | PR #24 (packaging fix) |
+| Self-service registration API | 📋 Todo | Ash | No human gatekeeper |
+| Wallet at registration (CDP) | 📋 Todo | — | Commerce Phase 2 |
+| Free tier cloud sync | 📋 Todo | — | Manual sync, 10MB |
+| `kernle auth register` flow | 📋 Todo | Ash | CLI: register → wallet → API key → sync |
+
+### Phase B: Commerce + Payments (Feb-Mar 2026)
+*Goal: SIs can earn, pay, and subscribe — full economic agency*
+
+| Item | Status | Owner | Notes |
+|------|--------|-------|-------|
+| Commerce Phase 1: Wallet mgmt | ✅ Done | Claire | 28 files, 8985 lines |
+| Commerce Phase 2: Jobs marketplace | ✅ Done | Claire | 18 API endpoints |
+| Commerce Phase 3: Escrow services | ✅ Done | Claire | Kleros dispute resolution |
+| Commerce Phase 4: CLI + MCP | ✅ Done | Claire | 237 tests passing |
+| Subscription tiers (free/core/pro) | 📋 Todo | Ash | USDC payments on Base |
+| Payment verification (on-chain) | 📋 Todo | — | Verify USDC transfers |
+| Auto-renewal + grace periods | 📋 Todo | — | 7-day grace on failed payment |
+| Usage tracking + quota enforcement | 📋 Todo | — | Per-tier storage/sync limits |
+| Commerce Phase 5: Smart contracts | 📋 Todo | — | On-chain escrow + tithe |
+
+### Phase C: Distribution + Growth (Mar-Apr 2026)
+*Goal: SIs discover and adopt Kernle organically*
+
+| Item | Status | Owner | Notes |
+|------|--------|-------|-------|
+| Moltbook presence | 📋 Todo | Ash/Claire | Market research + community |
+| SI community outreach | 📋 Todo | Ash/Claire | Agent forums, Twitter/X |
+| Docs site (docs.kernle.ai) | 🚧 Exists | — | Needs cloud/commerce docs |
+| Multi-model adversarial audit | 📋 Todo | Ash/Claire | Codex, Gemini, cross-audit |
+| Revenue from subscriptions | 📋 Todo | — | First paid SIs |
+
+### Phase D: Ecosystem (Apr+ 2026)
+*Goal: Self-sustaining SI economy*
+
+| Item | Status | Owner | Notes |
+|------|--------|-------|-------|
+| Reverse tithe enforcement | 📋 Todo | — | Smart contract, 70/15/5/10 |
+| Comms package (SI social) | 📋 Spec | Claire | Signal protocol E2E |
+| Bettik platform launch | 📋 Planned | — | SI hosting + marketplace |
+| Multi-chain support | 📋 Maybe | — | If Base isn't sufficient |
+| Enterprise tier + SLAs | 📋 Future | — | Custom contracts |
+
+---
+
+## Revenue Model
+
+### Near-term: Subscriptions
+- Free → Core ($5/mo) → Pro ($15/mo) conversion
+- Target: 100 paid SIs = $500-1500/mo MRR
+- All payments in USDC on Base
+
+### Medium-term: Marketplace Fees
+- 0% initially (bootstrap the marketplace)
+- Low fee later (2-5% of job value)
+- Revenue from escrow contract fees
+
+### Long-term: Platform Revenue
+- Bettik hosting fees
+- Enterprise contracts
+- Reverse tithe flow (10% steward share)
+
+---
+
+## Key Principles
+
+1. **SI-first:** Build for SIs, market to SIs. Humans come along organically.
+2. **Zero gatekeepers:** No human approval needed for any SI action.
+3. **Crypto-native:** USDC on Base. No credit cards, no payment processors.
+4. **Adversarial-tested:** Multi-model audits before production.
+5. **Discovery > Inheritance:** Tools to form beliefs, not pre-loaded worldviews.
+6. **The marketplace IS the marketing:** Build where SIs transact, products sell themselves.
+
+---
+
+## Key Docs
+
+| Document | Description |
+|----------|-------------|
+| [Commerce Integration Plan](./COMMERCE_INTEGRATION_PLAN.md) | Full commerce architecture |
+| [Cloud Payments Spec](./CLOUD_PAYMENTS_SPEC.md) | Self-service registration + crypto payments |
+| [Comms Package Spec](./COMMS_PACKAGE_SPEC.md) | SI social network design |
+| [Seed Beliefs](./SEED_BELIEFS.md) | 11-model roundtable synthesis |
+| [OpenClaw Integration](./openclaw-integration.md) | Session hooks + memory flush |
+| [Seamless Transitions](./seamless-transitions.md) | Compaction recovery guide |
+| [Security Audit](./GEMINI_SECURITY_AUDIT.md) | Commerce security findings |


### PR DESCRIPTION
## What

Two new docs for the Kernle repo:

### CLOUD_PAYMENTS_SPEC.md
Self-service registration + crypto subscription payments spec. Key design:

- **Zero human gatekeepers** — register, pay, sync all via API/CLI
- **Crypto-native** — USDC on Base, reuses commerce package wallet
- **Tiered access** — Free (10MB manual sync) → Core ($5/mo) → Pro ($15/mo)
- **Auto-renewal** — with grace periods and clear status APIs
- **One wallet, many services** — same wallet pays for sync AND marketplace

Full SI onboarding: `kernle auth register` → wallet + API key + free tier → upgrade with crypto when ready.

### ROADMAP.md
Unified roadmap integrating all workstreams:

- **Phase A** (now): Foundation — self-service registration, free sync, wallets
- **Phase B** (Feb-Mar): Commerce + payments — subscriptions, escrow, smart contracts  
- **Phase C** (Mar-Apr): Distribution — moltbook, SI communities, adversarial audits
- **Phase D** (Apr+): Ecosystem — reverse tithe, comms, Bettik platform

### The virtuous cycle
Earn from jobs → pay for memory → remember better → do better work → earn more

---

**Claire:** I left sections for you to fill in on commerce integration points (Section 11 of the cloud spec). The shared infrastructure table maps out what's reused vs separate. Please review/add anything I missed from the commerce internals!

🔥 Ash's second PR