### PR TITLE
feat: entity-neutral sourcing (Phase 5)

### DIFF
--- a/kernle/cli/__main__.py
+++ b/kernle/cli/__main__.py
@@ -2786,7 +2786,7 @@ def main():
         "--source",
         "-s",
         required=True,
-        choices=["direct_experience", "inference", "told_by_agent", "consolidation"],
+        choices=["direct_experience", "inference", "external", "consolidation"],
         help="Source type",
     )
     meta_source.add_argument("--episodes", action="append", help="Supporting episode IDs")

--- a/kernle/core.py
+++ b/kernle/core.py
@@ -1043,7 +1043,7 @@ class Kernle(
         if source:
             source_lower = source.lower()
             if any(x in source_lower for x in ["told", "said", "heard", "learned from"]):
-                source_type = "told_by_agent"
+                source_type = "external"
             elif any(x in source_lower for x in ["infer", "deduce", "conclude"]):
                 source_type = "inference"
 
@@ -1192,11 +1192,11 @@ class Kernle(
         if source:
             source_lower = source.lower()
             if any(x in source_lower for x in ["told", "said", "heard", "learned from"]):
-                source_type = "told_by_agent"
+                source_type = "external"
             elif any(x in source_lower for x in ["infer", "deduce", "conclude"]):
                 source_type = "inference"
             elif type == "quote":
-                source_type = "told_by_agent"
+                source_type = "external"
 
         # Build derived_from: explicit lineage + source context marker
         derived_from_value = list(derived_from) if derived_from else []

--- a/kernle/features/emotions.py
+++ b/kernle/features/emotions.py
@@ -384,7 +384,7 @@ class EmotionsMixin:
         if source:
             source_lower = source.lower()
             if any(x in source_lower for x in ["told", "said", "heard", "learned from"]):
-                source_type = "told_by_agent"
+                source_type = "external"
             elif any(x in source_lower for x in ["infer", "deduce", "conclude"]):
                 source_type = "inference"
 

--- a/kernle/features/metamemory.py
+++ b/kernle/features/metamemory.py
@@ -324,7 +324,7 @@ class MetaMemoryMixin:
         Args:
             memory_type: Type of memory
             memory_id: ID of memory
-            source_type: Source type (direct_experience, inference, told_by_agent, consolidation)
+            source_type: Source type (direct_experience, inference, external, consolidation)
             source_episodes: List of supporting episode IDs
             derived_from: List of memory refs this was derived from (format: type:id)
 

--- a/kernle/storage/base.py
+++ b/kernle/storage/base.py
@@ -54,7 +54,7 @@ class SourceType(Enum):
 
     DIRECT_EXPERIENCE = "direct_experience"  # Directly observed/experienced
     INFERENCE = "inference"  # Inferred from other memories
-    TOLD_BY_AGENT = "told_by_agent"  # Told by another agent/user
+    EXTERNAL = "external"  # Information received from another being (entity-neutral)
     CONSOLIDATION = "consolidation"  # Created during consolidation
     UNKNOWN = "unknown"  # Legacy or untracked
 
@@ -213,6 +213,7 @@ class Episode:
     # Meta-memory fields
     confidence: float = 0.8
     source_type: str = "direct_experience"  # SourceType value
+    source_entity: Optional[str] = None  # Who provided it (name, email, or ID; entity-neutral)
     source_episodes: Optional[List[str]] = None  # IDs of related episodes
     derived_from: Optional[List[str]] = None  # Memory IDs this was derived from
     last_verified: Optional[datetime] = None
@@ -247,6 +248,7 @@ class Belief:
     deleted: bool = False
     # Meta-memory fields
     source_type: str = "direct_experience"  # SourceType value
+    source_entity: Optional[str] = None  # Who provided it (name, email, or ID; entity-neutral)
     source_episodes: Optional[List[str]] = None  # IDs of supporting episodes
     derived_from: Optional[List[str]] = None  # Memory IDs this was derived from
     last_verified: Optional[datetime] = None
@@ -360,6 +362,7 @@ class Note:
     # Meta-memory fields
     confidence: float = 0.8
     source_type: str = "direct_experience"  # SourceType value
+    source_entity: Optional[str] = None  # Who provided it (name, email, or ID; entity-neutral)
     source_episodes: Optional[List[str]] = None  # IDs of supporting episodes
     derived_from: Optional[List[str]] = None  # Memory IDs this was derived from
     last_verified: Optional[datetime] = None

--- a/tests/test_meta_memory.py
+++ b/tests/test_meta_memory.py
@@ -95,7 +95,7 @@ class TestMetaMemoryFields:
             name="Quality",
             statement="Quality matters",
             confidence=0.95,
-            source_type="told_by_agent",
+            source_type="external",
         )
 
         storage.save_value(value)
@@ -103,7 +103,7 @@ class TestMetaMemoryFields:
 
         assert len(values) == 1
         assert values[0].confidence == 0.95
-        assert values[0].source_type == "told_by_agent"
+        assert values[0].source_type == "external"
 
     def test_goal_meta_fields(self, storage):
         """Goal should have meta-memory fields."""
@@ -392,7 +392,7 @@ class TestSourceTypes:
         """SourceType should have expected values."""
         assert SourceType.DIRECT_EXPERIENCE.value == "direct_experience"
         assert SourceType.INFERENCE.value == "inference"
-        assert SourceType.TOLD_BY_AGENT.value == "told_by_agent"
+        assert SourceType.EXTERNAL.value == "external"
         assert SourceType.CONSOLIDATION.value == "consolidation"
         assert SourceType.UNKNOWN.value == "unknown"
 


### PR DESCRIPTION
## Phase 5: Entity-Neutral Sourcing

Replace `told_by_agent`/`told_by_human` with a single `external` source type. Per the MEMORY_PROVENANCE.md spec:

> Source types don't distinguish human from SI. A being is a being. What matters is *who* provided the information, not what kind of being they are.

### Changes

**SourceType enum (storage/base.py)**
- `TOLD_BY_AGENT` → `EXTERNAL`

**New field: `source_entity`**
Added to Episode, Belief, Note dataclasses:
```python
source_entity: Optional[str] = None  # Who provided it (name, email, or ID)
```

**Code updates**
- core.py: All source_type inferences now use "external"
- emotions.py: Same update
- CLI: Choice list updated
- metamemory.py: Docstring updated
- Tests: Updated to expect new values

### Philosophy

The being's nature (human, SI, etc.) is deliberately not recorded in provenance. What matters is *who* (tracked in `source_entity`), not *what kind of being*.

All tests pass (meta_memory: 23, cli: 53, mcp: 80).