### PR TITLE
feat: Phase 7 — migration backfill for provenance metadata

### DIFF
--- a/kernle/cli/__main__.py
+++ b/kernle/cli/__main__.py
@@ -3463,6 +3463,18 @@ Beliefs already present in the agent's memory will be skipped.
         help="List seed beliefs without adding them",
     )
 
+    # migrate backfill-provenance - add provenance metadata to existing memories
+    migrate_provenance = migrate_sub.add_parser(
+        "backfill-provenance",
+        help="Backfill provenance metadata on existing memories (source_type, derived_from)",
+    )
+    migrate_provenance.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview what would be updated without making changes",
+    )
+    migrate_provenance.add_argument("--json", "-j", action="store_true")
+
     # setup - install platform hooks for automatic memory loading
     p_setup = subparsers.add_parser(
         "setup", help="Install platform hooks for automatic memory loading"


### PR DESCRIPTION
## Phase 7: Migration Backfill

**Completes the Memory Provenance implementation — all 7 phases done! 🎉**

### New CLI Command
```bash
# Preview what would change
kernle -a ash migrate backfill-provenance --dry-run

# Apply backfill
kernle -a ash migrate backfill-provenance

# JSON output for programmatic use
kernle -a ash migrate backfill-provenance --json
```

### What it does
- Scans all beliefs/episodes/notes for missing `source_type`
- Identifies seed beliefs by matching statements against the seed belief corpus
- Marks seed beliefs: `source_type='seed'`, `derived_from=['context:kernle_seed_v1.0.0']`
- Defaults non-seed memories without source to `direct_experience`

### Fix for new agents
`_migrate_seed_beliefs()` now passes `source='seed belief...'` and `derived_from` when creating beliefs, so new agents get proper provenance from day one.

### Verified
Ran on live agent `ash` — all 16 seed beliefs correctly backfilled.

All 1228 tests pass.

---

## Provenance Implementation Complete 🏁
| Phase | Description | PR |
|-------|------------|-----|
| 1 | `derived_from` CLI flags + core.py rename | #32 |
| 2 | Wire `process_raw()` + CLI promote | #35 |
| 3 | MCP tools provenance params | #36 |
| 4 | Reinforcement evidence tracking | #37 |
| 5 | Entity-neutral sourcing | #38 |
| 6 | CLI trace, reverse trace, orphan detection | #44 |
| **7** | **Migration backfill** | **This PR** |

Next: Full Kernle audit as requested by Sean.