### PR TITLE
feat: orphan detection CLI (Phase 6 audit)

### DIFF
--- a/kernle/cli/__main__.py
+++ b/kernle/cli/__main__.py
@@ -2809,6 +2809,14 @@ def main():
     meta_learn.add_argument("--limit", "-l", type=int, default=5, help="Max opportunities to show")
     meta_learn.add_argument("--json", "-j", action="store_true")
 
+    meta_orphans = meta_sub.add_parser(
+        "orphans", help="Find memories with missing provenance"
+    )
+    meta_orphans.add_argument(
+        "--limit", "-l", type=int, default=50, help="Max memories to return"
+    )
+    meta_orphans.add_argument("--json", "-j", action="store_true")
+
     # belief (belief revision operations)
     p_belief = subparsers.add_parser("belief", help="Belief revision operations")
     belief_sub = p_belief.add_subparsers(dest="belief_action", required=True)

--- a/kernle/cli/commands/meta.py
+++ b/kernle/cli/commands/meta.py
@@ -310,3 +310,37 @@ def cmd_meta(args, k: "Kernle"):
                 print(f"   Reason: {opp['reason']}")
                 print(f"   Action: {opp['suggested_action']}")
                 print()
+
+    elif args.meta_action == "orphans":
+        orphans = k.find_orphaned_memories(limit=args.limit)
+
+        if args.json:
+            print(json.dumps(orphans, indent=2, default=str))
+        else:
+            if not orphans:
+                print("✓ No orphaned memories found.")
+                print("All memories have proper provenance tracking.")
+                return
+
+            print("Orphaned Memories (missing provenance)")
+            print("=" * 60)
+            print()
+
+            source_icons = {
+                "unknown": "❓",
+                "none": "⚫",
+                "consolidation": "🔄",
+                "inference": "💭",
+            }
+
+            for mem in orphans:
+                icon = source_icons.get(mem["source_type"], "•")
+                print(f"{icon} [{mem['type']:8}] {mem['summary'][:45]}...")
+                print(f"   ID: {mem['id'][:12]}...  Source: {mem['source_type']}")
+                print(f"   Reason: {mem['reason']}")
+                print(f"   Created: {mem['created_at']}")
+                print()
+
+            print(f"Total orphans: {len(orphans)}")
+            print()
+            print("To fix: use `kernle meta source <type> <id> --source <source_type>`")

--- a/tests/test_orphan_detection.py
+++ b/tests/test_orphan_detection.py
@@ -1,0 +1,87 @@
+"""Tests for orphaned memory detection."""
+
+import pytest
+
+
+class TestFindOrphanedMemories:
+    """Tests for find_orphaned_memories."""
+
+    def test_no_orphans_when_empty(self, kernle_instance):
+        """No orphans with empty database."""
+        kernle, _ = kernle_instance
+        orphans = kernle.find_orphaned_memories()
+        assert orphans == []
+
+    def test_detects_unknown_source(self, kernle_instance):
+        """Detects memories with source_type='unknown'."""
+        kernle, _ = kernle_instance
+        # Create a belief with unknown source
+        belief_id = kernle.belief("Test belief")
+        # Manually set source_type to unknown
+        kernle.set_memory_source("belief", belief_id, "unknown")
+
+        orphans = kernle.find_orphaned_memories()
+        assert len(orphans) == 1
+        assert orphans[0]["source_type"] == "unknown"
+        assert orphans[0]["reason"] == "unknown source (legacy memory)"
+
+    def test_detects_consolidation_without_derived_from(self, kernle_instance):
+        """Detects consolidation memories without derived_from."""
+        kernle, _ = kernle_instance
+        # Create a belief sourced from consolidation
+        belief_id = kernle.belief("Consolidated insight")
+        # Set as consolidation but with no derived_from
+        kernle.set_memory_source("belief", belief_id, "consolidation")
+
+        orphans = kernle.find_orphaned_memories()
+        assert len(orphans) == 1
+        assert orphans[0]["source_type"] == "consolidation"
+        assert "derived_from" in orphans[0]["reason"]
+
+    def test_no_orphan_when_properly_sourced(self, kernle_instance):
+        """No orphan when memory has proper provenance."""
+        kernle, _ = kernle_instance
+        # Create properly sourced belief
+        belief_id = kernle.belief(
+            "Properly sourced belief",
+            source="direct observation",
+        )
+
+        orphans = kernle.find_orphaned_memories()
+        assert len(orphans) == 0
+
+    def test_limit_respected(self, kernle_instance):
+        """Limit parameter is respected."""
+        kernle, _ = kernle_instance
+        # Create multiple orphans
+        for i in range(10):
+            belief_id = kernle.belief(f"Unknown belief {i}")
+            kernle.set_memory_source("belief", belief_id, "unknown")
+
+        orphans = kernle.find_orphaned_memories(limit=5)
+        assert len(orphans) == 5
+
+    def test_inference_without_derived_from_is_orphan(self, kernle_instance):
+        """Inference source without derived_from is orphan."""
+        kernle, _ = kernle_instance
+        belief_id = kernle.belief("Inferred conclusion")
+        kernle.set_memory_source("belief", belief_id, "inference")
+
+        orphans = kernle.find_orphaned_memories()
+        assert len(orphans) == 1
+        assert orphans[0]["source_type"] == "inference"
+
+    def test_consolidation_with_derived_from_not_orphan(self, kernle_instance):
+        """Consolidation with derived_from is not an orphan."""
+        kernle, _ = kernle_instance
+        # First create source material
+        raw_id = kernle.raw("Source observation")
+        belief_id = kernle.belief("Consolidated insight")
+        # Set as consolidation WITH derived_from
+        kernle.set_memory_source(
+            "belief", belief_id, "consolidation",
+            derived_from=[f"raw:{raw_id}"]
+        )
+
+        orphans = kernle.find_orphaned_memories()
+        assert len(orphans) == 0


### PR DESCRIPTION
## Summary

Adds orphan detection to the CLI as part of Phase 6 (CLI inspection) from the memory provenance spec.

## Changes

### Backend: `find_orphaned_memories()`
- Finds memories with `source_type='unknown'` (legacy memories from before provenance tracking)
- Finds `consolidation`/`inference` memories that lack `derived_from` chains
- Returns structured list with type, id, summary, reason, and created_at

### CLI: `kernle meta orphans`
```bash
# Find orphaned memories
kernle meta orphans

# Limit results
kernle meta orphans --limit 10

# JSON output for automation
kernle meta orphans --json
```

### Tests
- 7 passing tests covering empty DB, unknown source, consolidation without derived_from, proper sourcing, limit handling, inference without derived_from, and consolidation with derived_from

## Phase 6 Split

This PR handles the audit infrastructure side of Phase 6:
- ✅ `meta orphans` - find memories with missing provenance
- ✅ `meta uncertain` - already existed (low confidence memories)

Sean is handling the `--trace` flag work (`trace_lineage()` is already merged in main).

## Testing

```bash
uv run pytest tests/test_orphan_detection.py tests/test_meta_memory.py -v
# 30 passed in 0.88s
```

---
*Part of memory provenance Phase 6 work with @seanbhart*