### PR TITLE
feat: Phase 6 — CLI trace, reverse trace, orphan detection

### DIFF
--- a/kernle/cli/__main__.py
+++ b/kernle/cli/__main__.py
@@ -2792,6 +2792,26 @@ def main():
     meta_source.add_argument("--episodes", action="append", help="Supporting episode IDs")
     meta_source.add_argument("--derived", action="append", help="Derived from (type:id format)")
 
+    # Provenance inspection subcommands (Phase 6)
+    meta_trace = meta_sub.add_parser("trace", help="Walk full derivation chain (root → target)")
+    meta_trace.add_argument(
+        "type", choices=["episode", "belief", "value", "goal", "note", "raw"], help="Memory type"
+    )
+    meta_trace.add_argument("id", help="Memory ID")
+    meta_trace.add_argument("--depth", "-d", type=int, default=20, help="Max traversal depth")
+    meta_trace.add_argument("--json", "-j", action="store_true")
+
+    meta_reverse = meta_sub.add_parser("reverse", help="Find memories derived FROM this one")
+    meta_reverse.add_argument(
+        "type", choices=["episode", "belief", "value", "goal", "note", "raw"], help="Memory type"
+    )
+    meta_reverse.add_argument("id", help="Memory ID")
+    meta_reverse.add_argument("--depth", "-d", type=int, default=10, help="Max traversal depth")
+    meta_reverse.add_argument("--json", "-j", action="store_true")
+
+    meta_orphans = meta_sub.add_parser("orphans", help="Detect dangling/broken references")
+    meta_orphans.add_argument("--json", "-j", action="store_true")
+
     # Meta-cognition subcommands (awareness of what I know/don't know)
     meta_knowledge = meta_sub.add_parser("knowledge", help="Show knowledge map across domains")
     meta_knowledge.add_argument("--json", "-j", action="store_true")


### PR DESCRIPTION
## Phase 6: Provenance Inspection

Implements the three CLI inspection commands from the provenance spec:

### New Commands

| Command | Purpose |
|---------|---------|
| `kernle meta trace <type> <id>` | Walk full derivation chain upward (root → target) |
| `kernle meta reverse <type> <id>` | Find all memories derived FROM a given memory |
| `kernle meta orphans` | Detect dangling/broken references |

### Core Additions (metamemory.py)
- `reverse_trace()`: Downstream dependency scanner with cycle protection
- `find_orphaned_references()`: Reference integrity checker across episode/belief/note

### Details
- **trace**: Tree-style output showing the full provenance chain with confidence bars, source types, and summaries. Handles cycles and missing refs gracefully.
- **reverse**: Impact analysis — shows what would be affected if a memory changes. Recursive with visited set protection.
- **orphans**: Scans `derived_from` and `source_episodes` fields, validates each `type:id` ref exists, skips `context:` markers.

All commands support `--json` output for programmatic use.

### Tests
7 new tests: trace chains, cycle detection, reverse traversal, empty dependents, clean refs, orphan detection, context ref handling.

**All 1228 tests pass** (7 new).

Closes the Phase 6 item from `docs/MEMORY_PROVENANCE.md`.

---
Phases complete: 1 ✅ 2 ✅ 3 ✅ 4 ✅ 5 ✅ 6 ✅ 7 (migration) remaining.