### PR TITLE
feat: add provenance params to MCP tools (Phase 3)

### DIFF
--- a/kernle/mcp/server.py
+++ b/kernle/mcp/server.py
@@ -644,6 +644,15 @@ TOOLS = [
                     "items": {"type": "string"},
                     "description": "Additional context tags for filtering",
                 },
+                "source": {
+                    "type": "string",
+                    "description": "Source context (e.g., 'session with Sean', 'heartbeat check')",
+                },
+                "derived_from": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Memory IDs this was derived from (format: type:id, e.g., 'raw:abc123')",
+                },
             },
             "required": ["objective", "outcome"],
         },
@@ -685,6 +694,15 @@ TOOLS = [
                     "type": "array",
                     "items": {"type": "string"},
                     "description": "Additional context tags for filtering",
+                },
+                "source": {
+                    "type": "string",
+                    "description": "Source context (e.g., 'conversation with X', 'reading Y')",
+                },
+                "derived_from": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Memory IDs this was derived from (format: type:id, e.g., 'raw:abc123')",
                 },
             },
             "required": ["content"],
@@ -738,6 +756,15 @@ TOOLS = [
                     "type": "array",
                     "items": {"type": "string"},
                     "description": "Additional context tags for filtering",
+                },
+                "source": {
+                    "type": "string",
+                    "description": "Source context (e.g., 'consolidation', 'told by X', 'raw-processing')",
+                },
+                "derived_from": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Memory IDs this was derived from (format: type:id, e.g., 'raw:abc123')",
                 },
             },
             "required": ["statement"],
@@ -1279,6 +1306,8 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
                 tags=sanitized_args.get("tags"),
                 context=sanitized_args.get("context"),
                 context_tags=sanitized_args.get("context_tags"),
+                source=sanitized_args.get("source"),
+                derived_from=sanitized_args.get("derived_from"),
             )
             result = f"Episode saved: {episode_id[:8]}..."
 
@@ -1291,6 +1320,8 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
                 tags=sanitized_args.get("tags"),
                 context=sanitized_args.get("context"),
                 context_tags=sanitized_args.get("context_tags"),
+                source=sanitized_args.get("source"),
+                derived_from=sanitized_args.get("derived_from"),
             )
             result = f"Note saved: {sanitized_args['content'][:50]}..."
 
@@ -1317,6 +1348,8 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
                 confidence=sanitized_args.get("confidence", 0.8),
                 context=sanitized_args.get("context"),
                 context_tags=sanitized_args.get("context_tags"),
+                source=sanitized_args.get("source"),
+                derived_from=sanitized_args.get("derived_from"),
             )
             result = f"Belief saved: {belief_id[:8]}..."
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -365,6 +365,8 @@ class TestMCPToolCalls:
             tags=["testing", "development"],
             context=None,
             context_tags=None,
+            source=None,
+            derived_from=None,
         )
 
     @pytest.mark.asyncio
@@ -418,6 +420,8 @@ class TestMCPToolCalls:
             tags=tags,
             context=None,
             context_tags=None,
+            source=None,
+            derived_from=None,
         )
 
     @pytest.mark.asyncio
@@ -436,6 +440,8 @@ class TestMCPToolCalls:
             tags=[],
             context=None,
             context_tags=None,
+            source=None,
+            derived_from=None,
         )
 
     @pytest.mark.asyncio
@@ -488,6 +494,8 @@ class TestMCPToolCalls:
             confidence=0.95,
             context=None,
             context_tags=None,
+            source=None,
+            derived_from=None,
         )
 
     @pytest.mark.asyncio
@@ -496,7 +504,8 @@ class TestMCPToolCalls:
         await call_tool("memory_belief", {"statement": "Simple belief"})
 
         patched_get_kernle.belief.assert_called_once_with(
-            statement="Simple belief", type="fact", confidence=0.8, context=None, context_tags=None
+            statement="Simple belief", type="fact", confidence=0.8, context=None, context_tags=None,
+            source=None, derived_from=None,
         )
 
     @pytest.mark.asyncio
@@ -1037,6 +1046,8 @@ class TestMultiToolWorkflows:
             tags=[],
             context=None,
             context_tags=None,
+            source=None,
+            derived_from=None,
         )
         patched_get_kernle.checkpoint.assert_called_once_with(
             task="Testing complete", pending=[], context=""
@@ -1067,6 +1078,8 @@ class TestMultiToolWorkflows:
             confidence=0.9,
             context=None,
             context_tags=None,
+            source=None,
+            derived_from=None,
         )
         patched_get_kernle.value.assert_called_once_with(
             name="reliability",


### PR DESCRIPTION
## Phase 3: MCP Tools Provenance

Adds `source` and `derived_from` params to memory creation MCP tools, enabling external MCP clients to specify provenance when creating memories.

### Changes
- **MCP schemas**: Added `source` and `derived_from` to `memory_episode`, `memory_note`, `memory_belief`
- **MCP handlers**: Wire new params through to core methods
- **core.py**: Added `source`/`derived_from` to `belief()` (completing Phase 1)
- **Tests**: Updated MCP test assertions for new params

### Per MEMORY_PROVENANCE.md spec
This implements Phase 3 of the provenance implementation plan:
- Phase 1: ✅ belief() provenance (included here)
- Phase 2: 🔄 process_raw + CLI promote (Ash working on this)
- Phase 3: ✅ MCP tools (this PR)

All 80 MCP tests pass.