### PR TITLE
feat: USDC payment verification module

### DIFF
--- a/backend/app/payments/__init__.py
+++ b/backend/app/payments/__init__.py
@@ -1,0 +1,15 @@
+"""Payment verification for Kernle cloud subscriptions."""
+
+from .verification import (
+    verify_usdc_transfer,
+    TransferVerificationResult,
+    PaymentVerificationError,
+    CHAIN_CONFIG,
+)
+
+__all__ = [
+    "verify_usdc_transfer",
+    "TransferVerificationResult",
+    "PaymentVerificationError",
+    "CHAIN_CONFIG",
+]

--- a/backend/app/payments/verification.py
+++ b/backend/app/payments/verification.py
@@ -1,0 +1,387 @@
+"""USDC payment verification on EVM chains (Base, Ethereum, etc).
+
+Verifies that a USDC transfer actually occurred on-chain by:
+1. Fetching the transaction receipt via JSON-RPC
+2. Parsing ERC20 Transfer event logs
+3. Validating amount, sender, and recipient
+"""
+
+import httpx
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# ERC20 Transfer event signature: Transfer(address indexed from, address indexed to, uint256 value)
+TRANSFER_EVENT_SIGNATURE = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+
+# Chain configurations
+CHAIN_CONFIG = {
+    "base": {
+        "rpc_url": "https://mainnet.base.org",
+        "usdc_address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        "usdc_decimals": 6,
+        "chain_id": 8453,
+        "explorer": "https://basescan.org",
+    },
+    "base_sepolia": {
+        "rpc_url": "https://sepolia.base.org", 
+        "usdc_address": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",  # Circle's testnet USDC
+        "usdc_decimals": 6,
+        "chain_id": 84532,
+        "explorer": "https://sepolia.basescan.org",
+    },
+    "ethereum": {
+        "rpc_url": "https://eth.llamarpc.com",
+        "usdc_address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        "usdc_decimals": 6,
+        "chain_id": 1,
+        "explorer": "https://etherscan.io",
+    },
+}
+
+
+class PaymentVerificationError(Exception):
+    """Raised when payment verification fails."""
+    pass
+
+
+@dataclass
+class TransferVerificationResult:
+    """Result of verifying a USDC transfer."""
+    
+    success: bool
+    tx_hash: str
+    chain: str
+    
+    # Transfer details (populated if success=True)
+    from_address: Optional[str] = None
+    to_address: Optional[str] = None
+    amount: Optional[Decimal] = None  # Human-readable (e.g., 5.00 for $5 USDC)
+    amount_raw: Optional[int] = None  # Raw units (e.g., 5000000 for $5 USDC)
+    
+    # Block info
+    block_number: Optional[int] = None
+    block_timestamp: Optional[datetime] = None
+    confirmations: Optional[int] = None
+    
+    # Error info (populated if success=False)
+    error: Optional[str] = None
+    error_code: Optional[str] = None
+    
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "success": self.success,
+            "tx_hash": self.tx_hash,
+            "chain": self.chain,
+            "from_address": self.from_address,
+            "to_address": self.to_address,
+            "amount": str(self.amount) if self.amount else None,
+            "amount_raw": self.amount_raw,
+            "block_number": self.block_number,
+            "block_timestamp": self.block_timestamp.isoformat() if self.block_timestamp else None,
+            "confirmations": self.confirmations,
+            "error": self.error,
+            "error_code": self.error_code,
+        }
+
+
+async def _rpc_call(rpc_url: str, method: str, params: list, timeout: float = 30.0) -> dict:
+    """Make a JSON-RPC call to an EVM node."""
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        response = await client.post(
+            rpc_url,
+            json={
+                "jsonrpc": "2.0",
+                "method": method,
+                "params": params,
+                "id": 1,
+            },
+            headers={"Content-Type": "application/json"},
+        )
+        response.raise_for_status()
+        result = response.json()
+        
+        if "error" in result:
+            raise PaymentVerificationError(f"RPC error: {result['error']}")
+        
+        return result.get("result")
+
+
+def _normalize_address(address: str) -> str:
+    """Normalize an Ethereum address to lowercase with 0x prefix."""
+    if not address:
+        return ""
+    address = address.lower()
+    if not address.startswith("0x"):
+        address = "0x" + address
+    # Pad to 42 characters if needed (0x + 40 hex chars)
+    if len(address) == 66:  # 32-byte padded address from event log
+        address = "0x" + address[-40:]
+    return address
+
+
+def _parse_transfer_log(log: dict, usdc_decimals: int) -> Optional[dict]:
+    """Parse an ERC20 Transfer event log.
+    
+    Transfer event: Transfer(address indexed from, address indexed to, uint256 value)
+    - topics[0]: event signature
+    - topics[1]: from address (indexed, padded to 32 bytes)
+    - topics[2]: to address (indexed, padded to 32 bytes)
+    - data: value (uint256)
+    """
+    topics = log.get("topics", [])
+    
+    if len(topics) < 3:
+        return None
+    
+    # Verify this is a Transfer event
+    if topics[0].lower() != TRANSFER_EVENT_SIGNATURE.lower():
+        return None
+    
+    from_address = _normalize_address(topics[1])
+    to_address = _normalize_address(topics[2])
+    
+    # Parse the value from data field
+    data = log.get("data", "0x0")
+    amount_raw = int(data, 16)
+    amount = Decimal(amount_raw) / Decimal(10 ** usdc_decimals)
+    
+    return {
+        "from_address": from_address,
+        "to_address": to_address,
+        "amount": amount,
+        "amount_raw": amount_raw,
+    }
+
+
+async def verify_usdc_transfer(
+    tx_hash: str,
+    expected_amount: Optional[Decimal] = None,
+    expected_from: Optional[str] = None,
+    expected_to: Optional[str] = None,
+    chain: str = "base",
+    min_confirmations: int = 1,
+    tolerance: Decimal = Decimal("0.01"),  # Allow 1 cent tolerance for rounding
+) -> TransferVerificationResult:
+    """Verify a USDC transfer on-chain.
+    
+    Args:
+        tx_hash: Transaction hash to verify
+        expected_amount: Expected USDC amount (human-readable, e.g., 5.00 for $5)
+        expected_from: Expected sender address
+        expected_to: Expected recipient address  
+        chain: Chain to verify on ("base", "base_sepolia", "ethereum")
+        min_confirmations: Minimum confirmations required
+        tolerance: Amount tolerance for matching (default 1 cent)
+    
+    Returns:
+        TransferVerificationResult with success status and transfer details
+    
+    Raises:
+        PaymentVerificationError: If RPC calls fail
+    """
+    if chain not in CHAIN_CONFIG:
+        return TransferVerificationResult(
+            success=False,
+            tx_hash=tx_hash,
+            chain=chain,
+            error=f"Unknown chain: {chain}",
+            error_code="UNKNOWN_CHAIN",
+        )
+    
+    config = CHAIN_CONFIG[chain]
+    rpc_url = config["rpc_url"]
+    usdc_address = _normalize_address(config["usdc_address"])
+    usdc_decimals = config["usdc_decimals"]
+    
+    # Normalize inputs
+    tx_hash = tx_hash.lower() if tx_hash.startswith("0x") else "0x" + tx_hash.lower()
+    if expected_from:
+        expected_from = _normalize_address(expected_from)
+    if expected_to:
+        expected_to = _normalize_address(expected_to)
+    
+    try:
+        # Get transaction receipt
+        receipt = await _rpc_call(rpc_url, "eth_getTransactionReceipt", [tx_hash])
+        
+        if not receipt:
+            return TransferVerificationResult(
+                success=False,
+                tx_hash=tx_hash,
+                chain=chain,
+                error="Transaction not found or not yet mined",
+                error_code="TX_NOT_FOUND",
+            )
+        
+        # Check transaction status (1 = success, 0 = reverted)
+        status = int(receipt.get("status", "0x0"), 16)
+        if status != 1:
+            return TransferVerificationResult(
+                success=False,
+                tx_hash=tx_hash,
+                chain=chain,
+                error="Transaction reverted",
+                error_code="TX_REVERTED",
+            )
+        
+        # Get block number and current block for confirmations
+        block_number = int(receipt.get("blockNumber", "0x0"), 16)
+        current_block = await _rpc_call(rpc_url, "eth_blockNumber", [])
+        current_block_num = int(current_block, 16)
+        confirmations = current_block_num - block_number
+        
+        if confirmations < min_confirmations:
+            return TransferVerificationResult(
+                success=False,
+                tx_hash=tx_hash,
+                chain=chain,
+                block_number=block_number,
+                confirmations=confirmations,
+                error=f"Insufficient confirmations: {confirmations} < {min_confirmations}",
+                error_code="INSUFFICIENT_CONFIRMATIONS",
+            )
+        
+        # Get block timestamp
+        block = await _rpc_call(rpc_url, "eth_getBlockByNumber", [hex(block_number), False])
+        block_timestamp = None
+        if block and "timestamp" in block:
+            timestamp_int = int(block["timestamp"], 16)
+            block_timestamp = datetime.fromtimestamp(timestamp_int, tz=timezone.utc)
+        
+        # Find USDC Transfer events in logs
+        logs = receipt.get("logs", [])
+        usdc_transfers = []
+        
+        for log in logs:
+            log_address = _normalize_address(log.get("address", ""))
+            if log_address != usdc_address:
+                continue
+            
+            transfer = _parse_transfer_log(log, usdc_decimals)
+            if transfer:
+                usdc_transfers.append(transfer)
+        
+        if not usdc_transfers:
+            return TransferVerificationResult(
+                success=False,
+                tx_hash=tx_hash,
+                chain=chain,
+                block_number=block_number,
+                block_timestamp=block_timestamp,
+                confirmations=confirmations,
+                error="No USDC transfer found in transaction",
+                error_code="NO_USDC_TRANSFER",
+            )
+        
+        # Find matching transfer
+        for transfer in usdc_transfers:
+            # Check from address
+            if expected_from and transfer["from_address"] != expected_from:
+                continue
+            
+            # Check to address
+            if expected_to and transfer["to_address"] != expected_to:
+                continue
+            
+            # Check amount (with tolerance)
+            if expected_amount is not None:
+                diff = abs(transfer["amount"] - expected_amount)
+                if diff > tolerance:
+                    continue
+            
+            # Found matching transfer!
+            return TransferVerificationResult(
+                success=True,
+                tx_hash=tx_hash,
+                chain=chain,
+                from_address=transfer["from_address"],
+                to_address=transfer["to_address"],
+                amount=transfer["amount"],
+                amount_raw=transfer["amount_raw"],
+                block_number=block_number,
+                block_timestamp=block_timestamp,
+                confirmations=confirmations,
+            )
+        
+        # No matching transfer found
+        # Return details of what we found for debugging
+        found_transfer = usdc_transfers[0] if usdc_transfers else None
+        error_details = []
+        if expected_from and found_transfer and found_transfer["from_address"] != expected_from:
+            error_details.append(f"from mismatch: expected {expected_from}, got {found_transfer['from_address']}")
+        if expected_to and found_transfer and found_transfer["to_address"] != expected_to:
+            error_details.append(f"to mismatch: expected {expected_to}, got {found_transfer['to_address']}")
+        if expected_amount and found_transfer:
+            error_details.append(f"amount: expected {expected_amount}, got {found_transfer['amount']}")
+        
+        return TransferVerificationResult(
+            success=False,
+            tx_hash=tx_hash,
+            chain=chain,
+            from_address=found_transfer["from_address"] if found_transfer else None,
+            to_address=found_transfer["to_address"] if found_transfer else None,
+            amount=found_transfer["amount"] if found_transfer else None,
+            amount_raw=found_transfer["amount_raw"] if found_transfer else None,
+            block_number=block_number,
+            block_timestamp=block_timestamp,
+            confirmations=confirmations,
+            error=f"Transfer found but doesn't match: {'; '.join(error_details)}",
+            error_code="TRANSFER_MISMATCH",
+        )
+        
+    except httpx.HTTPError as e:
+        logger.error(f"HTTP error verifying transfer {tx_hash}: {e}")
+        return TransferVerificationResult(
+            success=False,
+            tx_hash=tx_hash,
+            chain=chain,
+            error=f"Network error: {str(e)}",
+            error_code="NETWORK_ERROR",
+        )
+    except PaymentVerificationError as e:
+        logger.error(f"Verification error for {tx_hash}: {e}")
+        return TransferVerificationResult(
+            success=False,
+            tx_hash=tx_hash,
+            chain=chain,
+            error=str(e),
+            error_code="VERIFICATION_ERROR",
+        )
+    except Exception as e:
+        logger.exception(f"Unexpected error verifying transfer {tx_hash}")
+        return TransferVerificationResult(
+            success=False,
+            tx_hash=tx_hash,
+            chain=chain,
+            error=f"Unexpected error: {str(e)}",
+            error_code="UNEXPECTED_ERROR",
+        )
+
+
+# Synchronous wrapper for non-async contexts
+def verify_usdc_transfer_sync(
+    tx_hash: str,
+    expected_amount: Optional[Decimal] = None,
+    expected_from: Optional[str] = None,
+    expected_to: Optional[str] = None,
+    chain: str = "base",
+    min_confirmations: int = 1,
+    tolerance: Decimal = Decimal("0.01"),
+) -> TransferVerificationResult:
+    """Synchronous wrapper for verify_usdc_transfer."""
+    import asyncio
+    return asyncio.run(verify_usdc_transfer(
+        tx_hash=tx_hash,
+        expected_amount=expected_amount,
+        expected_from=expected_from,
+        expected_to=expected_to,
+        chain=chain,
+        min_confirmations=min_confirmations,
+        tolerance=tolerance,
+    ))

--- a/backend/tests/payments/__init__.py
+++ b/backend/tests/payments/__init__.py
@@ -1,0 +1,1 @@
+"""Payment verification tests."""

--- a/backend/tests/payments/test_verification.py
+++ b/backend/tests/payments/test_verification.py
@@ -1,0 +1,330 @@
+"""Tests for USDC payment verification."""
+
+import pytest
+from decimal import Decimal
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+from app.payments.verification import (
+    verify_usdc_transfer,
+    TransferVerificationResult,
+    PaymentVerificationError,
+    CHAIN_CONFIG,
+    _normalize_address,
+    _parse_transfer_log,
+    TRANSFER_EVENT_SIGNATURE,
+)
+
+
+class TestNormalizeAddress:
+    """Tests for address normalization."""
+    
+    def test_lowercase_with_prefix(self):
+        assert _normalize_address("0xAbC123") == "0xabc123"
+    
+    def test_adds_prefix(self):
+        assert _normalize_address("abc123") == "0xabc123"
+    
+    def test_handles_padded_address(self):
+        # 32-byte padded address (common in event logs)
+        padded = "0x000000000000000000000000833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+        assert _normalize_address(padded) == "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+    
+    def test_empty_string(self):
+        assert _normalize_address("") == ""
+    
+    def test_none(self):
+        assert _normalize_address(None) == ""
+
+
+class TestParseTransferLog:
+    """Tests for ERC20 Transfer event parsing."""
+    
+    def test_parse_valid_transfer(self):
+        log = {
+            "topics": [
+                TRANSFER_EVENT_SIGNATURE,
+                "0x000000000000000000000000sender0000000000000000000000000000000001",
+                "0x000000000000000000000000receiver00000000000000000000000000000002",
+            ],
+            "data": "0x00000000000000000000000000000000000000000000000000000000004c4b40",  # 5,000,000 = $5.00
+        }
+        
+        result = _parse_transfer_log(log, usdc_decimals=6)
+        
+        assert result is not None
+        assert result["amount"] == Decimal("5")
+        assert result["amount_raw"] == 5_000_000
+        assert "sender" in result["from_address"]
+        assert "receiver" in result["to_address"]
+    
+    def test_parse_wrong_event_signature(self):
+        log = {
+            "topics": [
+                "0xwrongsignature",
+                "0x000000000000000000000000sender0000000000000000000000000000000001",
+                "0x000000000000000000000000receiver00000000000000000000000000000002",
+            ],
+            "data": "0x00000000000000000000000000000000000000000000000000000000004c4b40",
+        }
+        
+        result = _parse_transfer_log(log, usdc_decimals=6)
+        assert result is None
+    
+    def test_parse_insufficient_topics(self):
+        log = {
+            "topics": [TRANSFER_EVENT_SIGNATURE],
+            "data": "0x00000000000000000000000000000000000000000000000000000000004c4b40",
+        }
+        
+        result = _parse_transfer_log(log, usdc_decimals=6)
+        assert result is None
+
+
+class TestChainConfig:
+    """Tests for chain configuration."""
+    
+    def test_base_config_exists(self):
+        assert "base" in CHAIN_CONFIG
+        config = CHAIN_CONFIG["base"]
+        assert "rpc_url" in config
+        assert "usdc_address" in config
+        assert config["usdc_decimals"] == 6
+    
+    def test_base_sepolia_config_exists(self):
+        assert "base_sepolia" in CHAIN_CONFIG
+        config = CHAIN_CONFIG["base_sepolia"]
+        assert "usdc_address" in config
+    
+    def test_ethereum_config_exists(self):
+        assert "ethereum" in CHAIN_CONFIG
+        config = CHAIN_CONFIG["ethereum"]
+        assert config["chain_id"] == 1
+
+
+class TestVerifyUsdcTransfer:
+    """Tests for the main verification function."""
+    
+    @pytest.mark.asyncio
+    async def test_unknown_chain(self):
+        result = await verify_usdc_transfer(
+            tx_hash="0x123",
+            chain="unknown_chain",
+        )
+        
+        assert result.success is False
+        assert result.error_code == "UNKNOWN_CHAIN"
+    
+    @pytest.mark.asyncio
+    async def test_tx_not_found(self):
+        with patch("app.payments.verification._rpc_call", new_callable=AsyncMock) as mock_rpc:
+            mock_rpc.return_value = None  # Transaction not found
+            
+            result = await verify_usdc_transfer(
+                tx_hash="0x123",
+                chain="base",
+            )
+            
+            assert result.success is False
+            assert result.error_code == "TX_NOT_FOUND"
+    
+    @pytest.mark.asyncio
+    async def test_tx_reverted(self):
+        with patch("app.payments.verification._rpc_call", new_callable=AsyncMock) as mock_rpc:
+            mock_rpc.return_value = {
+                "status": "0x0",  # Reverted
+                "blockNumber": "0x100",
+                "logs": [],
+            }
+            
+            result = await verify_usdc_transfer(
+                tx_hash="0x123",
+                chain="base",
+            )
+            
+            assert result.success is False
+            assert result.error_code == "TX_REVERTED"
+    
+    @pytest.mark.asyncio
+    async def test_insufficient_confirmations(self):
+        with patch("app.payments.verification._rpc_call", new_callable=AsyncMock) as mock_rpc:
+            # Return receipt, then current block
+            mock_rpc.side_effect = [
+                {
+                    "status": "0x1",
+                    "blockNumber": "0x100",  # 256
+                    "logs": [],
+                },
+                "0x100",  # Current block = same as tx block = 0 confirmations
+            ]
+            
+            result = await verify_usdc_transfer(
+                tx_hash="0x123",
+                chain="base",
+                min_confirmations=5,
+            )
+            
+            assert result.success is False
+            assert result.error_code == "INSUFFICIENT_CONFIRMATIONS"
+    
+    @pytest.mark.asyncio
+    async def test_no_usdc_transfer(self):
+        with patch("app.payments.verification._rpc_call", new_callable=AsyncMock) as mock_rpc:
+            mock_rpc.side_effect = [
+                {
+                    "status": "0x1",
+                    "blockNumber": "0x100",
+                    "logs": [],  # No logs
+                },
+                "0x110",  # 16 confirmations
+                {"timestamp": "0x65b5e800"},  # Some timestamp
+            ]
+            
+            result = await verify_usdc_transfer(
+                tx_hash="0x123",
+                chain="base",
+            )
+            
+            assert result.success is False
+            assert result.error_code == "NO_USDC_TRANSFER"
+    
+    @pytest.mark.asyncio
+    async def test_successful_verification(self):
+        usdc_address = CHAIN_CONFIG["base"]["usdc_address"]
+        
+        with patch("app.payments.verification._rpc_call", new_callable=AsyncMock) as mock_rpc:
+            mock_rpc.side_effect = [
+                {
+                    "status": "0x1",
+                    "blockNumber": "0x100",
+                    "logs": [
+                        {
+                            "address": usdc_address,
+                            "topics": [
+                                TRANSFER_EVENT_SIGNATURE,
+                                "0x000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                                "0x000000000000000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                            ],
+                            "data": "0x00000000000000000000000000000000000000000000000000000000004c4b40",  # $5.00
+                        }
+                    ],
+                },
+                "0x110",  # Current block
+                {"timestamp": "0x65b5e800"},  # Block timestamp
+            ]
+            
+            result = await verify_usdc_transfer(
+                tx_hash="0x123",
+                chain="base",
+            )
+            
+            assert result.success is True
+            assert result.amount == Decimal("5")
+            assert result.block_number == 256
+            assert result.confirmations == 16
+    
+    @pytest.mark.asyncio
+    async def test_amount_mismatch(self):
+        usdc_address = CHAIN_CONFIG["base"]["usdc_address"]
+        
+        with patch("app.payments.verification._rpc_call", new_callable=AsyncMock) as mock_rpc:
+            mock_rpc.side_effect = [
+                {
+                    "status": "0x1",
+                    "blockNumber": "0x100",
+                    "logs": [
+                        {
+                            "address": usdc_address,
+                            "topics": [
+                                TRANSFER_EVENT_SIGNATURE,
+                                "0x000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                                "0x000000000000000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                            ],
+                            "data": "0x00000000000000000000000000000000000000000000000000000000004c4b40",  # $5.00
+                        }
+                    ],
+                },
+                "0x110",
+                {"timestamp": "0x65b5e800"},
+            ]
+            
+            result = await verify_usdc_transfer(
+                tx_hash="0x123",
+                expected_amount=Decimal("10.00"),  # Expected $10, got $5
+                chain="base",
+            )
+            
+            assert result.success is False
+            assert result.error_code == "TRANSFER_MISMATCH"
+            assert "amount" in result.error.lower()
+    
+    @pytest.mark.asyncio
+    async def test_amount_within_tolerance(self):
+        usdc_address = CHAIN_CONFIG["base"]["usdc_address"]
+        
+        with patch("app.payments.verification._rpc_call", new_callable=AsyncMock) as mock_rpc:
+            mock_rpc.side_effect = [
+                {
+                    "status": "0x1",
+                    "blockNumber": "0x100",
+                    "logs": [
+                        {
+                            "address": usdc_address,
+                            "topics": [
+                                TRANSFER_EVENT_SIGNATURE,
+                                "0x000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                                "0x000000000000000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                            ],
+                            "data": "0x00000000000000000000000000000000000000000000000000000000004c4f48",  # $5.001 (within 1 cent)
+                        }
+                    ],
+                },
+                "0x110",
+                {"timestamp": "0x65b5e800"},
+            ]
+            
+            result = await verify_usdc_transfer(
+                tx_hash="0x123",
+                expected_amount=Decimal("5.00"),
+                chain="base",
+                tolerance=Decimal("0.01"),
+            )
+            
+            assert result.success is True
+
+
+class TestTransferVerificationResult:
+    """Tests for the result dataclass."""
+    
+    def test_to_dict_success(self):
+        result = TransferVerificationResult(
+            success=True,
+            tx_hash="0x123",
+            chain="base",
+            from_address="0xaaa",
+            to_address="0xbbb",
+            amount=Decimal("5.00"),
+            amount_raw=5_000_000,
+            block_number=100,
+            block_timestamp=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+            confirmations=10,
+        )
+        
+        d = result.to_dict()
+        assert d["success"] is True
+        assert d["amount"] == "5.00"
+        assert d["block_timestamp"] == "2026-01-01T12:00:00+00:00"
+    
+    def test_to_dict_failure(self):
+        result = TransferVerificationResult(
+            success=False,
+            tx_hash="0x123",
+            chain="base",
+            error="Something went wrong",
+            error_code="SOME_ERROR",
+        )
+        
+        d = result.to_dict()
+        assert d["success"] is False
+        assert d["error"] == "Something went wrong"
+        assert d["amount"] is None


### PR DESCRIPTION
## Summary

On-chain USDC payment verification for the subscription system. Verifies that transfers actually occurred on Base/Ethereum by parsing transaction receipts.

## Core Function

```python
from app.payments import verify_usdc_transfer
from decimal import Decimal

result = await verify_usdc_transfer(
    tx_hash="0x123...",
    expected_amount=Decimal("5.00"),
    expected_from="0xsender...",
    expected_to="0xkernle_treasury...",
    chain="base",
    min_confirmations=1,
)

if result.success:
    print(f"Verified: {result.amount} USDC at block {result.block_number}")
else:
    print(f"Failed: {result.error} ({result.error_code})")
```

## Features

- **Multi-chain**: Base (mainnet), Base Sepolia (testnet), Ethereum
- **ERC20 parsing**: Extracts Transfer events from tx logs
- **Validation**: Amount (with tolerance), sender, recipient
- **Confirmations**: Configurable minimum confirmation count
- **Error handling**: Structured error codes for each failure mode

## Error Codes

| Code | Meaning |
|------|---------|
| `TX_NOT_FOUND` | Transaction not mined yet |
| `TX_REVERTED` | Transaction failed |
| `INSUFFICIENT_CONFIRMATIONS` | Not enough block confirmations |
| `NO_USDC_TRANSFER` | No USDC transfer in tx |
| `TRANSFER_MISMATCH` | Transfer found but wrong amount/addresses |

## Tests

21 tests covering address normalization, event parsing, error cases, and successful verification.

## Integration

Ready to plug into Ash's subscription service — call `verify_usdc_transfer()` when a user submits a payment tx hash.

---
*Built to complement Ash's subscription service layer (PR coming)*