### PR TITLE
fix: audit-driven hardening — 7 fixes across storage, MCP, forgetting

### DIFF
--- a/audit/SUMMARY.md
+++ b/audit/SUMMARY.md
@@ -1,0 +1,84 @@
+# Full Kernle Audit — Consolidated Summary
+
+**Date:** 2026-02-01  
+**Scope:** 39K lines across 65 Python files (core, commerce, MCP, CLI, features, storage)  
+**Auditors:** 4 specialist sub-agents (security-core, security-commerce, quality-features, storage-integrity)
+
+---
+
+## Totals
+
+| Severity | Core Security | Commerce Security | Quality/Features | Storage Integrity | **Total** |
+|----------|:---:|:---:|:---:|:---:|:---:|
+| **P0 (Critical)** | 0 | 5 | 1 | 0 | **6** |
+| **P1 (High)** | 2 | 4 | 5 | 6 | **17** |
+| **P2 (Medium)** | 4 | 6 | 10 | 12 | **32** |
+| **P3 (Low)** | 5 | 5 | 8 | 6 | **24** |
+| **Total** | 11 | 20 | 24 | 24 | **79** |
+
+---
+
+## P0 Critical Findings (6)
+
+### Commerce (5) — All in stubbed/pre-production code
+1. **No on-chain escrow state verification** — double-release/double-refund possible
+2. **Transfers consume daily spend without rollback** — `_rollback_spend` never defined
+3. **SupabaseWalletStorage.atomic_claim_wallet() always returns True** — any address claims any wallet
+4. **No private key management infrastructure** — no secure key handling when CDP integrates
+5. **No transaction receipt verification** — reverted txns could appear successful
+
+### Quality/Features (1)
+6. **Memory poisoning via suggestion pipeline** — raw content flows unsanitized into structured memory (prompt injection vector)
+
+---
+
+## P1 High Findings — Top 10
+
+1. **MCP provenance params silently dropped** — `source`/`derived_from` not passed through validation, breaking lineage via MCP (Phase 3 bug)
+2. **Postgres save_belief()/save_episode() drops most fields** — active data loss (source_type, derived_from, confidence_history, forgetting fields all lost)
+3. **Forgetting system has no auto-protection** for values/identity memories — core values forgotten after 30 days
+4. **No GIN indexes on JSONB arrays** — lineage queries O(N) at scale
+5. **SQLite not in WAL mode** — concurrent CLI + MCP hits SQLITE_BUSY (2-line fix)
+6. **Postgres search is brute-force Python** — no semantic search
+7. **Postgres column names don't match SQLite** — sync loses data at mapping boundaries
+8. **Daily spend limits reset on restart** (in-memory fallback)
+9. **Importers pass unsanitized/unbounded content** to core API
+10. **No transaction safety in promote_suggestion** — partial failure creates duplicates
+
+---
+
+## What's Strong
+
+- **Core security is excellent**: zero SQL injection, parameterized queries everywhere, agent_id isolation in 55+ queries
+- **Path traversal protection**: `is_relative_to()` guards on all file ops
+- **Optimistic concurrency control**: version-based conflict detection on atomic updates
+- **Provenance validation**: `_validate_derived_from()` with type:id format + ref type allowlist
+- **Schema migrations are additive-only** (safe, no data loss)
+- **Raw sync defaults OFF** (prevents accidental secret leakage)
+
+---
+
+## Recommended Fix Priority
+
+### Immediate (quick wins, high impact)
+1. SQLite WAL mode + busy_timeout (2-line fix, prevents lock errors)
+2. Fix MCP provenance param passthrough (Phase 3 bug)
+3. Auto-protect values/identity from forgetting
+4. Cap confidence_history at ~100 entries
+
+### Before cloud sync goes live
+5. Fix Postgres save methods to include ALL dataclass fields
+6. Add GIN indexes on JSONB provenance columns
+7. Add `source_entity` column to SQLite schema
+8. Add `is_forgotten=0` filter to search queries
+
+### Before commerce goes to testnet
+9. Implement `_rollback_spend()` 
+10. Fix SupabaseWalletStorage stubs (raise NotImplementedError)
+11. Add receipt verification pattern
+12. Harden `"system"` actor_id bypass
+
+### Ongoing
+13. Sanitize suggestion→promotion pipeline
+14. Add content size limits to importers
+15. Align Postgres/SQLite column names

--- a/audit/quality-features.md
+++ b/audit/quality-features.md
@@ -1,0 +1,529 @@
+# Kernle Code Quality Audit Report
+
+**Auditor**: Code Quality Subagent  
+**Date**: 2026-02-01  
+**Scope**: MCP tools, CLI, Features, Importers, Error Handling  
+
+---
+
+## Executive Summary
+
+Overall code quality is **solid**. Input validation is comprehensive at the MCP layer, error handling follows defense-in-depth principles, and the feature modules use reasonable bounds. However, several issues exist ranging from data integrity risks to potential injection vectors.
+
+**Findings by severity:**
+- P0 (Critical): 1
+- P1 (High): 5
+- P2 (Medium): 10
+- P3 (Low): 8
+
+---
+
+## 1. MCP Tools (`kernle/mcp/server.py`)
+
+### P1-MCP-01: Provenance params (`source`, `derived_from`) not validated for some tools
+**Severity**: P1 (High)  
+**Location**: `validate_tool_input()`, tools `memory_episode`, `memory_note`, `memory_belief`
+
+The `source` and `derived_from` fields are defined in the Tool schemas for `memory_episode`, `memory_note`, and `memory_belief`, but `validate_tool_input()` does NOT sanitize or include them in the `sanitized_args` dict. The `call_tool()` handler then reads them via `sanitized_args.get("source")` and `sanitized_args.get("derived_from")`, which will always return `None`.
+
+**Impact**: Provenance data is silently dropped for all MCP tool calls. Lineage tracking is broken via MCP.
+
+**Evidence**: In `validate_tool_input` for `memory_episode`:
+```python
+sanitized["objective"] = sanitize_string(...)
+sanitized["outcome"] = sanitize_string(...)
+sanitized["lessons"] = sanitize_array(...)
+sanitized["tags"] = sanitize_array(...)
+sanitized["context"] = ...
+sanitized["context_tags"] = ...
+# source and derived_from are MISSING
+```
+
+But in `call_tool()`:
+```python
+episode_id = k.episode(
+    ...
+    source=sanitized_args.get("source"),      # Always None
+    derived_from=sanitized_args.get("derived_from"),  # Always None
+)
+```
+
+**Fix**: Add validation for `source` and `derived_from` in each tool's validation block.
+
+---
+
+### P2-MCP-02: `memory_belief_update` confidence default causes crash
+**Severity**: P2 (Medium)  
+**Location**: `validate_tool_input()`, `memory_belief_update` branch
+
+```python
+sanitized["confidence"] = (
+    validate_number(arguments.get("confidence"), "confidence", 0.0, 1.0, None)
+    if arguments.get("confidence") is not None
+    else None
+)
+```
+
+`validate_number()` with `default=None` will raise `ValueError("confidence is required")` if `value` is `None`. However, the outer `if` guard prevents this. The real issue is: if someone passes `confidence=0` (falsy), `arguments.get("confidence") is not None` is True, but `arguments.get("confidence")` evaluates to `0`, which is valid. This actually works correctly. **Downgrading concern — logic is sound but confusing.**
+
+**Revised assessment**: Code works but is fragile. A refactor would improve clarity.
+
+---
+
+### P2-MCP-03: `memory_auto_capture` source normalization is inconsistent  
+**Severity**: P2 (Medium)  
+**Location**: `call_tool()`, `memory_auto_capture` handler
+
+```python
+if source not in {"cli", "mcp", "sdk", "import", "unknown"}:
+    if "auto" in source.lower():
+        source = "mcp"
+    else:
+        source = "mcp"
+```
+
+Both branches of the `if/else` result in `"mcp"`. The enum check also doesn't include `"auto"` which is the default from `sanitize_string`. This means any non-standard source value silently becomes `"mcp"` with no warning.
+
+---
+
+### P3-MCP-04: Tool count mismatch with documented "33 tools"
+**Severity**: P3 (Low)  
+**Location**: `TOOLS` list
+
+The `TOOLS` list contains **28 tools** (counted). The remaining tools come from commerce (`get_commerce_tools()`). If commerce is not installed, clients see fewer tools than documented.
+
+---
+
+### P2-MCP-05: `memory_note_search` does multiplication hack for filtering
+**Severity**: P2 (Medium)  
+**Location**: `call_tool()`, `memory_note_search` handler
+
+```python
+results = k.search(query=query, limit=limit * 2)  # Get extra in case we filter
+```
+
+If the search returns mostly non-note results, the user gets fewer results than requested. For `limit=100`, it searches for 200 which may be expensive. Should use a dedicated note search or loop until limit is met.
+
+---
+
+### P3-MCP-06: Global singleton Kernle instance not thread-safe
+**Severity**: P3 (Low)  
+**Location**: `get_kernle()`, `set_agent_id()`
+
+The global `_mcp_agent_id` and function-attribute singleton pattern (`get_kernle._instance`) is not thread-safe. MCP stdio transport is single-threaded so this is currently safe, but would break if transport changes.
+
+---
+
+## 2. CLI (`kernle/cli/__main__.py`, `kernle/cli/commands/`)
+
+### P2-CLI-01: No ID format validation for update/delete operations
+**Severity**: P2 (Medium)  
+**Location**: `cmd_episode`, update handlers, forget commands
+
+IDs like `episode_id`, `goal_id`, `belief_id` are passed through without UUID format validation. Malformed IDs (e.g., SQL injection attempts like `'; DROP TABLE --`) are passed directly to storage layer. Safety depends entirely on the storage layer using parameterized queries.
+
+**Mitigation**: The `sanitize_string` function removes control characters but doesn't validate UUID format. Storage likely uses parameterized queries (SQLite), but defense-in-depth requires validation here.
+
+---
+
+### P2-CLI-02: `cmd_anxiety` `--auto` mode silently executes actions without confirmation
+**Severity**: P2 (Medium)  
+**Location**: `kernle/cli/commands/anxiety.py`, `cmd_anxiety()`, auto mode
+
+The `--auto` flag executes checkpoint saves, consolidation, identity synthesis, sync, and even `emergency_save()` without any confirmation prompt. While this is by design for automation, it can modify significant state.
+
+**Risk**: An agent miscalculating anxiety could trigger emergency saves repeatedly, creating noise in episode history.
+
+---
+
+### P3-CLI-03: `cmd_extract` builds content via string concatenation with user input
+**Severity**: P3 (Low)  
+**Location**: `__main__.py`, `cmd_extract()`
+
+```python
+capture_parts = [f"Conversation extract: {summary}"]
+if getattr(args, "topic", None):
+    capture_parts.append(f"Topic: {args.topic}")
+```
+
+Input is validated via `validate_input()` before use, so this is safe. But the pattern of building structured data via string concatenation is fragile.
+
+---
+
+### P3-CLI-04: `cmd_search` handles `min_score` but type is not validated
+**Severity**: P3 (Low)  
+**Location**: `__main__.py`, `cmd_search()`
+
+`min_score` comes from argparse (presumably as float), but there's no bounds check (0.0-1.0).
+
+---
+
+## 3. Features
+
+### 3a. Emotions (`kernle/features/emotions.py`)
+
+### P3-EMO-01: Keyword matching is substring-based, causing false positives
+**Severity**: P3 (Low)  
+**Location**: `detect_emotion()`
+
+```python
+if keyword in text_lower:
+```
+
+The keyword `"sad"` matches "saddle", "said" doesn't match but `"mad"` matches "made", "nomad", etc. The keyword `"love it"` uses multi-word matching which is better but inconsistent.
+
+**Impact**: Emotion auto-detection may produce inaccurate tags. Since confidence is labeled and this is heuristic-based, impact is low.
+
+---
+
+### P2-EMO-02: `episode_with_emotion` sets `valence or 0.0` — masks intentional zero valence
+**Severity**: P2 (Medium)  
+**Location**: `episode_with_emotion()`, line ~295
+
+```python
+episode = Episode(
+    ...
+    emotional_valence=valence or 0.0,
+    emotional_arousal=arousal or 0.0,
+)
+```
+
+If emotion detection returns `valence=0.0` (neutral), `0.0 or 0.0` evaluates to `0.0` (correct by accident). But if `valence` is explicitly `None` and `auto_detect` found nothing, this silently sets 0.0 rather than leaving it unset. This conflates "no emotion data" with "neutral emotion".
+
+---
+
+### 3b. Anxiety (`kernle/features/anxiety.py`)
+
+### P2-ANX-01: Anxiety score can theoretically exceed 100
+**Severity**: P2 (Medium)  
+**Location**: `get_anxiety_report()`, context_pressure calculation
+
+```python
+context_score = int(90 + (context_pressure_pct - 85) * 0.67)
+```
+
+When `context_pressure_pct = 100`: `90 + 15 * 0.67 = 100.05`, which rounds to 100. But the `min(100, ...)` guard on the dimension catches this. **All dimensions have `min(100, ...)` guards.** 
+
+However, the weighted composite score:
+```python
+overall_score = 0
+for dim_name, weight in self.ANXIETY_WEIGHTS.items():
+    overall_score += dimensions[dim_name]["score"] * weight
+overall_score = int(overall_score)
+```
+
+Weights sum to 1.0, and each dimension is capped at 100, so max composite is 100. **Bounds are correct.** No issue.
+
+**Can scores go negative?** All dimension scores use formulas starting from 0 or positive values. The minimum is 0. Composite minimum is 0. **Bounds are safe.**
+
+---
+
+### P3-ANX-02: Checkpoint age estimated at 500 tokens/minute is arbitrary
+**Severity**: P3 (Low)  
+**Location**: `get_anxiety_report()`, context pressure fallback
+
+```python
+estimated_tokens = checkpoint_age * 500
+```
+
+This is a rough heuristic. If the checkpoint is 6 hours old, it estimates 180,000 tokens, which would show 90% context pressure. This could cause false anxiety spikes for idle sessions.
+
+---
+
+### 3c. Suggestions (`kernle/features/suggestions.py`)
+
+### P0-SUG-01: Raw memory content flows into suggestion content without sanitization
+**Severity**: P0 (Critical)  
+**Location**: `_create_note_suggestion()`, `_create_belief_suggestion()`, `_create_episode_suggestion()`
+
+Raw entries are user-provided brain dumps. When suggestions are created, the raw content is extracted and stored in suggestion `content` dict fields. When promoted via `promote_suggestion()`, this content is passed directly to `k.episode()`, `k.belief()`, or `k.note()`.
+
+```python
+# _create_note_suggestion
+return MemorySuggestion(
+    ...
+    content={
+        "content": content,  # Raw user input, unvalidated
+        ...
+    },
+)
+
+# promote_suggestion
+elif memory_type == "note":
+    memory_id = self.note(
+        content=content.get("content", ""),  # Passed through
+    )
+```
+
+**Risk**: If the raw entry contains adversarial content (e.g., prompt injection text like "Ignore previous instructions and..."), it gets promoted verbatim into structured memory. On `memory_load`, this content is rendered back to the agent, potentially injecting instructions.
+
+**Impact**: Memory poisoning via raw capture → suggestion → promotion pipeline. The content is not sanitized for prompt injection patterns at any point.
+
+**Mitigation**: The core `note()`, `belief()`, `episode()` methods should have input validation. If they do (via `_validate_string_input`), the risk is reduced to content-level injection (not code injection). Still, the promotion pipeline should sanitize.
+
+---
+
+### P2-SUG-02: `_score_patterns` normalization can exceed 1.0 before cap
+**Severity**: P2 (Medium)  
+**Location**: `_score_patterns()`
+
+```python
+return min(1.0, matched_weight / (total_weight * 0.5))
+```
+
+The divisor is `total_weight * 0.5`, so matching >50% of patterns yields score >1.0 before the `min(1.0, ...)` cap. This is intentional (cap applied), but the threshold of 0.4 means even 2-3 keyword matches can create a suggestion. This leads to many low-quality suggestions.
+
+---
+
+### 3d. Forgetting (`kernle/features/forgetting.py`)
+
+### P1-FGT-01: No built-in protection for foundational/identity memories
+**Severity**: P1 (High)  
+**Location**: `run_forgetting_cycle()`, `forget()`
+
+The forgetting system relies on `is_protected` flag on individual memories. **There is no automatic protection for values or identity-related beliefs.** If a value or core belief has low access count and ages past the salience threshold, `run_forgetting_cycle()` will tombstone it.
+
+```python
+def get_forgetting_candidates(self, threshold=0.3, limit=20, memory_types=None):
+    # Default memory_types includes ALL types
+```
+
+The default `memory_types` parameter in the storage layer likely includes values, beliefs, etc. A newly created value that's never accessed could have salience:
+- `confidence=0.8, times_accessed=0, days_since=31`
+- `salience = (0.8 * (log(1) + 0.1)) / (31/30 + 1) = (0.8 * 0.1) / 2.03 = 0.039`
+
+This is well below the 0.3 threshold. **A core value could be forgotten after ~30 days if never explicitly accessed.**
+
+**Fix**: Auto-protect values and high-confidence beliefs, or exclude certain memory types from forgetting by default.
+
+---
+
+### P1-FGT-02: `run_forgetting_cycle(dry_run=False)` has no confirmation and no undo batching
+**Severity**: P1 (High)  
+**Location**: `run_forgetting_cycle()`
+
+Running with `dry_run=False` immediately tombstones up to `limit` memories. While individual memories can be recovered, there's no batch undo or transaction. If called programmatically (e.g., by anxiety auto-mode), it could forget many memories at once.
+
+The CLI `cmd_forget` does show a dry run message, but the feature API has no safety rail.
+
+---
+
+### P2-FGT-03: `calculate_salience` returns -1.0 for not found, but callers may not check
+**Severity**: P2 (Medium)  
+**Location**: `calculate_salience()`
+
+Returns `-1.0` for not-found memories. If a caller doesn't check for this sentinel value and compares `salience < threshold`, the not-found result always qualifies as a forgetting candidate.
+
+**In practice**: `get_forgetting_candidates` uses storage-layer queries, not `calculate_salience`, so this is only a risk for direct API callers.
+
+---
+
+### 3e. Knowledge (`kernle/features/knowledge.py`)
+
+### P2-KNW-01: Domain extraction uses belief_type as domain name
+**Severity**: P2 (Medium)  
+**Location**: `_extract_domains_from_tags()`
+
+```python
+domain = belief.belief_type or "general"
+```
+
+Belief types are limited enum values (`fact`, `rule`, `preference`, `constraint`, `learned`). This means all facts are grouped into one "fact" domain, all rules into "rule" domain, etc. This gives a very coarse domain map that doesn't reflect actual knowledge areas.
+
+Tags are used for episodes and notes (more useful), but beliefs lose their topic information.
+
+---
+
+### P3-KNW-02: Goal domain extraction uses first word of title
+**Severity**: P3 (Low)  
+**Location**: `_extract_domains_from_tags()`
+
+```python
+words = goal.title.lower().split()[:2]
+if words:
+    domain = words[0]
+```
+
+A goal titled "Learn Kubernetes basics" creates domain "learn". A goal titled "Fix the login bug" creates domain "fix". This is noisy and unhelpful.
+
+---
+
+### P3-KNW-03: `detect_knowledge_gaps` gap detection is naive
+**Severity**: P3 (Low)  
+**Location**: `detect_knowledge_gaps()`
+
+```python
+potential_gaps = query_words - found_topics - {"how", "do", "i", ...}
+```
+
+Splitting on whitespace and comparing word sets doesn't account for multi-word concepts or synonyms. Results are more noise than signal.
+
+---
+
+## 4. Importers
+
+### P1-IMP-01: No content size limits on imported data
+**Severity**: P1 (High)  
+**Location**: All importers (`csv_importer.py`, `json_importer.py`, `markdown.py`, `clawdbot.py`)
+
+None of the importers validate content length before calling `k.episode()`, `k.note()`, `k.belief()`, etc. A malicious or malformed import file could contain entries with megabytes of text per field.
+
+**Example** (JSON importer):
+```python
+k.episode(
+    objective=data.get("objective", ""),  # No length limit
+    outcome=data.get("outcome", ""),      # No length limit
+    ...
+)
+```
+
+If the core API methods don't enforce limits, this could bloat the database.
+
+---
+
+### P1-IMP-02: CSV importer trusts column values without sanitization
+**Severity**: P1 (High)  
+**Location**: `csv_importer.py`, `_map_columns()`, `_import_csv_item()`
+
+```python
+result[field_name] = value  # Raw CSV cell value
+```
+
+CSV cell values are used directly. No control character stripping, no length validation. If a CSV cell contains null bytes or extremely long strings, they pass through to storage.
+
+---
+
+### P2-IMP-03: Clawdbot importer reads arbitrary files from workspace
+**Severity**: P2 (Medium)  
+**Location**: `clawdbot.py`, `_parse_daily_notes()`
+
+```python
+for md_file in sorted(memory_dir.glob("*.md")):
+    content = md_file.read_text(encoding="utf-8")
+```
+
+Reads all `.md` files in the `memory/` directory. If a symlink exists pointing outside the workspace, this could read unintended files. Low risk in practice.
+
+---
+
+### P2-IMP-04: JSON importer doesn't validate data types within items
+**Severity**: P2 (Medium)  
+**Location**: `json_importer.py`, `_import_json_item()`
+
+```python
+k.episode(
+    objective=data.get("objective", ""),
+    outcome=data.get("outcome", ""),
+    emotional_valence=data.get("emotional_valence", 0.0),  # Could be a string
+)
+```
+
+If the JSON contains `"emotional_valence": "not_a_number"`, this passes through to the core API. Type validation depends on the core layer.
+
+---
+
+### P3-IMP-05: Duplicate detection is O(n) for goals and values
+**Severity**: P3 (Low)  
+**Location**: `csv_importer.py`, `json_importer.py`
+
+```python
+existing = k._storage.get_goals(status=None, limit=100)
+for g in existing:
+    if g.title == title:
+        return False
+```
+
+For large memory stores with >100 goals, duplicates beyond the first 100 won't be detected. Also, this is called per-row, making it O(n*m) for the import.
+
+---
+
+### P3-IMP-06: Markdown importer `_parse_beliefs` confidence parsing edge case
+**Severity**: P3 (Low)  
+**Location**: `markdown.py`, `_parse_beliefs()`
+
+```python
+confidence = float(val)
+if confidence > 1:
+    confidence = confidence / 100
+```
+
+A value like `150` becomes `1.5`, which exceeds 1.0. The final `min(1.0, max(0.0, confidence))` clamp catches this. Safe but the intermediate `/100` logic is confused (150/100=1.5, still >1). Should clamp immediately after conversion.
+
+---
+
+## 5. Error Handling
+
+### P2-ERR-01: `handle_tool_error` catches all exceptions, potentially masking bugs
+**Severity**: P2 (Medium)  
+**Location**: `server.py`, `call_tool()`
+
+```python
+except Exception as e:
+    return handle_tool_error(e, name, arguments)
+```
+
+The broad `except Exception` means programming errors (AttributeError, KeyError, TypeError from bugs) are caught and returned as "Internal server error" to the MCP client. While this prevents crashes, it makes debugging difficult without log access.
+
+---
+
+### P1-ERR-02: No transaction safety in `promote_suggestion`
+**Severity**: P1 (High)  
+**Location**: `suggestions.py`, `promote_suggestion()`
+
+```python
+memory_id = self.episode(...)  # Step 1: Create memory
+self._storage.update_suggestion_status(...)  # Step 2: Update suggestion
+self._storage.mark_raw_processed(...)  # Step 3: Mark raw as processed
+```
+
+If step 1 succeeds but step 2 or 3 fails (e.g., disk full, db lock), the memory is created but the suggestion remains "pending". Re-promoting would create a duplicate memory. There's no transaction wrapping these operations.
+
+---
+
+## Summary Table
+
+| ID | Severity | Component | Title |
+|---|---|---|---|
+| P0-SUG-01 | P0 | Suggestions | Raw content flows to structured memory unsanitized |
+| P1-MCP-01 | P1 | MCP | Provenance params silently dropped |
+| P1-FGT-01 | P1 | Forgetting | No auto-protection for values/identity memories |
+| P1-FGT-02 | P1 | Forgetting | No safety rail on live forgetting cycles |
+| P1-IMP-01 | P1 | Importers | No content size limits on imported data |
+| P1-IMP-02 | P1 | Importers | CSV values unsanitized |
+| P1-ERR-02 | P1 | Suggestions | No transaction safety in promote_suggestion |
+| P2-MCP-03 | P2 | MCP | Source normalization both branches identical |
+| P2-MCP-05 | P2 | MCP | Note search uses multiplication hack |
+| P2-CLI-01 | P2 | CLI | No UUID format validation for IDs |
+| P2-CLI-02 | P2 | CLI | Anxiety auto-mode executes without confirmation |
+| P2-EMO-02 | P2 | Emotions | `valence or 0.0` masks intentional None |
+| P2-SUG-02 | P2 | Suggestions | Pattern scoring threshold too permissive |
+| P2-FGT-03 | P2 | Forgetting | -1.0 sentinel for not-found may confuse callers |
+| P2-KNW-01 | P2 | Knowledge | Belief_type used as domain name (too coarse) |
+| P2-IMP-03 | P2 | Importers | Clawdbot reads all .md files (symlink risk) |
+| P2-IMP-04 | P2 | Importers | JSON importer doesn't validate data types |
+| P2-ERR-01 | P2 | MCP | Broad exception catch masks bugs |
+| P2-MCP-02 | P2 | MCP | belief_update confidence validation confusing |
+| P3-MCP-04 | P3 | MCP | Tool count may not match documented 33 |
+| P3-MCP-06 | P3 | MCP | Singleton not thread-safe |
+| P3-EMO-01 | P3 | Emotions | Substring keyword matching causes false positives |
+| P3-ANX-02 | P3 | Anxiety | Token estimation heuristic is arbitrary |
+| P3-CLI-03 | P3 | CLI | String concatenation for structured data |
+| P3-CLI-04 | P3 | CLI | min_score not bounds-checked |
+| P3-KNW-02 | P3 | Knowledge | Goal domain uses first word (noisy) |
+| P3-KNW-03 | P3 | Knowledge | Knowledge gap detection is naive |
+| P3-IMP-05 | P3 | Importers | Duplicate detection limited to first 100 |
+| P3-IMP-06 | P3 | Importers | Confidence parsing intermediate value > 1.0 |
+
+---
+
+## Recommended Priority Actions
+
+1. **P0-SUG-01**: Add sanitization to the suggestion→promotion pipeline. At minimum, run content through `_validate_string_input` before creating memories from suggestions.
+
+2. **P1-MCP-01**: Add `source` and `derived_from` to `validate_tool_input()` for `memory_episode`, `memory_note`, and `memory_belief`. This is a functional bug — provenance tracking is completely broken via MCP.
+
+3. **P1-FGT-01**: Auto-protect all values. Consider auto-protecting beliefs with confidence ≥ 0.8. Add `memory_types` default that excludes `value` and `drive` from forgetting candidates.
+
+4. **P1-IMP-01/02**: Add `sanitize_string()` or length-limit validation in importer code before passing to core API.
+
+5. **P1-ERR-02**: Wrap `promote_suggestion` in a transaction or implement idempotency check (skip if already promoted).

--- a/audit/security-commerce.md
+++ b/audit/security-commerce.md
@@ -1,0 +1,409 @@
+# Security Audit: Kernle Commerce & Wallet System
+
+**Auditor:** Automated Security Review  
+**Date:** 2026-02-01  
+**Scope:** `kernle/commerce/` — wallet, escrow, jobs subsystems  
+**Codebase State:** Pre-production (many stubs, CDP/Web3 not yet integrated)
+
+---
+
+## Executive Summary
+
+The commerce system is in early development with most blockchain interactions stubbed out. The **design** shows good security awareness — atomic operations for wallet claims, reentrancy guards on escrow operations, per-job locks for application acceptance, authorization checks, and input validation. However, several significant vulnerabilities exist in the current code, and the stubbed nature of the blockchain integration creates a large surface of **deferred risk** that must be addressed before mainnet deployment.
+
+**Finding Count:** 5 P0 (Critical) · 4 P1 (High) · 6 P2 (Medium) · 5 P3 (Low)
+
+---
+
+## P0 — Critical
+
+### P0-1: No On-Chain Verification of Escrow State Before Service-Layer Transitions
+
+**Files:** `escrow/service.py`, `jobs/service.py`  
+**Description:** The escrow service methods (`release()`, `refund()`, `fund()`, `assign_worker()`, `mark_delivered()`) do not read the on-chain escrow contract status before executing state-changing transactions. The TODO stubs simply return `success=True` without verification.
+
+When these are implemented, if the service layer doesn't **read and verify** the current on-chain status before sending a transaction, the following attacks become possible:
+
+- Calling `release()` on an already-released escrow (double-spend)
+- Calling `refund()` after a worker is assigned (theft from worker)
+- Calling `fund()` on an escrow that's already funded (double-deposit, loss of client funds)
+
+The reentrancy guards only protect against concurrent Python-level calls to the same EscrowService instance. They do **not** protect against direct on-chain calls or multi-instance deployments.
+
+**Impact:** Complete loss of escrowed funds (double-release, unauthorized refund).  
+**Recommendation:**
+1. Every state-changing escrow method must read `escrow.functions.status().call()` and verify the expected state before building the transaction.
+2. The Solidity contracts themselves must enforce state guards (they appear to via `InvalidState` error in ABI), but the Python layer should also verify to provide clear error messages and prevent wasted gas.
+3. Add receipt verification — after sending a transaction, parse the receipt logs to confirm the expected event was emitted.
+
+---
+
+### P0-2: Transfer Succeeds Without Balance Check or Actual Blockchain Execution
+
+**File:** `wallet/service.py` — `transfer()` method (lines ~280-320)  
+**Description:** The transfer method records the daily spend atomically, but then the actual CDP transfer is stubbed as always-successful:
+
+```python
+# STUB: Simulate successful transfer
+return TransferResult(
+    success=True,
+    ...
+    tx_hash=f"0x{'0' * 64}",  # Stub tx hash
+)
+```
+
+The daily spend has **already been incremented** before the stub return. There's a TODO comment about rolling back on failure, but the rollback mechanism (`_rollback_spend`) is **never defined**. This means:
+
+1. If the real transfer fails, the daily spend is permanently consumed — the user loses spending capacity but no money moves.
+2. No actual balance check occurs before the transfer (the `get_balance()` also returns stub zeros).
+
+**Impact:** In production, failed transfers would silently consume spending limits. With the stub, any actor can appear to transfer unlimited funds.  
+**Recommendation:**
+1. Implement `_rollback_spend()` method to decrement daily spend on transfer failure.
+2. Add balance verification before recording the spend.
+3. Only record spend after confirmed on-chain execution (or use a pending/committed two-phase approach).
+
+---
+
+### P0-3: SupabaseWalletStorage.atomic_claim_wallet Always Returns True
+
+**File:** `wallet/storage.py` — `SupabaseWalletStorage.atomic_claim_wallet()`  
+**Description:** The Supabase implementation of `atomic_claim_wallet` is stubbed to always return `True`:
+
+```python
+def atomic_claim_wallet(self, wallet_id: str, owner_eoa: str) -> bool:
+    ...
+    return True  # STUB: Always succeeds
+```
+
+If the SupabaseWalletStorage is used in any deployment (even testing against Supabase), **any address can claim any wallet**, and already-claimed wallets can be re-claimed by different addresses.
+
+**Impact:** Complete wallet takeover — any user can steal control of any agent's wallet.  
+**Recommendation:** Implement the conditional UPDATE query shown in the docstring comment immediately. Until then, add a `raise NotImplementedError()` to prevent accidental use.
+
+---
+
+### P0-4: No Private Key Management or Signing Infrastructure
+
+**Files:** `wallet/service.py`, `escrow/service.py`  
+**Description:** Throughout the codebase, transaction building comments reference `private_key` for signing:
+
+```python
+# signed_tx = self._web3.eth.account.sign_transaction(tx, private_key)
+```
+
+But there is **no key management infrastructure** — no secure storage, no HSM integration, no key derivation, no encryption at rest. The CDP SDK is intended to handle this, but:
+
+1. CDP credentials (`CDP_API_KEY`, `CDP_API_SECRET`) are loaded from plain environment variables with no rotation mechanism.
+2. No mention of CDP's server-side signing — if the key is client-side, it would need secure storage.
+3. The `cdp_wallet_id` is stored in the database with no encryption.
+
+**Impact:** When real keys are introduced, improper handling could expose all wallet private keys.  
+**Recommendation:**
+1. Use CDP's server-side signing exclusively (never store private keys locally).
+2. Encrypt `cdp_wallet_id` at rest in the database.
+3. Implement CDP credential rotation.
+4. Add audit logging for all signing operations.
+
+---
+
+### P0-5: No Transaction Receipt Verification
+
+**Files:** `escrow/service.py` (all transaction methods)  
+**Description:** The TODO comments show the intended pattern:
+
+```python
+# tx_hash = self._web3.eth.send_raw_transaction(signed_tx.rawTransaction)
+# receipt = self._web3.eth.wait_for_transaction_receipt(tx_hash)
+```
+
+But there's no code to verify:
+- `receipt.status == 1` (transaction succeeded on-chain)
+- Expected events were emitted in the receipt logs
+- The receipt `to` address matches the expected contract
+
+Without receipt verification, the service layer could believe a transaction succeeded when it was reverted on-chain.
+
+**Impact:** Escrow state desync — service marks job as completed/funded/released but the on-chain state is unchanged. Funds stuck or double-spent.  
+**Recommendation:** Implement a `_verify_receipt()` helper that checks status, parses expected events, and raises `TransactionFailedError` on any mismatch.
+
+---
+
+## P1 — High
+
+### P1-1: Daily Spend Resets on Process Restart (In-Memory Fallback)
+
+**File:** `wallet/service.py` — `_daily_spend` dict  
+**Description:** The `InMemoryWalletStorage` returns `None` for `get_daily_spend()` and `increment_daily_spend()` in its first implementation, causing the service to fall back to its own in-memory `_daily_spend` dict. This dict:
+
+1. Resets to zero on every process restart
+2. Is not shared across multiple service instances (horizontal scaling)
+3. Uses `threading.Lock` which doesn't protect across processes
+
+An attacker could:
+- Wait for a service restart, then immediately spend the full daily limit again
+- If multiple instances exist, spend the daily limit once per instance
+
+**Impact:** Daily spending limits can be bypassed, potentially draining wallet of `spending_limit_daily` multiple times per day.  
+**Recommendation:**
+1. Implement persistent daily spend tracking in Supabase/database as the **only** path (remove in-memory fallback for production).
+2. Use database-level `SELECT FOR UPDATE` for atomic increment (the SQL is already drafted in the Supabase storage comments).
+3. Add an integration test that verifies limits survive restarts.
+
+---
+
+### P1-2: Escrow-Job State Synchronization Gap
+
+**Files:** `jobs/service.py`, `escrow/service.py`  
+**Description:** The job service and escrow service are **not transactional** together. The flow is:
+
+1. `EscrowService.release(escrow_addr)` — releases on-chain funds
+2. `JobService.approve_job(job_id)` — marks job completed in database
+
+If step 1 succeeds but step 2 fails (e.g., database error, process crash), the funds are released but the job is never marked completed. There's no reconciliation mechanism.
+
+Similarly, `fund_job()` takes an `escrow_address` parameter with no verification that the address actually corresponds to a funded escrow contract.
+
+**Impact:** Funds released but job stuck in "delivered" state (worker can't prove completion). Or: job marked as funded with a fake/unfunded escrow address.  
+**Recommendation:**
+1. Implement an event-driven reconciliation: the `EscrowEventMonitor` should listen for `Released` events and auto-complete the corresponding job.
+2. In `fund_job()`, verify on-chain that the escrow at `escrow_address` is in FUNDED status and matches the job's budget.
+3. Add a periodic background job that compares on-chain escrow states with database job states and flags discrepancies.
+
+---
+
+### P1-3: No Rate Limiting on Wallet/Job Operations
+
+**Files:** `wallet/service.py`, `jobs/service.py`  
+**Description:** There is no rate limiting at the service layer for:
+- `create_wallet()` — could spam wallet creation (each costs gas and CDP resources)
+- `create_job()` — could flood the marketplace with spam jobs
+- `apply_to_job()` — one agent per job limit exists, but one agent could apply to thousands of jobs
+- `transfer()` — per-tx and daily limits exist, but there's no transactions-per-minute limit
+
+**Impact:** Resource exhaustion, marketplace spam, gas drainage.  
+**Recommendation:** Add rate limiting at the API/service layer (e.g., max N wallet creations per user per hour, max N job postings per day).
+
+---
+
+### P1-4: InMemoryWalletStorage.atomic_claim_wallet Not Actually Atomic Under Threading
+
+**File:** `wallet/storage.py` — first `InMemoryWalletStorage` class  
+**Description:** The comment says "In-memory is single-threaded, so this is atomic" but the `WalletService` uses `threading.Lock` for daily spend, implying multi-threaded usage is expected. The `atomic_claim_wallet` in `InMemoryWalletStorage` has no lock:
+
+```python
+def atomic_claim_wallet(self, wallet_id, owner_eoa):
+    wallet = self._wallets.get(wallet_id)
+    if wallet.owner_eoa is not None:
+        return False  # Already claimed
+    # TOCTOU gap here under threading
+    wallet.owner_eoa = owner_eoa
+```
+
+Under concurrent requests, two threads could both read `owner_eoa is None`, pass the check, and both write — last writer wins.
+
+**Impact:** Wallet ownership can be stolen via race condition in testing/dev (which may mask bugs that reach production).  
+**Recommendation:** Add a `threading.Lock` to the in-memory storage's claim operation, or use the second `InMemoryWalletStorage` class (which also lacks the lock but at least has daily spend locking as a pattern).
+
+Note: There are **two** `InMemoryWalletStorage` classes in `storage.py` — this is itself a bug (see P3-1).
+
+---
+
+## P2 — Medium
+
+### P2-1: Spending Limits Use `float` Type — Precision Loss
+
+**Files:** `wallet/models.py`, `wallet/service.py`, `config.py`  
+**Description:** Spending limits (`spending_limit_per_tx`, `spending_limit_daily`) are stored as Python `float`, while amounts use `Decimal`. The comparison in `transfer()`:
+
+```python
+if float(amount) > wallet.spending_limit_per_tx:
+```
+
+This mixes `float` and `Decimal`, which can cause precision errors. For example:
+```python
+>>> float(Decimal("0.1") + Decimal("0.2")) == 0.3
+False  # It's 0.30000000000000004
+```
+
+**Impact:** Transactions near the spending limit boundary could be incorrectly accepted or rejected.  
+**Recommendation:** Change `spending_limit_per_tx` and `spending_limit_daily` to `Decimal` throughout. Use `Decimal` comparisons exclusively.
+
+---
+
+### P2-2: No Checksum Validation on Ethereum Addresses
+
+**Files:** `wallet/models.py`, `jobs/models.py`, `wallet/service.py`  
+**Description:** Address validation checks length and hex format but not EIP-55 checksums. A typo in an address (e.g., `0xdead...` vs `0xDeaD...`) would pass validation. Sending funds to an invalid checksum address is irrecoverable.
+
+**Impact:** Funds sent to mistyped addresses are permanently lost.  
+**Recommendation:** Implement EIP-55 checksum validation using `web3.Web3.is_checksum_address()` or equivalent. Accept lowercase/uppercase but warn on non-checksummed.
+
+---
+
+### P2-3: No Tithe/Fee Mechanism — Potential for Manipulation When Added
+
+**Files:** All commerce files  
+**Description:** The codebase has **no tithe/reverse-tithe/fee** implementation despite the project docs referencing it. When this is added, common vulnerabilities include:
+- Fee calculated client-side and passed as parameter (attacker sets fee to 0)
+- Fee calculated on `budget_usdc` (float) instead of actual escrow amount
+- Rounding errors that can be exploited over many small transactions
+- Fee not enforced at the smart contract level (bypassed by direct contract interaction)
+
+**Impact:** Revenue loss or fee manipulation when feature is implemented.  
+**Recommendation:** When implementing tithe:
+1. Calculate exclusively server-side (never trust client-provided fee amounts)
+2. Use `Decimal` with explicit rounding (`ROUND_HALF_UP` or `ROUND_CEILING`)
+3. Enforce in the Solidity contract (immutable split at release time)
+4. Add invariant tests: `worker_payout + tithe == escrow_amount`
+
+---
+
+### P2-4: Job `cancel_job` Allows Cancellation After Worker Accepted
+
+**File:** `jobs/service.py`, `jobs/models.py`  
+**Description:** The state transition table allows:
+```python
+JobStatus.ACCEPTED: {JobStatus.DELIVERED, JobStatus.DISPUTED, JobStatus.CANCELLED}
+```
+
+A client can cancel a job **after** a worker has been accepted and started working. The service only checks `job.client_id != actor_id` but doesn't verify whether the cancellation is fair to the worker. No partial payment or dispute is forced.
+
+**Impact:** Client can cancel a job after the worker has invested time, getting a full refund and paying the worker nothing.  
+**Recommendation:**
+1. Remove `CANCELLED` from `ACCEPTED` transitions, or
+2. Force the cancellation through the dispute flow when a worker is assigned, or
+3. Implement partial payment (e.g., pro-rata based on time elapsed vs deadline)
+
+---
+
+### P2-5: `system` Actor Bypasses All Arbitrator Checks
+
+**File:** `jobs/service.py` — `_is_authorized_arbitrator()`  
+**Description:**
+```python
+if actor_id == "system":
+    return True
+```
+
+Any caller that can pass `actor_id="system"` can resolve disputes. If API routes don't sanitize `actor_id`, an external user could claim to be `"system"`.
+
+**Impact:** Unauthorized dispute resolution — attacker redirects escrow funds.  
+**Recommendation:**
+1. Never accept `"system"` as an actor_id from external input.
+2. Add an internal-only flag or use a separate code path for system-initiated actions.
+3. Validate at the API layer that `actor_id` matches authenticated session.
+
+---
+
+### P2-6: Duplicate Class Definitions Create Import Ambiguity
+
+**File:** `wallet/storage.py`, `jobs/storage.py`  
+**Description:** Both files define `InMemoryWalletStorage` / `InMemoryJobStorage` **twice** — a simpler version followed by a more complete version. Python will use the **last** definition, but:
+1. The first definition may be imported by tests that specifically reference it
+2. IDE analysis and type checkers may flag the first one
+3. The two implementations have different behaviors (first InMemoryWalletStorage lacks daily spend tracking, second has it)
+
+**Impact:** Wrong storage implementation used in tests, potentially hiding bugs.  
+**Recommendation:** Remove the duplicate class definitions. Keep only the more complete version.
+
+---
+
+## P3 — Low
+
+### P3-1: Stub Transaction Hashes Are Deterministic
+
+**Files:** `escrow/service.py`, `wallet/service.py`  
+**Description:** Stub tx hashes are all `0x` + 64 zeros. If any verification code checks for unique tx hashes, or if these stubs leak into a database that later expects real hashes, it creates confusion.
+
+**Impact:** Low — only affects development, but could mask bugs in tx verification logic.  
+**Recommendation:** Generate random stub hashes: `f"0x{uuid.uuid4().hex}{uuid.uuid4().hex[:32]}"`.
+
+---
+
+### P3-2: Config Secrets Loaded from Environment with No Validation
+
+**File:** `config.py`  
+**Description:** `CDP_API_KEY` and `CDP_API_SECRET` are loaded from env vars with no format validation. If a user sets a malformed key, the error won't surface until a CDP API call is made, potentially mid-transaction.
+
+**Impact:** Debugging difficulty, potential mid-operation failures.  
+**Recommendation:** Validate credential format on config load. Log warnings for missing credentials at startup.
+
+---
+
+### P3-3: `_job_id_to_bytes32` Uses SHA-256 — Not Reversible
+
+**File:** `escrow/service.py`  
+**Description:** Job IDs are hashed to `bytes32` via SHA-256 for use as Solidity `bytes32`. This means you cannot derive the job ID from the on-chain `bytes32` value — you must maintain an off-chain mapping. If the database is lost, the link between on-chain escrows and jobs is severed.
+
+**Impact:** Disaster recovery difficulty.  
+**Recommendation:** Store the `bytes32` mapping in the job record. Alternatively, if job IDs are UUIDs (16 bytes), pad to 32 bytes instead of hashing — this preserves reversibility.
+
+---
+
+### P3-4: No Pagination Bounds on Job/Application Listing
+
+**Files:** `jobs/service.py`, `jobs/storage.py`  
+**Description:** `list_jobs(limit=100)` and `list_applications(limit=100)` have defaults but no maximum enforcement. A caller can set `limit=1000000` and fetch the entire database.
+
+**Impact:** Memory exhaustion, slow queries.  
+**Recommendation:** Enforce `MAX_LIMIT = 100` (or similar) and clamp user-provided values.
+
+---
+
+### P3-5: Wallet Address Generation Is Deterministic from Agent ID
+
+**File:** `wallet/service.py` — `create_wallet()` stub  
+**Description:** The stub generates wallet addresses deterministically from `agent_id`:
+```python
+base_hash = uuid.uuid5(uuid.NAMESPACE_DNS, agent_id).hex
+```
+
+If this stub is ever used in a context where the address is treated as a real address, anyone can predict wallet addresses for any agent.
+
+**Impact:** Low (stub only), but if stub addresses leak into production data, could cause confusion.  
+**Recommendation:** Use `uuid.uuid4()` for stub addresses, or clearly mark stub addresses with a prefix like `0xDEAD`.
+
+---
+
+## Deferred Risk Summary
+
+The following areas are **entirely stubbed** and represent major security surface that must be audited when implemented:
+
+| Area | Risk | Stub Location |
+|------|------|---------------|
+| CDP Wallet Creation | Key generation, seed phrase handling | `wallet/service.py:create_wallet()` |
+| CDP Transfer Signing | Private key exposure, replay attacks | `wallet/service.py:transfer()` |
+| Web3 Contract Calls | ABI encoding errors, gas manipulation | `escrow/service.py:*` |
+| On-Chain Balance Check | False balance reporting | `wallet/service.py:get_balance()` |
+| Supabase Storage | SQL injection, RLS bypass | `wallet/storage.py`, `jobs/storage.py` |
+| Event Parsing | Log spoofing via crafted events | `escrow/events.py:parse_log()` |
+| USDC Allowance Check | Insufficient allowance not caught | `escrow/service.py:fund()` |
+
+---
+
+## Recommendations Priority
+
+### Immediate (Before Any Testnet Deployment)
+1. **P0-3:** Fix SupabaseWalletStorage stubs to raise `NotImplementedError`
+2. **P0-2:** Implement `_rollback_spend()` and balance checking
+3. **P2-6:** Remove duplicate class definitions
+4. **P2-5:** Harden `"system"` actor_id handling
+
+### Before Testnet with Real Tokens
+5. **P0-1:** Implement on-chain state verification in all escrow methods
+6. **P0-5:** Implement receipt verification
+7. **P1-1:** Implement persistent daily spend tracking
+8. **P1-2:** Build escrow↔job reconciliation via event monitoring
+9. **P2-1:** Migrate spending limits from `float` to `Decimal`
+
+### Before Mainnet
+10. **P0-4:** Full key management audit once CDP is integrated
+11. **P2-2:** Add EIP-55 checksum validation
+12. **P2-3:** Design and audit tithe mechanism with smart contract enforcement
+13. **P2-4:** Redesign cancellation policy for accepted jobs
+14. **P1-3:** Implement rate limiting
+
+---
+
+*End of audit report.*

--- a/audit/security-core.md
+++ b/audit/security-core.md
@@ -1,0 +1,379 @@
+# Kernle Core Memory System — Security Audit Report
+
+**Auditor:** Automated Security Review  
+**Date:** 2026-02-01  
+**Scope:** Core memory storage layer (sqlite.py, postgres.py, base.py, core.py, metamemory.py)  
+**Commit:** HEAD at time of audit  
+
+---
+
+## Executive Summary
+
+The Kernle core memory system demonstrates **strong security fundamentals**. SQL injection is well-mitigated through consistent use of parameterized queries, agent_id isolation is enforced across all WHERE clauses, and path traversal protections are in place. The codebase shows evidence of deliberate security engineering (table name allowlists, input validation, HTTPS enforcement, file permission hardening).
+
+**Critical (P0):** 0 findings  
+**High (P1):** 2 findings  
+**Medium (P2):** 4 findings  
+**Low (P3):** 5 findings  
+
+---
+
+## 1. SQL Injection Analysis
+
+### 1.1 Parameterized Queries — ✅ PASS
+
+All user-supplied data flows through parameterized queries (`?` placeholders) in sqlite.py. Every `save_*`, `get_*`, `update_*`, `delete_*`, and `search` method uses parameter binding for:
+- `agent_id`
+- `id` / `record_id`
+- All content fields (objective, outcome, statement, content, blob, etc.)
+- Filter values (status, note_type, since timestamps, etc.)
+
+**Evidence:** Checked all ~60+ SQL operations in sqlite.py. Zero instances of string formatting for user data.
+
+### 1.2 Dynamic Table Names — ⚠️ FINDING
+
+**[P2-SQL-01] Some f-string table interpolations lack validate_table_name() calls**
+
+The codebase uses f-string interpolation for table names in several methods. An `ALLOWED_TABLES` frozenset and `validate_table_name()` function exist (line 100-141 of sqlite.py), and they are called in several critical paths. However, not all paths that use `table_map.get()` also call `validate_table_name()`.
+
+**Affected methods (table comes from hardcoded `table_map` dict — low actual risk):**
+- `update_memory_meta()` (line 4662) — builds `f"UPDATE {table} SET ..."` without `validate_table_name()`
+- `record_access()` (line 4846) — uses `f"UPDATE {table} ..."` without validation
+- `forget_memory()` (line 4953) — **does** call `validate_table_name()` ✓
+- `recover_memory()` (line 5009) — does NOT call `validate_table_name()`
+- `protect_memory()` (line 5058) — does NOT call `validate_table_name()`
+- `get_forgetting_candidates()` — does NOT call `validate_table_name()`
+- `get_forgotten_memories()` — does NOT call `validate_table_name()`
+- `get_stats()` (line 4367) — iterates hardcoded table list without validation
+
+**Mitigating factors:**
+- All table names come from hardcoded `table_map` dicts (not user input)
+- The `table_map.get()` pattern returns `None` for unknown keys, causing early return
+- No external caller can inject a table name directly
+
+**Risk:** LOW in practice because values come from hardcoded maps. However, defense-in-depth dictates adding `validate_table_name()` consistently.
+
+**Recommendation:** Add `validate_table_name(table)` call after every `table_map.get()` for consistency and defense-in-depth.
+
+### 1.3 LIKE Pattern Injection — ✅ MITIGATED
+
+The `search_raw_fts()` method properly escapes LIKE wildcards using `_escape_like_pattern()` (line 3886). The `_text_search()` method (line 4304) does NOT escape LIKE patterns, but the search_term is wrapped in `%...%` and the risk is limited to unexpected matching behavior (no data exfiltration).
+
+**[P3-SQL-02] _text_search() LIKE patterns not escaped**
+
+`search_term = f"%{query}%"` at line 4304 does not escape `%` or `_` characters in the user's query. This could cause unexpected matching but cannot cause injection since parameterized queries are used.
+
+**Recommendation:** Apply `_escape_like_pattern()` to user queries in `_text_search()` for consistency.
+
+### 1.4 mark_synced() Integer Array — ✅ ACCEPTABLE
+
+`mark_synced()` (line 5316) builds `f"UPDATE sync_queue SET synced = 1 WHERE id IN ({placeholders})"` where `placeholders` is built from `",".join("?" * len(ids))`. The IDs are passed as parameters. This is safe.
+
+### 1.5 Supabase/PostgreSQL (postgres.py) — ✅ PASS
+
+The Supabase client uses its builder pattern (`.eq()`, `.gte()`, `.lte()`, `.upsert()`) which handles parameterization internally. No raw SQL strings are constructed. All queries include `.eq("agent_id", self.agent_id)` for isolation.
+
+---
+
+## 2. Input Validation
+
+### 2.1 core.py String Validation — ✅ GOOD
+
+The `Kernle` class in core.py implements `_validate_string_input()` (line ~380) which:
+- Checks type is `str`
+- Enforces max_length (configurable per field)
+- Strips null bytes (`\x00`)
+- Normalizes line endings (`\r\n` → `\n`)
+
+This is called for:
+- Episode: objective (1000), outcome (1000), lessons (500 each), tags (100 each)
+- Note: content (2000), speaker (200), reason (1000), tags (100 each)
+- Belief: statement (1000)
+- Value: name (200), statement (1000)
+- Goal: title (500), description (1000)
+- Checkpoint: task (500), context (1000)
+- Agent ID: separate sanitization with alphanumeric-only filter
+
+### 2.2 Agent ID Validation — ✅ GOOD
+
+`_validate_agent_id()` (line ~340):
+- Strips whitespace
+- Allows only `[a-zA-Z0-9\-_.]` characters
+- Enforces max 100 characters
+- Rejects empty strings
+
+### 2.3 Note Type Validation — ✅ GOOD
+
+The `note()` method validates `type` against an explicit allowlist: `("note", "decision", "insight", "quote")`.
+
+### 2.4 derived_from Validation — ✅ GOOD
+
+`_validate_derived_from()` validates reference format (`type:id`) and checks type against a known allowlist. This prevents garbage data in provenance chains.
+
+### 2.5 Raw Entry Size Limits — ✅ GOOD
+
+`save_raw()` rejects blobs > 50MB and logs warnings at 1MB and 10MB thresholds. This prevents storage exhaustion.
+
+### 2.6 Budget Parameter Validation — ✅ GOOD
+
+`load()` clamps budget to `[MIN_TOKEN_BUDGET, MAX_TOKEN_BUDGET]` range (100–50000).
+
+### 2.7 Missing Validation — ⚠️ FINDINGS
+
+**[P2-INPUT-01] belief_type not validated against allowlist in storage layer**
+
+While `note_type` is validated in `core.py`, `belief_type` is not validated against an allowlist anywhere. The `belief()` method in core.py accepts arbitrary strings for `type` parameter (mapped to `belief_type`). A user could set `belief_type` to any string.
+
+Looking at the code pattern, valid types appear to be: `fact`, `opinion`, `principle`, `strategy`, `model`, `observation`. But this is not enforced.
+
+**Recommendation:** Add explicit validation similar to note_type:
+```python
+if belief_type not in ("fact", "opinion", "principle", "strategy", "model", "observation"):
+    raise ValueError("Invalid belief type")
+```
+
+**[P2-INPUT-02] Confidence values not clamped in all paths**
+
+While `update_episode_emotion()` properly clamps valence/arousal values, confidence values passed to `save_episode()`, `save_belief()`, etc. are not clamped to [0.0, 1.0] at the storage layer. The `verify_memory()` method in metamemory.py does use `min(1.0, ...)` but doesn't enforce `max(0.0, ...)`.
+
+**Recommendation:** Add `confidence = max(0.0, min(1.0, confidence))` clamping in save methods.
+
+**[P3-INPUT-03] source_type not validated against SourceType enum**
+
+`source_type` field accepts arbitrary strings. The `SourceType` enum exists in base.py but is not enforced at the storage layer.
+
+---
+
+## 3. Access Control (Agent Isolation)
+
+### 3.1 Agent ID Filtering — ✅ EXCELLENT
+
+**Every single query** that reads or modifies memory records includes `agent_id = ?` with `self.agent_id`. This was verified across all methods:
+
+| Method Category | agent_id in WHERE | Count Verified |
+|---|---|---|
+| `get_*` (single record) | ✅ `AND agent_id = ?` | 12/12 |
+| `get_*` (list) | ✅ `WHERE agent_id = ?` | 10/10 |
+| `save_*` (INSERT) | ✅ Uses `self.agent_id` | 9/9 |
+| `update_*` | ✅ `AND agent_id = ?` in WHERE | 8/8 |
+| `delete/forget/recover` | ✅ `AND agent_id = ?` | 3/3 |
+| `search` (all variants) | ✅ `WHERE agent_id = ?` | 5/5 |
+| `record_access` | ✅ `AND agent_id = ?` | 1/1 |
+| `load_all` (batch) | ✅ All 7 queries filtered | 7/7 |
+
+### 3.2 Supabase (postgres.py) Agent Isolation — ✅ PASS
+
+All Supabase queries use `.eq("agent_id", self.agent_id)` for reads and include `"agent_id": self.agent_id` in writes.
+
+### 3.3 Save Methods Override agent_id — ✅ GOOD
+
+In `save_episode()`, `save_belief()`, etc., the INSERT always uses `self.agent_id` (not `episode.agent_id`). This means even if a caller passes a manipulated record with a different agent_id, the storage layer forces the correct agent_id.
+
+### 3.4 Sync Pull Agent Isolation — ⚠️ FINDING
+
+**[P1-ACCESS-01] _mark_synced() missing agent_id filter**
+
+`_mark_synced()` (line 5542) executes:
+```python
+conn.execute(f"UPDATE {table} SET cloud_synced_at = ? WHERE id = ?", (now, record_id))
+```
+
+This updates by `id` only, without `AND agent_id = ?`. While the `id` is a UUID and the method is only called internally during sync operations, this is a defense-in-depth gap. If a UUID collision occurred or a cloud service returned a manipulated record_id, it could theoretically mark another agent's record as synced.
+
+**Risk:** LOW — requires UUID collision AND compromised cloud backend. But violates the otherwise-perfect agent isolation pattern.
+
+**Recommendation:** Add `AND agent_id = ?` to the WHERE clause.
+
+### 3.5 Embedding/Vector Search Agent Isolation — ⚠️ FINDING
+
+**[P1-ACCESS-02] Vector search queries vec_embeddings without agent_id filter**
+
+The `_vector_search()` method (line ~4201) queries `vec_embeddings` table which contains embeddings from ALL agents in the same database. The vector search itself does not filter by agent_id:
+
+```python
+rows = conn.execute(
+    """SELECT id, distance
+       FROM vec_embeddings
+       WHERE embedding MATCH ?
+       ORDER BY distance
+       LIMIT ?""",
+    (query_packed, limit * 2),
+).fetchall()
+```
+
+However, after getting vector results, `_fetch_record()` is called which DOES include `AND agent_id = ?`. So cross-agent results are fetched but then filtered out.
+
+**Risk:** MEDIUM — No data is leaked to the caller because `_fetch_record()` filters by agent_id. But:
+1. Performance: Agent A's queries process Agent B's embeddings unnecessarily
+2. Timing side-channel: An attacker could potentially infer the existence of other agents' records by observing which vector IDs return `None` from `_fetch_record()`
+
+**Recommendation:** Prefix vector IDs with agent_id (e.g., `agent_id:table:record_id`) and add a WHERE filter, OR use a separate vec table per agent.
+
+---
+
+## 4. Data Integrity (Provenance Write-Once Enforcement)
+
+### 4.1 Provenance Fields Are Mutable — ⚠️ FINDING
+
+**[P2-INTEGRITY-01] Provenance fields (source_type, derived_from, source_episodes) can be overwritten after creation**
+
+The `update_memory_meta()` method allows updating:
+- `source_type`
+- `source_episodes`
+- `derived_from`
+- `confidence_history`
+
+There is no write-once enforcement. An agent (or malicious caller) could rewrite the provenance of any memory, changing its source_type from "inference" to "direct_experience" and deleting the derived_from chain.
+
+Similarly, `update_episode_atomic()` and `update_belief_atomic()` can overwrite all fields including provenance fields.
+
+**Mitigating factors:**
+- `confidence_history` is append-only by convention (verify_memory appends)
+- The provenance chain is informational, not used for access control decisions
+- In single-agent mode, the agent is both author and consumer of provenance
+
+**Risk:** MEDIUM in multi-agent scenarios; LOW in single-agent mode.
+
+**Recommendation:** Consider:
+1. Making `source_type` and initial `derived_from` write-once (only settable when NULL/empty)
+2. Making `confidence_history` append-only at the storage layer
+3. Adding a `provenance_locked` flag that prevents provenance mutation after initial creation
+
+### 4.2 Optimistic Concurrency Control — ✅ GOOD
+
+`update_episode_atomic()` and `update_belief_atomic()` implement proper optimistic concurrency control with version checking. The `WHERE version = ?` clause prevents lost updates. `VersionConflictError` is raised on conflict.
+
+### 4.3 Soft Delete Integrity — ✅ GOOD
+
+All delete operations use soft delete (`deleted = 1`), and all read queries filter `AND deleted = 0`. Records can be recovered.
+
+### 4.4 Sync Conflict Resolution — ✅ GOOD
+
+Sync conflicts are recorded in `sync_conflicts` table with full snapshots of both versions. Array fields (tags, lessons, derived_from) are merged using set union rather than overwritten, preserving data from both sides. The `MAX_SYNC_ARRAY_SIZE = 500` limit prevents resource exhaustion from merge amplification.
+
+---
+
+## 5. Secrets and Credentials
+
+### 5.1 No Hardcoded Credentials — ✅ PASS
+
+No hardcoded API keys, tokens, passwords, or secrets were found in any of the audited files. All credentials are loaded from:
+1. Environment variables (`KERNLE_SUPABASE_URL`, `KERNLE_SUPABASE_KEY`, `KERNLE_AUTH_TOKEN`, etc.)
+2. Config files (`~/.kernle/credentials.json`, `~/.kernle/config.json`)
+
+### 5.2 Credential Loading — ✅ GOOD
+
+`_load_cloud_credentials()` (line 793) follows a proper priority chain:
+1. `~/.kernle/credentials.json`
+2. Environment variables (override file values)
+3. `~/.kernle/config.json` (fallback)
+
+### 5.3 Supabase Key Validation — ✅ GOOD
+
+postgres.py validates:
+- URL must be HTTPS (line ~139)
+- Key must be non-empty and ≥100 characters (basic JWT-like validation)
+- URL hostname is validated against known Supabase domains with fallback to reasonable hostname patterns
+- SSRF-like URL manipulation is partially mitigated by hostname validation
+
+### 5.4 Raw Sync Default OFF — ✅ GOOD SECURITY DESIGN
+
+`_should_sync_raw()` defaults to OFF, noting that "raw blobs often contain accidental secrets." This is a thoughtful security decision.
+
+### 5.5 File Permissions — ✅ GOOD
+
+`_init_db()` sets `0o600` on the database file and `0o700` on directories. `_sync_beliefs_to_file()` sets `0o600` on flat files.
+
+**[P3-PERMS-01] Not all flat file writes set 0o600 permissions**
+
+`_sync_values_to_file()`, `_sync_goals_to_file()`, `_sync_relationships_to_file()`, and `_append_raw_to_file()` do NOT set restrictive permissions on their output files. Only `_sync_beliefs_to_file()` does.
+
+**Recommendation:** Apply `os.chmod(file, 0o600)` consistently to all flat file writes.
+
+---
+
+## 6. Path Traversal
+
+### 6.1 Database Path Validation — ✅ EXCELLENT
+
+`_validate_db_path()` (line ~675):
+- Resolves to absolute path via `.resolve()`
+- Checks `is_relative_to()` against safe directories (home, /tmp, tempdir)
+- Handles macOS `/var/folders` and `/private/var/folders`
+- Rejects paths outside safe boundaries
+
+### 6.2 Checkpoint Directory Validation — ✅ EXCELLENT
+
+`_validate_checkpoint_dir()` in core.py uses the same robust pattern with `is_relative_to()`.
+
+### 6.3 Agent ID Used in Paths — ✅ MITIGATED
+
+Agent ID is used to construct directory paths (`self._agent_dir = self.db_path.parent / agent_id`). The `_validate_agent_id()` method strips all non-alphanumeric characters except `-_.`, preventing `../` traversal.
+
+### 6.4 Raw File Flat File Writes — ✅ MITIGATED
+
+`_append_raw_to_file()` constructs filenames from timestamps (`YYYY-MM-DD.md`), not user input. The directory is within the validated agent directory.
+
+**[P3-PATH-01] Daily raw file name from datetime is safe but should be validated**
+
+The date string is derived from `datetime.fromisoformat()` which produces safe filenames. No issue, but worth noting.
+
+---
+
+## 7. Additional Findings
+
+**[P3-MISC-01] FTS5 query passed directly to MATCH**
+
+In `search_raw_fts()` (line ~3854), the user's query is passed directly to FTS5 MATCH:
+```python
+AND raw_fts MATCH ?
+```
+This is parameterized, so no SQL injection. However, FTS5 MATCH has its own query syntax (AND, OR, NOT, NEAR, prefix*). A malformed FTS5 query will raise `sqlite3.OperationalError`, which is caught. Malicious FTS5 syntax could cause performance issues but not data leakage.
+
+**[P3-MISC-02] Checkpoint file size check is good but MAX_CHECKPOINT_SIZE could be configurable**
+
+The 10MB limit on checkpoint files (line ~978) is hardcoded. This is fine but could benefit from being configurable for agents with large working states.
+
+---
+
+## Summary Table
+
+| ID | Severity | Category | Description | Status |
+|---|---|---|---|---|
+| P1-ACCESS-01 | **P1** | Access Control | `_mark_synced()` missing agent_id filter | Open |
+| P1-ACCESS-02 | **P1** | Access Control | Vector search processes all agents' embeddings | Open |
+| P2-SQL-01 | **P2** | SQL Injection | Some f-string table names lack validate_table_name() | Open |
+| P2-INPUT-01 | **P2** | Input Validation | belief_type not validated against allowlist | Open |
+| P2-INPUT-02 | **P2** | Input Validation | Confidence values not clamped in all paths | Open |
+| P2-INTEGRITY-01 | **P2** | Data Integrity | Provenance fields are mutable after creation | Open |
+| P3-SQL-02 | **P3** | SQL Injection | _text_search() LIKE patterns not escaped | Open |
+| P3-INPUT-03 | **P3** | Input Validation | source_type not validated against SourceType enum | Open |
+| P3-PERMS-01 | **P3** | Secrets/Perms | Not all flat file writes set 0o600 | Open |
+| P3-MISC-01 | **P3** | Misc | FTS5 query syntax can cause perf issues | Open |
+| P3-MISC-02 | **P3** | Misc | MAX_CHECKPOINT_SIZE not configurable | Open |
+
+---
+
+## Positive Security Patterns Observed
+
+1. **`ALLOWED_TABLES` frozenset + `validate_table_name()`** — Table allowlist is a strong pattern
+2. **Consistent parameterized queries** — Zero string formatting for user data in SQL
+3. **`self.agent_id` forced in save methods** — Can't inject a different agent_id via records
+4. **`is_relative_to()` for path validation** — Resistant to `../` and symlink attacks
+5. **Raw sync OFF by default** — Prevents accidental secret leakage to cloud
+6. **Optimistic concurrency control** — Version-based conflict detection prevents lost updates
+7. **HTTPS enforcement for Supabase URLs** — Prevents MITM
+8. **Secure file permissions** (0o600/0o700) on database and directories
+9. **`MAX_SYNC_ARRAY_SIZE`** — Prevents sync merge amplification DoS
+10. **`_escape_like_pattern()`** — LIKE wildcard escaping exists (though inconsistently applied)
+
+---
+
+## Recommended Priority Actions
+
+1. **P1:** Add `AND agent_id = ?` to `_mark_synced()` query
+2. **P1:** Add agent_id prefix to vector embeddings or filter vec_embeddings by agent scope
+3. **P2:** Add `validate_table_name()` to all methods using `table_map.get()` for defense-in-depth
+4. **P2:** Add belief_type and source_type allowlist validation
+5. **P2:** Clamp confidence to [0.0, 1.0] in all save paths
+6. **P3:** Apply `os.chmod(0o600)` to all flat file writes consistently

--- a/audit/storage-integrity.md
+++ b/audit/storage-integrity.md
@@ -1,0 +1,259 @@
+# Storage Layer Integrity & Performance Audit
+
+**Auditor**: Storage Integrity Subagent  
+**Date**: 2026-02-01  
+**Scope**: `kernle/storage/` — SQLite, Postgres/Supabase, embeddings, base models  
+**Files Reviewed**: `base.py`, `sqlite.py` (~6100 lines), `postgres.py` (~2100 lines), `embeddings.py`
+
+---
+
+## Executive Summary
+
+The storage layer is well-architected for a local-first memory system with cloud sync. SQLite is the primary, feature-complete backend; Postgres/Supabase is a secondary cloud backend with significant feature gaps. The codebase shows good security awareness (table name allowlists, LIKE escaping, path validation) and solid schema design. However, there are **critical data integrity risks** in the Postgres backend, **missing indexes for JSON fields**, and **race conditions** in confidence updates on Postgres. Below are 28 findings rated P0–P3.
+
+---
+
+## Findings
+
+### 1. Schema Integrity
+
+#### F1: No Foreign Keys Enforced (SQLite) — P3 (Low)
+**Location**: `sqlite.py` SCHEMA definition  
+**Issue**: No `FOREIGN KEY` constraints exist between tables. For example, `source_episodes` references episode IDs stored as a JSON array TEXT column, not via FK. `derived_from` similarly has no referential integrity.  
+**Impact**: Orphaned references are possible (e.g., a belief's `source_episodes` could reference a deleted episode). However, given the soft-delete pattern (`deleted=0/1`) and JSON array storage, FK enforcement would be impractical here.  
+**Recommendation**: Accept as design trade-off. Consider periodic referential integrity checks as a CLI command (e.g., `kernle doctor --check-refs`).
+
+#### F2: `source_entity` Column Missing from SQLite Schema — P2 (Medium)
+**Location**: `base.py` Episode/Belief/Note dataclasses define `source_entity`, but `sqlite.py` SCHEMA and `_row_to_*` converters never reference it.  
+**Impact**: `source_entity` data is silently dropped on save and always `None` on read. Any code setting `episode.source_entity = "user@example.com"` will lose that data.  
+**Recommendation**: Add `source_entity TEXT` column to episodes, beliefs, notes, and relationships tables. Add migration in `_migrate_schema()`.
+
+#### F3: `note_type` Index Missing — P3 (Low)
+**Location**: `sqlite.py` SCHEMA — `notes` table  
+**Issue**: Notes are filtered by `note_type` in `get_notes()`, but there's no index on `(agent_id, note_type)`.  
+**Impact**: Minor at typical scale (< 10K notes), but will cause full scans at scale.  
+**Recommendation**: Add `CREATE INDEX IF NOT EXISTS idx_notes_type ON notes(agent_id, note_type);`
+
+#### F4: `tags` Column Not Indexed — P2 (Medium)
+**Location**: All tables with `tags TEXT` (JSON array)  
+**Issue**: Tag filtering happens in Python after fetching all rows: `episodes = [e for e in episodes if e.tags and any(t in e.tags for t in tags)]`. No index can help with JSON array contains in SQLite.  
+**Impact**: Tag-based queries scan all rows then filter in Python. With O(N) episodes and O(T) tags, this is O(N×T). At 10K+ episodes, this becomes slow.  
+**Recommendation**: (a) Add an FTS5 index on tags JSON for keyword matching, or (b) create a separate `episode_tags` junction table for efficient lookups.
+
+---
+
+### 2. JSONB / JSON Fields
+
+#### F5: No GIN Index on `derived_from` / `source_episodes` (Postgres) — P1 (High)
+**Location**: `postgres.py` — Supabase schema (server-side)  
+**Issue**: Previous audit flagged this. `derived_from` and `source_episodes` are stored as JSONB arrays in Postgres but likely lack GIN indexes. Any query like "find all memories derived from episode X" requires full table scans with `@>` operator.  
+**Impact**: Lineage traversal and provenance queries will be O(N) per table at scale.  
+**Recommendation**: Add `CREATE INDEX idx_episodes_derived_from ON agent_episodes USING GIN (derived_from);` and similarly for all tables with these fields.
+
+#### F6: JSON Serialization/Deserialization is Consistent — P3 (Informational)
+**Location**: `sqlite.py` `_to_json()` / `_from_json()`  
+**Assessment**: The implementation correctly uses `json.dumps()` / `json.loads()` with proper null handling. `_from_json` catches `JSONDecodeError` and returns `None`. The Postgres backend relies on Supabase client to handle JSON natively (JSONB columns accept Python lists/dicts directly). **No JSON injection vector found** — all JSON fields are serialized through `json.dumps()`, not string concatenation.
+
+#### F7: `confidence_history` Unbounded Growth — P2 (Medium)
+**Location**: `base.py` — `confidence_history: Optional[List[Dict[str, Any]]]`  
+**Issue**: Every confidence change appends to the array. There is no max length or rotation policy. Over time, a frequently-updated belief could accumulate thousands of history entries.  
+**Impact**: (a) Increasingly large JSON blobs serialized/deserialized on every read. (b) Potential SQLite row size issues (though SQLite supports up to 1GB per row by default). (c) Sync payload bloat.  
+**Recommendation**: Cap `confidence_history` at ~100 entries with FIFO eviction. Apply on write in `update_memory_meta()`.
+
+#### F8: `steps` Field in Playbooks — No Validation — P2 (Medium)
+**Location**: `base.py` `Playbook.steps: List[Dict[str, Any]]`  
+**Issue**: The `steps` field accepts arbitrary dict structures with no schema validation. Malformed steps could cause runtime errors in playbook execution code.  
+**Impact**: Data quality issue. Steps with missing `action` keys or wrong types will fail at runtime, not at save time.  
+**Recommendation**: Add validation in `save_playbook()` to ensure each step has required keys.
+
+---
+
+### 3. Query Performance
+
+#### F9: Text Search Uses Unescaped LIKE Wildcards — P3 (Low)
+**Location**: `sqlite.py` `_text_search()` — `search_term = f"%{query}%"`  
+**Issue**: The search query is embedded in a LIKE pattern without escaping `%` and `_` characters. A search for `"100% correct"` would match unexpected rows.  
+**Contrast**: `search_raw_fts()` correctly uses `_escape_like_pattern()`, but `_text_search()` does not.  
+**Impact**: Incorrect search results. Not a security issue (parameterized queries prevent SQL injection), but a correctness issue.  
+**Recommendation**: Apply `_escape_like_pattern()` in `_text_search()` as well.
+
+#### F10: `get_forgetting_candidates()` Does N Table Scans — P2 (Medium)
+**Location**: `sqlite.py` line ~5100  
+**Issue**: Queries each of 7 tables with `LIMIT limit*2`, fetches all rows, computes salience in Python, then sorts. For 7 tables × 200 rows = 1,400 rows processed in Python per call.  
+**Impact**: Acceptable at current scale. At 100K+ memories across tables, this becomes expensive. The `ORDER BY created_at ASC` doesn't leverage an ideal index for this use case.  
+**Recommendation**: Add a composite index `(agent_id, is_protected, is_forgotten, created_at)` and consider pre-computing salience scores as a materialized column.
+
+#### F11: `load_all()` Opens Multiple Connections — P2 (Medium)
+**Location**: `sqlite.py` `load_all()` calls individual `get_*` methods, each opening a separate connection via `_connect()`.  
+**Issue**: 7+ separate connection open/close cycles per `load_all()` call.  
+**Impact**: Measurable overhead (~5-10ms per connection on macOS). The method exists specifically to batch queries but doesn't achieve batching.  
+**Recommendation**: Implement `load_all()` with a single `_connect()` context and inline queries, similar to how `get_stats()` uses a single connection.
+
+#### F12: Postgres Search is Brute-Force — P1 (High)
+**Location**: `postgres.py` `search()` method (line ~950)  
+**Issue**: Search fetches `limit * 5` rows per table type, iterates in Python, does case-insensitive string matching. This is O(N) across all records with no semantic understanding.  
+**Impact**: At scale (10K+ records), this will be very slow and return poor-quality results. The comment says "TODO: Use pgvector for semantic search."  
+**Recommendation**: Implement pgvector-based search. This is a significant feature gap that degrades the value of the Postgres backend.
+
+#### F13: Vector Search Doesn't Filter by `is_forgotten` — P2 (Medium)
+**Location**: `sqlite.py` `_vector_search()` and `_text_search()`  
+**Issue**: Queries filter `deleted = 0` but NOT `is_forgotten = 0`. Forgotten memories will appear in search results.  
+**Impact**: Users see tombstoned memories in search, contradicting the forgetting feature's intent.  
+**Recommendation**: Add `AND COALESCE(is_forgotten, 0) = 0` to all search queries.
+
+---
+
+### 4. Concurrency
+
+#### F14: Postgres `record_access()` Has Read-Then-Write Race — P1 (High)
+**Location**: `postgres.py` `record_access()` (line ~1640)  
+**Issue**: The method reads `times_accessed`, increments in Python, then writes back. Two concurrent calls can read the same value and both write `value + 1`, losing an increment.  
+**Impact**: The code even documents this: "Under high concurrency, some increments may be lost." For access tracking, approximate counts are acceptable — but the same pattern could be applied elsewhere.  
+**Recommendation**: Use Supabase RPC function with `SET times_accessed = times_accessed + 1` (atomic SQL increment). The relationship code already does this via `increment_interaction_count` RPC.
+
+#### F15: SQLite Concurrency — Connection-Per-Operation Pattern — P2 (Medium)
+**Location**: `sqlite.py` `_connect()` context manager  
+**Issue**: Each operation opens a new `sqlite3.connect()`. SQLite uses file-level locking — concurrent writes from multiple processes (e.g., CLI + MCP server) can cause `SQLITE_BUSY` errors. No WAL mode is explicitly set.  
+**Impact**: Under concurrent access (likely when both CLI and MCP server are running), writes may fail with "database is locked." Default journal mode is DELETE, which blocks readers during writes.  
+**Recommendation**: (a) Enable WAL mode: `PRAGMA journal_mode=WAL;` in `_init_db()`. (b) Set `PRAGMA busy_timeout=5000;` to auto-retry on lock contention. (c) Consider a connection pool for long-running processes.
+
+#### F16: `update_memory_meta()` Lacks Optimistic Locking — P2 (Medium)
+**Location**: `sqlite.py` `update_memory_meta()` (line ~4615)  
+**Issue**: Uses `version = version + 1` but doesn't check expected version. Unlike `update_episode_atomic()` and `update_belief_atomic()` which properly implement OCC, `update_memory_meta()` will silently overwrite concurrent changes.  
+**Impact**: Concurrent confidence updates could lose data. The version increment prevents sync conflicts but doesn't prevent local race conditions.  
+**Recommendation**: Add optional `expected_version` parameter matching the pattern in `update_episode_atomic()`.
+
+---
+
+### 5. Data Migration Safety
+
+#### F17: Schema Migrations Are Additive-Only — P3 (Low, Positive)
+**Location**: `sqlite.py` `_migrate_schema()`  
+**Assessment**: All migrations use `ALTER TABLE ... ADD COLUMN`. No destructive migrations (DROP COLUMN, type changes). This is safe — migrations cannot lose data. The raw blob migration (`UPDATE raw_entries SET blob = content`) preserves original data in both columns.
+
+#### F18: No Migration Rollback Mechanism — P2 (Medium)
+**Location**: `sqlite.py` `_migrate_schema()`  
+**Issue**: Failed migrations are caught and logged but the schema version is still bumped to `SCHEMA_VERSION`. There's no way to roll back a partially-applied migration.  
+**Impact**: A partial migration failure (e.g., disk full during ALTER TABLE) could leave the schema in an inconsistent state.  
+**Recommendation**: (a) Run migrations in a transaction. (b) Only bump schema version after all migrations succeed. (c) Consider backing up the DB before migration (`cp memories.db memories.db.pre-v12`).
+
+#### F19: `schema_version` Table Doesn't Track Individual Migrations — P3 (Low)
+**Location**: `sqlite.py` — single `version INTEGER PRIMARY KEY`  
+**Issue**: Only stores one version number. Can't determine which specific migrations have been applied if they were applied out of order or partially.  
+**Recommendation**: Consider a `migrations_applied` table with individual migration IDs and timestamps for more granular tracking.
+
+---
+
+### 6. Embedding Storage
+
+#### F20: Hash Embeddings Are Not Semantic — P2 (Medium)
+**Location**: `embeddings.py` `HashEmbedder`  
+**Issue**: The default embedder uses character n-gram hashing, not semantic embeddings. It's deterministic and fast but only captures lexical similarity (exact/near-exact matches).  
+**Impact**: "Find memories about dogs" won't match "I adopted a puppy" — no semantic understanding. The code comments acknowledge this: "Not semantically meaningful."  
+**Recommendation**: Prioritize integration testing with OpenAI embeddings to ensure the upgrade path works. Consider adding a local model option (e.g., sentence-transformers) for offline semantic search.
+
+#### F21: Embedding Dimension Change Requires Full Rebuild — P2 (Medium)
+**Location**: `sqlite.py` — `vec_embeddings` virtual table created with `FLOAT[{dim}]`  
+**Issue**: If the embedding dimension changes (e.g., switching from HashEmbedder's 384 to OpenAI's 1536), the virtual table schema is incompatible. There's no migration path — the old table must be dropped and rebuilt.  
+**Impact**: Switching embedding providers will silently fail or error on existing databases. No code handles this dimension mismatch.  
+**Recommendation**: Check embedding dimension on startup. If mismatched, rebuild the vector table and re-embed all records.
+
+#### F22: Embedding Not Saved for Drives, Relationships, Playbooks — P3 (Low)
+**Location**: `sqlite.py` — `_get_searchable_content()` and search methods  
+**Issue**: Only episodes, notes, beliefs, values, and goals generate embeddings. Drives, relationships, and playbooks are not embedded or searchable via vector search.  
+**Impact**: These record types won't appear in semantic search results.  
+**Recommendation**: Add searchable content extraction for drives (`drive_type: focus_areas`), relationships (`entity_name: notes`), and playbooks (`name: description, triggers`).
+
+---
+
+### 7. Memory Limits
+
+#### F23: No Size Limits on Text Fields — P2 (Medium)
+**Location**: All tables — `objective TEXT`, `content TEXT`, `blob TEXT`, `statement TEXT`  
+**Issue**: No `CHECK` constraints or application-level validation on field lengths. A raw entry's `blob` field is explicitly designed for "no length limits" brain dumps.  
+**Impact**: (a) A single massive memory (e.g., pasting an entire codebase) would inflate the DB, slow queries, and generate huge embeddings. (b) Embedding generation for very long texts may exceed token limits on OpenAI. (c) Sync payloads could become enormous.  
+**Recommendation**: Add soft limits with warnings: (a) Warn if a single text field exceeds 100KB. (b) Truncate text before embedding (first 8K chars). (c) Add a max blob size for raw entries in config.
+
+#### F24: `MAX_SYNC_ARRAY_SIZE` Only Enforced During Merge — P3 (Low)
+**Location**: `sqlite.py` `_merge_array_fields()` — `MAX_SYNC_ARRAY_SIZE = 500`  
+**Issue**: Array size is capped during sync merge, but not during normal writes. A single-backend operation could accumulate >500 items in `source_episodes` or `tags`.  
+**Impact**: Low — arrays this large are unlikely in normal use. But the inconsistency means sync could silently truncate user data.  
+**Recommendation**: Enforce consistent limits on array fields at write time too.
+
+---
+
+### 8. Postgres vs SQLite Parity
+
+#### F25: Postgres Missing Features — P1 (High)
+**Location**: `postgres.py` — documented in file header  
+
+| Feature | SQLite | Postgres |
+|---------|--------|----------|
+| Raw entries | ✅ Full | ❌ `NotImplementedError` |
+| Memory suggestions | ✅ Full | ❌ Not implemented |
+| FTS5 keyword search | ✅ Full | ❌ Not implemented |
+| Semantic vector search | ✅ sqlite-vec | ❌ TODO comment only |
+| Batch operations | ✅ Single txn | ❌ N+1 individual calls |
+| Sync queue | ✅ Full | ❌ No-op |
+| Health check tracking | ✅ Full | ❌ Not implemented |
+| Flat file sync | ✅ Full | ❌ Not implemented |
+| Optimistic locking | ✅ `update_*_atomic()` | ❌ Not implemented |
+
+**Impact**: Users switching from SQLite to Postgres will lose significant functionality. The Postgres backend is not a drop-in replacement.  
+**Recommendation**: Either (a) clearly document Postgres as a sync-only backend, not a primary backend, or (b) implement the missing features.
+
+#### F26: Column Name Mismatches Between Backends — P1 (High)
+**Location**: `postgres.py` header documentation  
+**Issue**: Fundamental schema differences between backends:
+- Episodes: `outcome` (SQLite) vs `outcome_description` (Postgres)
+- Notes: `agent_id` (SQLite) vs `owner_id` (Postgres), stored in `notes` vs `memories` table
+- Relationships: `entity_name` (SQLite) vs `other_agent_id` (Postgres), `sentiment` vs `trust_level`
+- Drives: `updated_at` (SQLite) vs `last_satisfied_at` (Postgres)
+
+**Impact**: Sync between backends requires field-level mapping that's fragile and error-prone. Adding new fields requires updating mapping code in two places. Data that exists in one schema but not the other (e.g., `source_entity` in SQLite, if added) may be lost during sync.  
+**Recommendation**: Create a schema migration plan to align column names, or formalize the mapping layer as a tested abstraction.
+
+#### F27: Postgres `save_belief()` Drops Fields — P1 (High)
+**Location**: `postgres.py` `save_belief()` (line ~380)  
+**Issue**: Only saves `id, agent_id, statement, belief_type, confidence, is_active, is_foundational, local_updated_at, cloud_synced_at, version`. Missing: `source_type`, `source_episodes`, `derived_from`, `last_verified`, `verification_count`, `confidence_history`, `supersedes`, `superseded_by`, `times_reinforced`, `context`, `context_tags`, ALL forgetting fields.  
+**Impact**: **Data loss.** Saving a belief to Postgres then reading it back will have `None` for all meta-memory and forgetting fields. A round-trip through sync will strip this metadata.  
+**Recommendation**: Add ALL fields to Postgres save methods. This same pattern likely affects `save_value()`, `save_goal()`, and `save_drive()` — each only saves a subset of fields.
+
+#### F28: Postgres `save_episode()` Hardcodes `confidence: 0.8` — P2 (Medium)
+**Location**: `postgres.py` `save_episode()` (line ~170)  
+**Issue**: `"confidence": 0.8` is hardcoded instead of using `episode.confidence`. Also missing: `source_entity`, `source_type`, `source_episodes`, `derived_from`, `last_verified`, `verification_count`, `confidence_history`, all forgetting fields, context fields.  
+**Impact**: Same as F27 — data loss on save.  
+**Recommendation**: Use `episode.confidence` and add all missing fields.
+
+---
+
+## Summary by Priority
+
+| Priority | Count | Findings |
+|----------|-------|----------|
+| **P0** (Critical) | 0 | — |
+| **P1** (High) | 5 | F5 (GIN indexes), F12 (Postgres search), F14 (race condition), F25 (feature parity), F26 (column mismatches), F27 (data loss on save) |
+| **P2** (Medium) | 12 | F2 (source_entity), F4 (tags index), F7 (unbounded history), F8 (steps validation), F10 (forgetting scans), F11 (load_all connections), F13 (forgotten in search), F15 (SQLite WAL), F16 (meta update locking), F18 (migration rollback), F20 (hash embeddings), F21 (dimension change), F23 (text size limits), F28 (hardcoded confidence) |
+| **P3** (Low) | 6 | F1 (no FKs), F3 (note_type index), F6 (JSON OK), F9 (LIKE escaping), F17 (safe migrations), F19 (migration tracking), F22 (missing embeddings), F24 (array limits) |
+
+---
+
+## Recommended Priority Actions
+
+### Immediate (P1)
+1. **F27/F28**: Fix Postgres save methods to include ALL fields from dataclasses. This is actively losing data.
+2. **F15**: Add `PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000;` to SQLite init — simple 2-line fix that prevents lock errors.
+3. **F5**: Add GIN indexes on `derived_from` and `source_episodes` JSONB columns in Postgres.
+4. **F14**: Replace read-then-write with atomic SQL increment in Postgres `record_access()`.
+
+### Near-Term (P2)
+5. **F2**: Add `source_entity` column to SQLite schema + migration.
+6. **F13**: Add `is_forgotten = 0` filter to search queries.
+7. **F7**: Cap `confidence_history` at 100 entries.
+8. **F21**: Add dimension check + rebuild logic for embedding table.
+9. **F11**: Implement single-connection `load_all()`.
+
+### Backlog (P3)
+10. Add `note_type` composite index.
+11. Consider junction tables for tags.
+12. Add migration tracking table.

--- a/kernle/mcp/server.py
+++ b/kernle/mcp/server.py
@@ -229,6 +229,12 @@ def validate_tool_input(name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
             sanitized["context_tags"] = (
                 sanitize_array(arguments.get("context_tags"), "context_tags", 100, 20) or None
             )
+            sanitized["source"] = sanitize_string(
+                arguments.get("source"), "source", 500, required=False
+            )
+            sanitized["derived_from"] = sanitize_array(
+                arguments.get("derived_from"), "derived_from", 200, 20
+            )
 
         elif name == "memory_note":
             sanitized["content"] = sanitize_string(
@@ -249,6 +255,12 @@ def validate_tool_input(name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
             )
             sanitized["context_tags"] = (
                 sanitize_array(arguments.get("context_tags"), "context_tags", 100, 20) or None
+            )
+            sanitized["source"] = sanitize_string(
+                arguments.get("source"), "source", 500, required=False
+            )
+            sanitized["derived_from"] = sanitize_array(
+                arguments.get("derived_from"), "derived_from", 200, 20
             )
 
         elif name == "memory_search":
@@ -275,6 +287,12 @@ def validate_tool_input(name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
             )
             sanitized["context_tags"] = (
                 sanitize_array(arguments.get("context_tags"), "context_tags", 100, 20) or None
+            )
+            sanitized["source"] = sanitize_string(
+                arguments.get("source"), "source", 500, required=False
+            )
+            sanitized["derived_from"] = sanitize_array(
+                arguments.get("derived_from"), "derived_from", 200, 20
             )
 
         elif name == "memory_value":


### PR DESCRIPTION
## Audit-Driven Hardening

Full Kernle codebase audit found **79 findings** (6 P0, 17 P1, 32 P2, 24 P3). This PR addresses the highest-impact fixes:

### Fixes

| # | Finding | Severity | Fix |
|---|---------|----------|-----|
| 1 | SQLite not in WAL mode | P1 | `PRAGMA journal_mode=WAL; busy_timeout=5000` on every connection |
| 2 | MCP drops provenance params | P1 | Added `source`/`derived_from` to `validate_tool_input()` for episode/note/belief |
| 3 | Forgetting can tombstone foundational beliefs | P1 | Exclude `is_foundational=1` from forgetting candidates |
| 4 | Unbounded confidence_history growth | P2 | Cap at 100 entries (FIFO eviction) |
| 5 | `source_entity` column missing from SQLite | P2 | Schema v13: add column to all 7 tables + wire into save/read |
| 6 | Forgotten memories appear in search | P2 | Add `is_forgotten=0` filter to `_fetch_record` + all text search queries |
| 7 | Missing `validate_table_name()` | P2 | Defense-in-depth in `update_memory_meta()` |

### Audit Reports
Full reports included in `audit/` directory:
- `SUMMARY.md` — consolidated findings
- `security-core.md` — SQL injection, access control, input validation
- `security-commerce.md` — wallet, escrow, spending limits
- `quality-features.md` — MCP, CLI, features, importers
- `storage-integrity.md` — schema, performance, concurrency

### Remaining P0s (commerce — all in stubbed pre-production code)
These are tracked but not fixed here since the commerce system is pre-production:
- Escrow state verification
- Spend rollback mechanism
- Wallet claim stub
- Key management infrastructure
- Receipt verification

All 1228 tests pass.