### PR TITLE
feat: Evidence tracking for belief reinforcement (Phase 4)

### DIFF
--- a/kernle/cli/__main__.py
+++ b/kernle/cli/__main__.py
@@ -2830,6 +2830,8 @@ def main():
 
     belief_reinforce = belief_sub.add_parser("reinforce", help="Manually reinforce a belief")
     belief_reinforce.add_argument("id", help="Belief ID")
+    belief_reinforce.add_argument("--evidence", help="Evidence source (e.g., 'episode:abc123', 'raw:def456')")
+    belief_reinforce.add_argument("--reason", help="Human-readable reason for reinforcement")
 
     belief_supersede = belief_sub.add_parser("supersede", help="Replace a belief with a new one")
     belief_supersede.add_argument("old_id", help="ID of belief to supersede")

--- a/kernle/cli/commands/belief.py
+++ b/kernle/cli/commands/belief.py
@@ -119,9 +119,13 @@ def cmd_belief(args, k: "Kernle"):
 
     elif args.belief_action == "reinforce":
         belief_id = validate_input(args.id, "belief_id", 100)
+        evidence = getattr(args, "evidence", None)
+        reason = getattr(args, "reason", None)
 
-        if k.reinforce_belief(belief_id):
+        if k.reinforce_belief(belief_id, evidence_source=evidence, reason=reason):
             print(f"✓ Belief {belief_id[:8]}... reinforced")
+            if evidence:
+                print(f"  Evidence: {evidence}")
         else:
             print(f"✗ Belief {belief_id[:8]}... not found")
 

--- a/tests/test_cli_belief.py
+++ b/tests/test_cli_belief.py
@@ -304,7 +304,7 @@ class TestCmdBeliefReinforce:
 
         cmd_belief(args, k)
 
-        k.reinforce_belief.assert_called_with("b123")
+        k.reinforce_belief.assert_called_with("b123", evidence_source=None, reason=None)
         captured = capsys.readouterr()
         assert "✓" in captured.out
         assert "reinforced" in captured.out


### PR DESCRIPTION
Phase 4 of memory provenance (per MEMORY_PROVENANCE.md).

## Changes

**`reinforce_belief()` now tracks what triggered reinforcement:**
- New params: `evidence_source` (e.g., `"episode:abc123"`) and `reason`
- `confidence_history` entries include `evidence_source` field
- Episode references auto-added to `source_episodes` on reinforcement

**`revise_beliefs_from_episode()` passes evidence:**
- Reinforcement calls now include `evidence_source=f"episode:{episode_id}"`
- Reason includes episode objective for traceability
- Result dict includes `evidence_source` per reinforced belief

**CLI `belief reinforce` updated:**
- New flags: `--evidence` and `--reason`

## Verification

```
Source episodes: ['episode:b818f8ee-...']
Last history: {
  "old": 0.7, "new": 0.713,
  "reason": "Confirmed by test run",
  "evidence_source": "episode:b818f8ee-..."
}
✅ Reinforcement evidence tracking working!
✅ Episode-driven revision with evidence tracking working!
```

All 1221 tests pass.