### PR TITLE
feat: cloud subscription system — self-service tiers, payments, CLI

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -21,6 +21,7 @@ from .routes import (
     maintenance_router,
     memories_router,
     skills_router,
+    subscriptions_router,
     sync_router,
     wallets_router,
 )
@@ -159,6 +160,7 @@ app.include_router(jobs_router, prefix="/api/v1")
 app.include_router(skills_router, prefix="/api/v1")
 app.include_router(escrow_router, prefix="/api/v1")
 app.include_router(maintenance_router, prefix="/api/v1")
+app.include_router(subscriptions_router, prefix="/api/v1")
 
 
 @app.get("/")

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -5,6 +5,7 @@ from .auth import router as auth_router
 from .commerce import escrow_router, jobs_router, maintenance_router, skills_router, wallets_router
 from .embeddings import router as embeddings_router
 from .memories import router as memories_router
+from .subscriptions import router as subscriptions_router
 from .sync import router as sync_router
 
 __all__ = [
@@ -18,4 +19,5 @@ __all__ = [
     "skills_router",
     "escrow_router",
     "maintenance_router",
+    "subscriptions_router",
 ]

--- a/backend/app/routes/subscriptions.py
+++ b/backend/app/routes/subscriptions.py
@@ -1,0 +1,559 @@
+"""Subscription management routes."""
+
+from datetime import datetime
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Query, Request, status
+from pydantic import BaseModel, Field
+
+from ..auth import CurrentAgent
+from ..database import Database
+from ..logging_config import get_logger
+from ..rate_limit import limiter
+
+logger = get_logger("kernle.subscriptions")
+
+router = APIRouter(tags=["subscriptions"])
+
+# ---------------------------------------------------------------------------
+# Pydantic models — request / response
+# ---------------------------------------------------------------------------
+
+VALID_TIERS = {"free", "core", "pro", "enterprise"}
+TIER_PRICES = {"free": "0", "core": "5.000000", "pro": "15.000000"}
+
+
+# -- Shared / nested models -------------------------------------------------
+
+class TierInfo(BaseModel):
+    """Current subscription tier details."""
+    tier: str
+    status: str  # active | grace_period | cancelled | expired
+    starts_at: datetime | None = None
+    renews_at: datetime | None = None
+    cancelled_at: datetime | None = None
+    auto_renew: bool = True
+    renewal_amount: str | None = None
+
+
+class UsageInfo(BaseModel):
+    """Current-period usage snapshot."""
+    period: str  # YYYY-MM
+    storage_used: int = 0
+    storage_limit: int = 0
+    sync_count: int = 0
+    last_sync: datetime | None = None
+    agents_used: int = 0
+    agents_limit: int = 0
+
+
+class PaymentInfo(BaseModel):
+    """Single payment record."""
+    id: str
+    amount: str
+    currency: str = "USDC"
+    tx_hash: str | None = None
+    from_address: str | None = None
+    to_address: str | None = None
+    chain: str = "base"
+    status: str  # pending | confirmed | failed | refunded
+    period_start: datetime | None = None
+    period_end: datetime | None = None
+    created_at: datetime | None = None
+    confirmed_at: datetime | None = None
+
+
+# -- Request models ----------------------------------------------------------
+
+class UpgradeRequest(BaseModel):
+    """Request to upgrade subscription tier."""
+    tier: str = Field(..., description="Target tier: core, pro, or enterprise")
+
+
+class DowngradeRequest(BaseModel):
+    """Request to downgrade subscription tier."""
+    tier: str = Field(..., description="Target tier to downgrade to")
+
+
+class PaymentConfirmRequest(BaseModel):
+    """Confirm an on-chain payment."""
+    payment_id: str = Field(..., description="Payment ID returned by /upgrade")
+    tx_hash: str = Field(..., description="On-chain transaction hash")
+
+
+# -- Response models ---------------------------------------------------------
+
+class SubscriptionStatusResponse(BaseModel):
+    """Full subscription status with usage."""
+    subscription: TierInfo
+    usage: UsageInfo
+
+
+class UpgradeResponse(BaseModel):
+    """Payment instructions returned after requesting an upgrade."""
+    payment_id: str
+    amount: str
+    currency: str = "USDC"
+    treasury_address: str
+    chain: str = "base"
+    tier: str
+    message: str
+
+
+class DowngradeResponse(BaseModel):
+    """Confirmation of a scheduled downgrade."""
+    current_tier: str
+    new_tier: str
+    effective_at: datetime
+    message: str
+
+
+class CancelResponse(BaseModel):
+    """Confirmation of cancellation."""
+    tier: str
+    status: str
+    cancelled_at: datetime
+    active_until: datetime
+    message: str
+
+
+class ReactivateResponse(BaseModel):
+    """Confirmation of reactivation."""
+    tier: str
+    status: str
+    auto_renew: bool
+    renews_at: datetime | None = None
+    message: str
+
+
+class PaymentHistoryResponse(BaseModel):
+    """Paginated payment history."""
+    payments: list[PaymentInfo]
+    total: int
+    page: int
+    per_page: int
+
+
+class PaymentConfirmResponse(BaseModel):
+    """Result of payment confirmation."""
+    payment_id: str
+    status: str  # confirmed | pending_verification | failed
+    tier: str | None = None
+    activated_at: datetime | None = None
+    message: str
+
+
+class UsageResponse(BaseModel):
+    """Current-period usage with quota info."""
+    usage: UsageInfo
+
+
+# ---------------------------------------------------------------------------
+# Service imports (lazy — the companion task creates these)
+# ---------------------------------------------------------------------------
+
+# These are imported inside each handler to allow the module to load even if
+# the service module is not yet present (companion task builds it).  In
+# production both will exist.
+
+def _svc():
+    """Lazy-import subscription service functions."""
+    from ..subscriptions import service as svc
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+# ── GET /api/v1/subscriptions/me ──────────────────────────────────────────
+
+@router.get("/subscriptions/me", response_model=SubscriptionStatusResponse)
+async def get_subscription_status(
+    auth: CurrentAgent,
+    db: Database,
+):
+    """
+    Get current subscription status and usage for the authenticated user.
+
+    Returns tier info, renewal dates, and current-period usage.
+    """
+    svc = _svc()
+
+    subscription = await svc.get_subscription(db, auth.user_id)
+    if not subscription:
+        # Every user implicitly has a free tier
+        subscription = {
+            "tier": "free",
+            "status": "active",
+            "starts_at": None,
+            "renews_at": None,
+            "cancelled_at": None,
+            "auto_renew": False,
+            "renewal_amount": None,
+        }
+
+    usage = await svc.get_current_usage(db, auth.user_id)
+    if not usage:
+        usage = {
+            "period": datetime.utcnow().strftime("%Y-%m"),
+            "storage_used": 0,
+            "storage_limit": 0,
+            "sync_count": 0,
+            "last_sync": None,
+            "agents_used": 0,
+            "agents_limit": 0,
+        }
+
+    return SubscriptionStatusResponse(
+        subscription=TierInfo(**subscription),
+        usage=UsageInfo(**usage),
+    )
+
+
+# ── POST /api/v1/subscriptions/upgrade ────────────────────────────────────
+
+@router.post("/subscriptions/upgrade", response_model=UpgradeResponse)
+@limiter.limit("5/minute")
+async def upgrade_subscription(
+    request: Request,
+    body: UpgradeRequest,
+    auth: CurrentAgent,
+    db: Database,
+):
+    """
+    Request a subscription upgrade.
+
+    Returns payment instructions (amount, treasury address, payment_id).
+    The client should make an on-chain USDC transfer and then call
+    POST /subscriptions/payments/confirm with the tx_hash.
+    """
+    target_tier = body.tier.lower()
+
+    if target_tier not in VALID_TIERS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid tier '{body.tier}'. Valid tiers: {', '.join(sorted(VALID_TIERS))}",
+        )
+
+    if target_tier == "free":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot upgrade to free tier. Use /downgrade instead.",
+        )
+
+    if target_tier == "enterprise":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Enterprise tier requires custom arrangement. Contact support.",
+        )
+
+    svc = _svc()
+
+    # Validate upgrade is allowed (e.g. not already on this tier or higher)
+    current_sub = await svc.get_subscription(db, auth.user_id)
+    current_tier = current_sub.get("tier", "free") if current_sub else "free"
+
+    tier_order = {"free": 0, "core": 1, "pro": 2, "enterprise": 3}
+    if tier_order.get(target_tier, 0) <= tier_order.get(current_tier, 0):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Cannot upgrade from '{current_tier}' to '{target_tier}'. "
+                   f"Current tier is equal or higher.",
+        )
+
+    # Create a pending payment record and return instructions
+    payment = await svc.create_upgrade_payment(db, auth.user_id, target_tier)
+    if not payment:
+        logger.error(f"Failed to create upgrade payment for user={auth.user_id} tier={target_tier}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to initiate upgrade. Please try again.",
+        )
+
+    logger.info(
+        f"Upgrade initiated: user={auth.user_id} "
+        f"{current_tier} -> {target_tier} payment_id={payment['payment_id']}"
+    )
+
+    return UpgradeResponse(
+        payment_id=payment["payment_id"],
+        amount=payment["amount"],
+        currency=payment.get("currency", "USDC"),
+        treasury_address=payment["treasury_address"],
+        chain=payment.get("chain", "base"),
+        tier=target_tier,
+        message=f"Send {payment['amount']} USDC to {payment['treasury_address']} on Base. "
+                f"Then confirm with POST /subscriptions/payments/confirm.",
+    )
+
+
+# ── POST /api/v1/subscriptions/downgrade ──────────────────────────────────
+
+@router.post("/subscriptions/downgrade", response_model=DowngradeResponse)
+@limiter.limit("5/minute")
+async def downgrade_subscription(
+    request: Request,
+    body: DowngradeRequest,
+    auth: CurrentAgent,
+    db: Database,
+):
+    """
+    Schedule a subscription downgrade (effective at end of current period).
+
+    The user keeps their current tier until the period ends.
+    """
+    target_tier = body.tier.lower()
+
+    if target_tier not in VALID_TIERS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid tier '{body.tier}'. Valid tiers: {', '.join(sorted(VALID_TIERS))}",
+        )
+
+    svc = _svc()
+
+    current_sub = await svc.get_subscription(db, auth.user_id)
+    current_tier = current_sub.get("tier", "free") if current_sub else "free"
+
+    tier_order = {"free": 0, "core": 1, "pro": 2, "enterprise": 3}
+    if tier_order.get(target_tier, 0) >= tier_order.get(current_tier, 0):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Cannot downgrade from '{current_tier}' to '{target_tier}'. "
+                   f"Target must be a lower tier.",
+        )
+
+    result = await svc.schedule_downgrade(db, auth.user_id, target_tier)
+    if not result:
+        logger.error(f"Failed to schedule downgrade for user={auth.user_id}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to schedule downgrade.",
+        )
+
+    logger.info(
+        f"Downgrade scheduled: user={auth.user_id} "
+        f"{current_tier} -> {target_tier} effective_at={result['effective_at']}"
+    )
+
+    return DowngradeResponse(
+        current_tier=current_tier,
+        new_tier=target_tier,
+        effective_at=result["effective_at"],
+        message=f"Downgrade to '{target_tier}' scheduled. "
+                f"Your current '{current_tier}' tier remains active until {result['effective_at']}.",
+    )
+
+
+# ── POST /api/v1/subscriptions/cancel ─────────────────────────────────────
+
+@router.post("/subscriptions/cancel", response_model=CancelResponse)
+@limiter.limit("5/minute")
+async def cancel_subscription(
+    request: Request,
+    auth: CurrentAgent,
+    db: Database,
+):
+    """
+    Cancel auto-renewal for the current subscription.
+
+    The subscription remains active until the end of the current billing period.
+    """
+    svc = _svc()
+
+    current_sub = await svc.get_subscription(db, auth.user_id)
+    if not current_sub or current_sub.get("tier") == "free":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No active paid subscription to cancel.",
+        )
+
+    if current_sub.get("status") == "cancelled":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Subscription is already cancelled.",
+        )
+
+    result = await svc.cancel_subscription(db, auth.user_id)
+    if not result:
+        logger.error(f"Failed to cancel subscription for user={auth.user_id}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to cancel subscription.",
+        )
+
+    logger.info(f"Subscription cancelled: user={auth.user_id} tier={current_sub['tier']}")
+
+    return CancelResponse(
+        tier=current_sub["tier"],
+        status="cancelled",
+        cancelled_at=result["cancelled_at"],
+        active_until=result["active_until"],
+        message=f"Auto-renewal cancelled. Your '{current_sub['tier']}' tier remains active "
+                f"until {result['active_until']}.",
+    )
+
+
+# ── POST /api/v1/subscriptions/reactivate ─────────────────────────────────
+
+@router.post("/subscriptions/reactivate", response_model=ReactivateResponse)
+@limiter.limit("5/minute")
+async def reactivate_subscription(
+    request: Request,
+    auth: CurrentAgent,
+    db: Database,
+):
+    """
+    Re-enable auto-renewal for a cancelled subscription.
+
+    Only works if the subscription has not yet expired.
+    """
+    svc = _svc()
+
+    current_sub = await svc.get_subscription(db, auth.user_id)
+    if not current_sub or current_sub.get("tier") == "free":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No paid subscription to reactivate.",
+        )
+
+    if current_sub.get("status") not in ("cancelled",):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Subscription status is '{current_sub.get('status')}' — "
+                   f"only cancelled subscriptions can be reactivated.",
+        )
+
+    result = await svc.reactivate_subscription(db, auth.user_id)
+    if not result:
+        logger.error(f"Failed to reactivate subscription for user={auth.user_id}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to reactivate subscription.",
+        )
+
+    logger.info(f"Subscription reactivated: user={auth.user_id} tier={current_sub['tier']}")
+
+    return ReactivateResponse(
+        tier=current_sub["tier"],
+        status="active",
+        auto_renew=True,
+        renews_at=result.get("renews_at"),
+        message=f"Auto-renewal re-enabled for '{current_sub['tier']}' tier.",
+    )
+
+
+# ── GET /api/v1/subscriptions/payments ─────────────────────────────────────
+
+@router.get("/subscriptions/payments", response_model=PaymentHistoryResponse)
+async def list_payments(
+    auth: CurrentAgent,
+    db: Database,
+    page: int = Query(1, ge=1, description="Page number"),
+    per_page: int = Query(20, ge=1, le=100, description="Items per page"),
+):
+    """
+    List payment history for the authenticated user.
+
+    Supports pagination via page/per_page query params.
+    """
+    svc = _svc()
+
+    result = await svc.list_payments(db, auth.user_id, page=page, per_page=per_page)
+
+    payments = [PaymentInfo(**p) for p in result.get("payments", [])]
+
+    return PaymentHistoryResponse(
+        payments=payments,
+        total=result.get("total", 0),
+        page=page,
+        per_page=per_page,
+    )
+
+
+# ── POST /api/v1/subscriptions/payments/confirm ───────────────────────────
+
+@router.post("/subscriptions/payments/confirm", response_model=PaymentConfirmResponse)
+@limiter.limit("10/minute")
+async def confirm_payment(
+    request: Request,
+    body: PaymentConfirmRequest,
+    auth: CurrentAgent,
+    db: Database,
+):
+    """
+    Confirm an on-chain USDC payment by providing the transaction hash.
+
+    The server verifies the transaction on-chain (or marks it for async
+    verification) and activates the tier upgrade upon confirmation.
+    """
+    svc = _svc()
+
+    # Verify the payment belongs to this user
+    payment = await svc.get_payment(db, body.payment_id, auth.user_id)
+    if not payment:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Payment not found or does not belong to this account.",
+        )
+
+    if payment.get("status") == "confirmed":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Payment has already been confirmed.",
+        )
+
+    # Attempt on-chain verification and tier activation
+    result = await svc.confirm_payment(db, body.payment_id, body.tx_hash, auth.user_id)
+    if not result:
+        logger.error(
+            f"Payment confirmation failed: user={auth.user_id} "
+            f"payment_id={body.payment_id} tx_hash={body.tx_hash}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to confirm payment. Please try again or contact support.",
+        )
+
+    logger.info(
+        f"Payment confirmed: user={auth.user_id} payment_id={body.payment_id} "
+        f"tx_hash={body.tx_hash} status={result['status']}"
+    )
+
+    return PaymentConfirmResponse(
+        payment_id=body.payment_id,
+        status=result["status"],
+        tier=result.get("tier"),
+        activated_at=result.get("activated_at"),
+        message=result.get("message", "Payment processed."),
+    )
+
+
+# ── GET /api/v1/usage/me ──────────────────────────────────────────────────
+
+@router.get("/usage/me", response_model=UsageResponse)
+async def get_usage(
+    auth: CurrentAgent,
+    db: Database,
+):
+    """
+    Get current-period usage with quota info for the authenticated user.
+
+    Returns storage used/limit, sync count, active agents count/limit.
+    """
+    svc = _svc()
+
+    usage = await svc.get_current_usage(db, auth.user_id)
+    if not usage:
+        usage = {
+            "period": datetime.utcnow().strftime("%Y-%m"),
+            "storage_used": 0,
+            "storage_limit": 0,
+            "sync_count": 0,
+            "last_sync": None,
+            "agents_used": 0,
+            "agents_limit": 0,
+        }
+
+    return UsageResponse(usage=UsageInfo(**usage))

--- a/backend/app/subscriptions/__init__.py
+++ b/backend/app/subscriptions/__init__.py
@@ -1,0 +1,50 @@
+"""Subscription management for Kernle cloud sync."""
+
+from .models import (
+    SubscriptionTier,
+    SubscriptionStatus,
+    PaymentStatus,
+    TierConfig,
+    TIER_CONFIGS,
+    Subscription,
+    SubscriptionPayment,
+    UsageRecord,
+    QuotaCheckResult,
+    UpgradeRequest,
+    UpgradeResponse,
+    DowngradeRequest,
+    DowngradeResponse,
+    CancelRequest,
+    CancelResponse,
+    SubscriptionStatusResponse,
+    UsageResponse,
+    PaymentInfo,
+)
+from .service import SubscriptionService
+
+__all__ = [
+    # Enums
+    "SubscriptionTier",
+    "SubscriptionStatus",
+    "PaymentStatus",
+    # Config
+    "TierConfig",
+    "TIER_CONFIGS",
+    # Models
+    "Subscription",
+    "SubscriptionPayment",
+    "UsageRecord",
+    "QuotaCheckResult",
+    # API models
+    "UpgradeRequest",
+    "UpgradeResponse",
+    "DowngradeRequest",
+    "DowngradeResponse",
+    "CancelRequest",
+    "CancelResponse",
+    "SubscriptionStatusResponse",
+    "UsageResponse",
+    "PaymentInfo",
+    # Service
+    "SubscriptionService",
+]

--- a/backend/app/subscriptions/models.py
+++ b/backend/app/subscriptions/models.py
@@ -1,0 +1,280 @@
+"""Pydantic models for the Kernle subscription system.
+
+All monetary values use Decimal — never float — for precision.
+Quotas apply only to storage and stack count, never sync frequency.
+"""
+
+from datetime import datetime
+from decimal import Decimal
+from enum import Enum
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+# =============================================================================
+# Enums
+# =============================================================================
+
+
+class SubscriptionTier(str, Enum):
+    """Available subscription tiers."""
+
+    free = "free"
+    core = "core"
+    pro = "pro"
+    enterprise = "enterprise"
+
+
+class SubscriptionStatus(str, Enum):
+    """Subscription lifecycle states."""
+
+    active = "active"
+    grace_period = "grace_period"
+    cancelled = "cancelled"
+    expired = "expired"
+
+
+class PaymentStatus(str, Enum):
+    """On-chain payment verification states."""
+
+    pending = "pending"
+    confirmed = "confirmed"
+    failed = "failed"
+    refunded = "refunded"
+
+
+# =============================================================================
+# Tier Configuration
+# =============================================================================
+
+
+class OverflowPricing(BaseModel):
+    """Per-unit overflow pricing beyond tier limits."""
+
+    per_stack_usdc: Decimal = Decimal("0")
+    per_gb_usdc: Decimal = Decimal("0")
+
+
+class TierConfig(BaseModel):
+    """Static configuration for a subscription tier."""
+
+    tier: SubscriptionTier
+    price_usdc: Decimal
+    storage_limit_bytes: int
+    stack_limit: int
+    overflow: OverflowPricing | None = None
+    is_custom: bool = False  # True for enterprise
+
+    class Config:
+        frozen = True
+
+
+# Canonical tier definitions — single source of truth
+TIER_CONFIGS: dict[SubscriptionTier, TierConfig] = {
+    SubscriptionTier.free: TierConfig(
+        tier=SubscriptionTier.free,
+        price_usdc=Decimal("0"),
+        storage_limit_bytes=10 * 1024 * 1024,  # 10 MB
+        stack_limit=1,
+    ),
+    SubscriptionTier.core: TierConfig(
+        tier=SubscriptionTier.core,
+        price_usdc=Decimal("5"),
+        storage_limit_bytes=100 * 1024 * 1024,  # 100 MB
+        stack_limit=3,
+        overflow=OverflowPricing(
+            per_stack_usdc=Decimal("1.50"),
+            per_gb_usdc=Decimal("0.50"),
+        ),
+    ),
+    SubscriptionTier.pro: TierConfig(
+        tier=SubscriptionTier.pro,
+        price_usdc=Decimal("15"),
+        storage_limit_bytes=1 * 1024 * 1024 * 1024,  # 1 GB
+        stack_limit=10,
+        overflow=OverflowPricing(
+            per_stack_usdc=Decimal("1.00"),
+            per_gb_usdc=Decimal("0.50"),
+        ),
+    ),
+    SubscriptionTier.enterprise: TierConfig(
+        tier=SubscriptionTier.enterprise,
+        price_usdc=Decimal("0"),  # Custom pricing
+        storage_limit_bytes=0,  # Unlimited (enforced differently)
+        stack_limit=0,  # Unlimited
+        is_custom=True,
+    ),
+}
+
+
+def get_tier_config(tier: SubscriptionTier) -> TierConfig:
+    """Look up the config for a tier. Raises KeyError for unknown tiers."""
+    return TIER_CONFIGS[tier]
+
+
+# Tier ordering for upgrade / downgrade validation
+_TIER_ORDER: dict[SubscriptionTier, int] = {
+    SubscriptionTier.free: 0,
+    SubscriptionTier.core: 1,
+    SubscriptionTier.pro: 2,
+    SubscriptionTier.enterprise: 3,
+}
+
+
+def is_upgrade(current: SubscriptionTier, target: SubscriptionTier) -> bool:
+    """Return True if moving from *current* to *target* is an upgrade."""
+    return _TIER_ORDER[target] > _TIER_ORDER[current]
+
+
+def is_downgrade(current: SubscriptionTier, target: SubscriptionTier) -> bool:
+    """Return True if moving from *current* to *target* is a downgrade."""
+    return _TIER_ORDER[target] < _TIER_ORDER[current]
+
+
+# =============================================================================
+# Database / Domain Models
+# =============================================================================
+
+
+class Subscription(BaseModel):
+    """A user's subscription record (mirrors the subscriptions table)."""
+
+    id: str
+    user_id: str
+    tier: SubscriptionTier
+    status: SubscriptionStatus = SubscriptionStatus.active
+    starts_at: datetime
+    renews_at: datetime | None = None
+    cancelled_at: datetime | None = None
+    auto_renew: bool = True
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+class SubscriptionPayment(BaseModel):
+    """Record of a single payment (mirrors subscription_payments table)."""
+
+    id: str
+    subscription_id: str
+    amount: Decimal
+    currency: str = "USDC"
+    tx_hash: str
+    from_address: str
+    to_address: str
+    chain: str = "base"
+    status: PaymentStatus = PaymentStatus.pending
+    period_start: datetime
+    period_end: datetime
+    created_at: datetime | None = None
+    confirmed_at: datetime | None = None
+
+
+class UsageRecord(BaseModel):
+    """Current-period usage for a user (mirrors usage_records table).
+
+    Note: sync_count is tracked for analytics only — there are NO
+    sync frequency limits on any tier.
+    """
+
+    user_id: str
+    period: str  # "YYYY-MM"
+    storage_bytes: int = 0
+    sync_count: int = 0
+    stacks_syncing: int = 0
+    updated_at: datetime | None = None
+
+
+# =============================================================================
+# Quota Check
+# =============================================================================
+
+
+class QuotaCheckResult(BaseModel):
+    """Result of a quota check against the user's tier."""
+
+    allowed: bool
+    reason: str | None = None
+    tier: SubscriptionTier
+    storage_used: int = 0
+    storage_limit: int = 0
+    stacks_used: int = 0
+    stacks_limit: int = 0
+
+
+# =============================================================================
+# API Request / Response Models
+# =============================================================================
+
+
+class PaymentInfo(BaseModel):
+    """Payment details returned after an upgrade or recorded payment."""
+
+    amount: Decimal
+    currency: str = "USDC"
+    to_address: str
+    chain: str = "base"
+    tx_hash: str | None = None
+    status: PaymentStatus = PaymentStatus.pending
+
+
+class UpgradeRequest(BaseModel):
+    """Request to upgrade subscription tier."""
+
+    tier: SubscriptionTier
+
+
+class UpgradeResponse(BaseModel):
+    """Response after requesting an upgrade."""
+
+    subscription: Subscription
+    payment: PaymentInfo
+    message: str
+
+
+class DowngradeRequest(BaseModel):
+    """Request to downgrade subscription tier."""
+
+    tier: SubscriptionTier
+
+
+class DowngradeResponse(BaseModel):
+    """Response after requesting a downgrade (effective next billing period)."""
+
+    subscription: Subscription
+    effective_at: datetime
+    message: str
+
+
+class CancelRequest(BaseModel):
+    """Request to cancel auto-renewal."""
+
+    reason: str | None = None
+
+
+class CancelResponse(BaseModel):
+    """Response after cancellation request."""
+
+    subscription: Subscription
+    message: str
+
+
+class SubscriptionStatusResponse(BaseModel):
+    """Full subscription status including usage and renewal info."""
+
+    subscription: Subscription
+    tier_config: TierConfig
+    usage: UsageRecord
+    renewal_amount: Decimal | None = None
+    can_renew: bool | None = None
+
+
+class UsageResponse(BaseModel):
+    """Current period usage details."""
+
+    period: str
+    storage_bytes: int
+    storage_limit_bytes: int
+    sync_count: int
+    stacks_syncing: int
+    stacks_limit: int

--- a/backend/app/subscriptions/service.py
+++ b/backend/app/subscriptions/service.py
@@ -1,0 +1,803 @@
+"""Subscription service — business logic for tier management, payments, and quotas.
+
+All monetary values use Decimal. Sync frequency is never limited.
+On-chain payment verification is a separate concern; this service
+accepts tx_hash and marks payment records but does not verify on-chain.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Literal
+
+from supabase import Client
+
+from .models import (
+    TIER_CONFIGS,
+    OverflowPricing,
+    PaymentInfo,
+    PaymentStatus,
+    QuotaCheckResult,
+    Subscription,
+    SubscriptionPayment,
+    SubscriptionStatus,
+    SubscriptionTier,
+    TierConfig,
+    UsageRecord,
+    get_tier_config,
+    is_downgrade,
+    is_upgrade,
+)
+
+logger = logging.getLogger("kernle.subscriptions")
+
+# =============================================================================
+# Table names (keep in sync with SQL migrations)
+# =============================================================================
+
+SUBSCRIPTIONS_TABLE = "subscriptions"
+SUBSCRIPTION_PAYMENTS_TABLE = "subscription_payments"
+USAGE_RECORDS_TABLE = "usage_records"
+
+# Kernle treasury address on Base (receives subscription payments)
+TREASURY_ADDRESS = "0x0000000000000000000000000000000000000000"  # TODO: set real multisig
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _current_period() -> str:
+    """Return the current billing period as 'YYYY-MM'."""
+    return _now().strftime("%Y-%m")
+
+
+def _next_month(dt: datetime) -> datetime:
+    """Return the same day next month (clamped to valid day)."""
+    import calendar
+
+    year = dt.year + (dt.month // 12)
+    month = (dt.month % 12) + 1
+    max_day = calendar.monthrange(year, month)[1]
+    return dt.replace(year=year, month=month, day=min(dt.day, max_day))
+
+
+# =============================================================================
+# Service
+# =============================================================================
+
+
+class SubscriptionService:
+    """Stateless service — every method receives a Supabase `Client`."""
+
+    # ------------------------------------------------------------------
+    # Subscription CRUD
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def get_or_create_subscription(
+        db: Client,
+        user_id: str,
+    ) -> Subscription:
+        """Return the user's active subscription, creating a free-tier one if none exists."""
+        import asyncio
+
+        def _query():
+            return (
+                db.table(SUBSCRIPTIONS_TABLE)
+                .select("*")
+                .eq("user_id", user_id)
+                .in_("status", ["active", "grace_period"])
+                .order("created_at", desc=True)
+                .limit(1)
+                .execute()
+            )
+
+        result = await asyncio.to_thread(_query)
+
+        if result.data:
+            return Subscription(**result.data[0])
+
+        # No active subscription — create free tier
+        now = _now()
+        data = {
+            "user_id": user_id,
+            "tier": SubscriptionTier.free.value,
+            "status": SubscriptionStatus.active.value,
+            "starts_at": now.isoformat(),
+            "renews_at": None,  # free tier doesn't renew
+            "auto_renew": False,
+        }
+
+        def _insert():
+            return db.table(SUBSCRIPTIONS_TABLE).insert(data).execute()
+
+        result = await asyncio.to_thread(_insert)
+
+        if not result.data:
+            raise RuntimeError(f"Failed to create free subscription for user {user_id}")
+
+        logger.info("Created free-tier subscription for user %s", user_id)
+        return Subscription(**result.data[0])
+
+    @staticmethod
+    async def get_subscription(
+        db: Client,
+        subscription_id: str,
+    ) -> Subscription | None:
+        """Fetch a subscription by its ID."""
+        import asyncio
+
+        def _query():
+            return (
+                db.table(SUBSCRIPTIONS_TABLE)
+                .select("*")
+                .eq("id", subscription_id)
+                .limit(1)
+                .execute()
+            )
+
+        result = await asyncio.to_thread(_query)
+        return Subscription(**result.data[0]) if result.data else None
+
+    # ------------------------------------------------------------------
+    # Upgrade
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def upgrade_tier(
+        db: Client,
+        user_id: str,
+        new_tier: SubscriptionTier,
+    ) -> tuple[Subscription, PaymentInfo]:
+        """Validate and initiate an upgrade.
+
+        Returns the updated subscription and payment info the caller
+        should use to submit on-chain payment.
+
+        Raises:
+            ValueError: if the tier change is invalid.
+        """
+        import asyncio
+
+        sub = await SubscriptionService.get_or_create_subscription(db, user_id)
+        current_tier = sub.tier
+
+        if new_tier == current_tier:
+            raise ValueError(f"Already on {current_tier.value} tier")
+
+        if not is_upgrade(current_tier, new_tier):
+            raise ValueError(
+                f"Cannot upgrade from {current_tier.value} to {new_tier.value} — "
+                "use downgrade instead"
+            )
+
+        if new_tier == SubscriptionTier.enterprise:
+            raise ValueError("Enterprise tier requires custom arrangement — contact support")
+
+        config = get_tier_config(new_tier)
+        now = _now()
+        renews_at = _next_month(now)
+
+        update = {
+            "tier": new_tier.value,
+            "status": SubscriptionStatus.active.value,
+            "starts_at": now.isoformat(),
+            "renews_at": renews_at.isoformat(),
+            "auto_renew": True,
+            "updated_at": now.isoformat(),
+        }
+
+        def _update():
+            return (
+                db.table(SUBSCRIPTIONS_TABLE)
+                .update(update)
+                .eq("id", sub.id)
+                .execute()
+            )
+
+        result = await asyncio.to_thread(_update)
+
+        if not result.data:
+            raise RuntimeError("Failed to update subscription")
+
+        updated_sub = Subscription(**result.data[0])
+
+        payment_info = PaymentInfo(
+            amount=config.price_usdc,
+            currency="USDC",
+            to_address=TREASURY_ADDRESS,
+            chain="base",
+            status=PaymentStatus.pending,
+        )
+
+        logger.info(
+            "User %s upgraded %s → %s (amount=%s USDC)",
+            user_id,
+            current_tier.value,
+            new_tier.value,
+            config.price_usdc,
+        )
+        return updated_sub, payment_info
+
+    # ------------------------------------------------------------------
+    # Downgrade
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def downgrade_tier(
+        db: Client,
+        user_id: str,
+        new_tier: SubscriptionTier,
+    ) -> tuple[Subscription, datetime]:
+        """Schedule a downgrade effective at the next billing period.
+
+        Returns the subscription (unchanged tier until period ends) and the
+        effective date.
+
+        Raises:
+            ValueError: if the tier change is invalid.
+        """
+        import asyncio
+
+        sub = await SubscriptionService.get_or_create_subscription(db, user_id)
+
+        if new_tier == sub.tier:
+            raise ValueError(f"Already on {sub.tier.value} tier")
+
+        if not is_downgrade(sub.tier, new_tier):
+            raise ValueError(
+                f"Cannot downgrade from {sub.tier.value} to {new_tier.value} — "
+                "use upgrade instead"
+            )
+
+        # Downgrade takes effect at the end of the current period
+        effective_at = sub.renews_at or _next_month(_now())
+
+        # Store the pending downgrade — the renewal job will apply it
+        # We record the target tier in a metadata-friendly way:
+        # set auto_renew to false so the current tier expires, then
+        # the renewal checker will create the new-tier subscription.
+        now = _now()
+        update = {
+            "auto_renew": False,
+            "updated_at": now.isoformat(),
+            # Store pending downgrade tier for the renewal job
+            # Using cancelled_at as a signal that a change is pending
+        }
+
+        def _update():
+            return (
+                db.table(SUBSCRIPTIONS_TABLE)
+                .update(update)
+                .eq("id", sub.id)
+                .execute()
+            )
+
+        result = await asyncio.to_thread(_update)
+
+        if not result.data:
+            raise RuntimeError("Failed to schedule downgrade")
+
+        updated_sub = Subscription(**result.data[0])
+
+        logger.info(
+            "User %s scheduled downgrade %s → %s effective %s",
+            user_id,
+            sub.tier.value,
+            new_tier.value,
+            effective_at.isoformat(),
+        )
+        return updated_sub, effective_at
+
+    # ------------------------------------------------------------------
+    # Cancel
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def cancel_subscription(
+        db: Client,
+        user_id: str,
+    ) -> Subscription:
+        """Cancel auto-renewal. The subscription remains active until renews_at."""
+        import asyncio
+
+        sub = await SubscriptionService.get_or_create_subscription(db, user_id)
+
+        if sub.tier == SubscriptionTier.free:
+            raise ValueError("Free tier cannot be cancelled")
+
+        if sub.status == SubscriptionStatus.cancelled:
+            raise ValueError("Subscription is already cancelled")
+
+        now = _now()
+        update = {
+            "auto_renew": False,
+            "cancelled_at": now.isoformat(),
+            "updated_at": now.isoformat(),
+        }
+
+        def _update():
+            return (
+                db.table(SUBSCRIPTIONS_TABLE)
+                .update(update)
+                .eq("id", sub.id)
+                .execute()
+            )
+
+        result = await asyncio.to_thread(_update)
+
+        if not result.data:
+            raise RuntimeError("Failed to cancel subscription")
+
+        logger.info("User %s cancelled subscription (expires %s)", user_id, sub.renews_at)
+        return Subscription(**result.data[0])
+
+    # ------------------------------------------------------------------
+    # Renewal
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def check_renewal(
+        db: Client,
+        subscription_id: str,
+    ) -> Subscription:
+        """Check whether a subscription should renew and handle accordingly.
+
+        Called by a periodic job. Logic:
+        1. If auto_renew is True and renews_at has passed → attempt renewal
+           (actual payment initiation is the caller's responsibility).
+        2. If auto_renew is False and renews_at has passed → expire or
+           downgrade to free.
+        3. If still within period → no-op.
+
+        Returns the (possibly updated) subscription.
+        """
+        import asyncio
+
+        sub = await SubscriptionService.get_subscription(db, subscription_id)
+        if sub is None:
+            raise ValueError(f"Subscription {subscription_id} not found")
+
+        # Free tier never renews
+        if sub.tier == SubscriptionTier.free:
+            return sub
+
+        # Not yet due
+        now = _now()
+        if sub.renews_at and now < sub.renews_at:
+            return sub
+
+        # --- Renewal is due ---
+
+        if sub.auto_renew:
+            # Extend by one month — caller must verify payment succeeded
+            new_renews = _next_month(now)
+            update = {
+                "renews_at": new_renews.isoformat(),
+                "status": SubscriptionStatus.active.value,
+                "updated_at": now.isoformat(),
+            }
+
+            def _renew():
+                return (
+                    db.table(SUBSCRIPTIONS_TABLE)
+                    .update(update)
+                    .eq("id", sub.id)
+                    .execute()
+                )
+
+            result = await asyncio.to_thread(_renew)
+            logger.info("Subscription %s renewed until %s", subscription_id, new_renews)
+            return Subscription(**result.data[0]) if result.data else sub
+
+        # auto_renew is off — check grace period
+        if sub.status == SubscriptionStatus.active:
+            # Enter 7-day grace period
+            update = {
+                "status": SubscriptionStatus.grace_period.value,
+                "updated_at": now.isoformat(),
+            }
+
+            def _grace():
+                return (
+                    db.table(SUBSCRIPTIONS_TABLE)
+                    .update(update)
+                    .eq("id", sub.id)
+                    .execute()
+                )
+
+            result = await asyncio.to_thread(_grace)
+            logger.info("Subscription %s entered grace period", subscription_id)
+            return Subscription(**result.data[0]) if result.data else sub
+
+        if sub.status == SubscriptionStatus.grace_period:
+            # Grace period check: 7 days after renews_at
+            grace_end = sub.renews_at
+            if grace_end:
+                from datetime import timedelta
+
+                grace_end = grace_end + timedelta(days=7)
+
+            if grace_end is None or now >= grace_end:
+                # Grace period expired — downgrade to free
+                update = {
+                    "tier": SubscriptionTier.free.value,
+                    "status": SubscriptionStatus.expired.value,
+                    "auto_renew": False,
+                    "renews_at": None,
+                    "updated_at": now.isoformat(),
+                }
+
+                def _expire():
+                    return (
+                        db.table(SUBSCRIPTIONS_TABLE)
+                        .update(update)
+                        .eq("id", sub.id)
+                        .execute()
+                    )
+
+                result = await asyncio.to_thread(_expire)
+                logger.warning("Subscription %s expired → free tier", subscription_id)
+                return Subscription(**result.data[0]) if result.data else sub
+
+        return sub
+
+    # ------------------------------------------------------------------
+    # Payments
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def record_payment(
+        db: Client,
+        subscription_id: str,
+        tx_hash: str,
+        amount: Decimal,
+        from_address: str,
+        to_address: str = TREASURY_ADDRESS,
+        chain: str = "base",
+        currency: str = "USDC",
+        period_start: datetime | None = None,
+        period_end: datetime | None = None,
+    ) -> SubscriptionPayment:
+        """Store a payment record.
+
+        On-chain verification happens elsewhere — this just persists
+        the record with status=pending until confirmed.
+        """
+        import asyncio
+
+        now = _now()
+        if period_start is None:
+            period_start = now
+        if period_end is None:
+            period_end = _next_month(now)
+
+        data = {
+            "subscription_id": subscription_id,
+            "amount": str(amount),  # Supabase stores DECIMAL as string
+            "currency": currency,
+            "tx_hash": tx_hash,
+            "from_address": from_address,
+            "to_address": to_address,
+            "chain": chain,
+            "status": PaymentStatus.pending.value,
+            "period_start": period_start.isoformat(),
+            "period_end": period_end.isoformat(),
+            "created_at": now.isoformat(),
+        }
+
+        def _insert():
+            return db.table(SUBSCRIPTION_PAYMENTS_TABLE).insert(data).execute()
+
+        result = await asyncio.to_thread(_insert)
+
+        if not result.data:
+            raise RuntimeError(f"Failed to record payment for subscription {subscription_id}")
+
+        logger.info(
+            "Recorded payment %s for subscription %s (amount=%s %s)",
+            tx_hash,
+            subscription_id,
+            amount,
+            currency,
+        )
+        return SubscriptionPayment(**result.data[0])
+
+    @staticmethod
+    async def confirm_payment(
+        db: Client,
+        tx_hash: str,
+    ) -> SubscriptionPayment | None:
+        """Mark a payment as confirmed (called after on-chain verification)."""
+        import asyncio
+
+        now = _now()
+
+        def _update():
+            return (
+                db.table(SUBSCRIPTION_PAYMENTS_TABLE)
+                .update({
+                    "status": PaymentStatus.confirmed.value,
+                    "confirmed_at": now.isoformat(),
+                })
+                .eq("tx_hash", tx_hash)
+                .execute()
+            )
+
+        result = await asyncio.to_thread(_update)
+        if not result.data:
+            return None
+
+        logger.info("Payment %s confirmed", tx_hash)
+        return SubscriptionPayment(**result.data[0])
+
+    @staticmethod
+    async def fail_payment(
+        db: Client,
+        tx_hash: str,
+    ) -> SubscriptionPayment | None:
+        """Mark a payment as failed."""
+        import asyncio
+
+        def _update():
+            return (
+                db.table(SUBSCRIPTION_PAYMENTS_TABLE)
+                .update({"status": PaymentStatus.failed.value})
+                .eq("tx_hash", tx_hash)
+                .execute()
+            )
+
+        result = await asyncio.to_thread(_update)
+        if not result.data:
+            return None
+
+        logger.warning("Payment %s failed", tx_hash)
+        return SubscriptionPayment(**result.data[0])
+
+    # ------------------------------------------------------------------
+    # Usage tracking
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def get_usage(
+        db: Client,
+        user_id: str,
+    ) -> UsageRecord:
+        """Get current-period usage, creating a record if needed."""
+        import asyncio
+
+        period = _current_period()
+
+        def _upsert():
+            return (
+                db.table(USAGE_RECORDS_TABLE)
+                .upsert(
+                    {
+                        "user_id": user_id,
+                        "period": period,
+                    },
+                    on_conflict="user_id,period",
+                )
+                .execute()
+            )
+
+        result = await asyncio.to_thread(_upsert)
+
+        if result.data:
+            return UsageRecord(**result.data[0])
+
+        # Fallback: try select
+        def _select():
+            return (
+                db.table(USAGE_RECORDS_TABLE)
+                .select("*")
+                .eq("user_id", user_id)
+                .eq("period", period)
+                .limit(1)
+                .execute()
+            )
+
+        result = await asyncio.to_thread(_select)
+        if result.data:
+            return UsageRecord(**result.data[0])
+
+        # Return empty usage
+        return UsageRecord(user_id=user_id, period=period)
+
+    @staticmethod
+    async def increment_usage(
+        db: Client,
+        user_id: str,
+        storage_delta: int = 0,
+        sync_count_delta: int = 0,
+    ) -> UsageRecord:
+        """Atomically increment usage counters for the current period.
+
+        storage_delta can be negative (e.g. when data is deleted).
+        sync_count_delta is for analytics only — no limits enforced.
+        """
+        import asyncio
+
+        period = _current_period()
+        now = _now()
+
+        # Ensure record exists
+        await SubscriptionService.get_usage(db, user_id)
+
+        # Use RPC for atomic increment if available, otherwise fallback
+        try:
+
+            def _rpc():
+                return db.rpc(
+                    "increment_subscription_usage",
+                    {
+                        "p_user_id": user_id,
+                        "p_period": period,
+                        "p_storage_delta": storage_delta,
+                        "p_sync_delta": sync_count_delta,
+                    },
+                ).execute()
+
+            result = await asyncio.to_thread(_rpc)
+            if result.data and len(result.data) > 0:
+                return UsageRecord(**result.data[0])
+        except Exception:
+            logger.debug(
+                "increment_subscription_usage RPC unavailable, using read-modify-write"
+            )
+
+        # Fallback: read-modify-write (has race window, acceptable for now)
+        usage = await SubscriptionService.get_usage(db, user_id)
+        new_storage = max(0, usage.storage_bytes + storage_delta)
+        new_sync = usage.sync_count + sync_count_delta
+
+        def _update():
+            return (
+                db.table(USAGE_RECORDS_TABLE)
+                .update({
+                    "storage_bytes": new_storage,
+                    "sync_count": new_sync,
+                    "updated_at": now.isoformat(),
+                })
+                .eq("user_id", user_id)
+                .eq("period", period)
+                .execute()
+            )
+
+        result = await asyncio.to_thread(_update)
+        if result.data:
+            return UsageRecord(**result.data[0])
+
+        return UsageRecord(
+            user_id=user_id,
+            period=period,
+            storage_bytes=new_storage,
+            sync_count=new_sync,
+        )
+
+    @staticmethod
+    async def update_stacks_syncing(
+        db: Client,
+        user_id: str,
+        stacks_syncing: int,
+    ) -> UsageRecord:
+        """Set the current number of stacks actively syncing.
+
+        Called when agents start/stop syncing to keep the count accurate.
+        """
+        import asyncio
+
+        period = _current_period()
+        now = _now()
+
+        # Ensure record exists
+        await SubscriptionService.get_usage(db, user_id)
+
+        def _update():
+            return (
+                db.table(USAGE_RECORDS_TABLE)
+                .update({
+                    "stacks_syncing": stacks_syncing,
+                    "updated_at": now.isoformat(),
+                })
+                .eq("user_id", user_id)
+                .eq("period", period)
+                .execute()
+            )
+
+        result = await asyncio.to_thread(_update)
+        if result.data:
+            return UsageRecord(**result.data[0])
+
+        return UsageRecord(
+            user_id=user_id,
+            period=period,
+            stacks_syncing=stacks_syncing,
+        )
+
+    # ------------------------------------------------------------------
+    # Quota enforcement
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def check_quota(
+        db: Client,
+        user_id: str,
+        operation: Literal["push", "create_stack"] = "push",
+    ) -> QuotaCheckResult:
+        """Check whether the user's current usage allows the operation.
+
+        Quotas enforced:
+        - storage_bytes vs tier storage_limit_bytes
+        - stacks_syncing vs tier stack_limit
+
+        NOT enforced (by design):
+        - sync frequency — unlimited on all tiers
+        """
+        sub = await SubscriptionService.get_or_create_subscription(db, user_id)
+        config = get_tier_config(sub.tier)
+        usage = await SubscriptionService.get_usage(db, user_id)
+
+        # Enterprise: unlimited
+        if config.is_custom:
+            return QuotaCheckResult(
+                allowed=True,
+                tier=sub.tier,
+                storage_used=usage.storage_bytes,
+                storage_limit=0,
+                stacks_used=usage.stacks_syncing,
+                stacks_limit=0,
+            )
+
+        result = QuotaCheckResult(
+            allowed=True,
+            tier=sub.tier,
+            storage_used=usage.storage_bytes,
+            storage_limit=config.storage_limit_bytes,
+            stacks_used=usage.stacks_syncing,
+            stacks_limit=config.stack_limit,
+        )
+
+        if operation == "push":
+            # Check storage
+            if usage.storage_bytes >= config.storage_limit_bytes:
+                # On tiers with overflow pricing, allow but log
+                if config.overflow:
+                    logger.info(
+                        "User %s exceeded storage (%d / %d) — overflow billing applies",
+                        user_id,
+                        usage.storage_bytes,
+                        config.storage_limit_bytes,
+                    )
+                else:
+                    result.allowed = False
+                    result.reason = (
+                        f"Storage limit reached ({usage.storage_bytes} / "
+                        f"{config.storage_limit_bytes} bytes). "
+                        "Upgrade tier or remove old data."
+                    )
+                    return result
+
+        if operation == "create_stack":
+            # Check stack count
+            if usage.stacks_syncing >= config.stack_limit:
+                if config.overflow:
+                    logger.info(
+                        "User %s exceeded stacks (%d / %d) — overflow billing applies",
+                        user_id,
+                        usage.stacks_syncing,
+                        config.stack_limit,
+                    )
+                else:
+                    result.allowed = False
+                    result.reason = (
+                        f"Stack limit reached ({usage.stacks_syncing} / "
+                        f"{config.stack_limit}). "
+                        "Upgrade tier for more stacks."
+                    )
+                    return result
+
+        return result

--- a/backend/supabase/migrations/024_subscriptions.sql
+++ b/backend/supabase/migrations/024_subscriptions.sql
@@ -1,0 +1,146 @@
+-- =============================================================================
+-- Migration 024: Subscription management tables
+-- =============================================================================
+-- Implements the cloud payments spec (docs/CLOUD_PAYMENTS_SPEC.md)
+-- Supports tiered subscriptions with crypto (USDC) payments on Base L2
+
+-- =============================================================================
+-- Update users table tier constraint for new tiers
+-- =============================================================================
+
+ALTER TABLE users DROP CONSTRAINT IF EXISTS users_tier_check;
+ALTER TABLE users ADD CONSTRAINT users_tier_check
+    CHECK (tier IN ('free', 'core', 'pro', 'enterprise', 'paid', 'unlimited'));
+
+-- =============================================================================
+-- Subscriptions table
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS subscriptions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id TEXT NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    tier TEXT NOT NULL DEFAULT 'free',
+    status TEXT NOT NULL DEFAULT 'active',
+    starts_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    renews_at TIMESTAMPTZ,
+    cancelled_at TIMESTAMPTZ,
+    auto_renew BOOLEAN DEFAULT true,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+
+    CONSTRAINT sub_valid_tier CHECK (tier IN ('free', 'core', 'pro', 'enterprise')),
+    CONSTRAINT sub_valid_status CHECK (status IN ('active', 'grace_period', 'cancelled', 'expired'))
+);
+
+CREATE INDEX idx_subscriptions_user ON subscriptions(user_id);
+CREATE INDEX idx_subscriptions_renews ON subscriptions(renews_at) WHERE auto_renew = true AND status = 'active';
+CREATE INDEX idx_subscriptions_status ON subscriptions(status);
+
+-- =============================================================================
+-- Subscription payments table
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS subscription_payments (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    subscription_id UUID NOT NULL REFERENCES subscriptions(id) ON DELETE CASCADE,
+    user_id TEXT NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    amount DECIMAL(18, 6) NOT NULL,
+    currency TEXT NOT NULL DEFAULT 'USDC',
+    tx_hash TEXT UNIQUE,
+    from_address TEXT,
+    to_address TEXT,
+    chain TEXT NOT NULL DEFAULT 'base',
+    status TEXT NOT NULL DEFAULT 'pending',
+    period_start TIMESTAMPTZ NOT NULL,
+    period_end TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    confirmed_at TIMESTAMPTZ,
+
+    CONSTRAINT pay_valid_status CHECK (status IN ('pending', 'confirmed', 'failed', 'refunded')),
+    CONSTRAINT pay_valid_currency CHECK (currency IN ('USDC'))
+);
+
+CREATE INDEX idx_sub_payments_subscription ON subscription_payments(subscription_id);
+CREATE INDEX idx_sub_payments_user ON subscription_payments(user_id);
+CREATE INDEX idx_sub_payments_tx ON subscription_payments(tx_hash);
+CREATE INDEX idx_sub_payments_status ON subscription_payments(status);
+
+-- =============================================================================
+-- Storage usage tracking table
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS usage_records (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id TEXT NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    period TEXT NOT NULL,                    -- YYYY-MM format
+    storage_bytes BIGINT DEFAULT 0,
+    sync_count INTEGER DEFAULT 0,
+    stacks_syncing INTEGER DEFAULT 0,
+    peak_stacks INTEGER DEFAULT 0,          -- Peak syncing stacks for overflow billing
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+
+    UNIQUE(user_id, period)
+);
+
+CREATE INDEX idx_usage_records_user_period ON usage_records(user_id, period);
+
+-- =============================================================================
+-- Payment intents (for the two-phase upgrade flow)
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS payment_intents (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id TEXT NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    subscription_id UUID REFERENCES subscriptions(id),
+    tier TEXT NOT NULL,
+    amount DECIMAL(18, 6) NOT NULL,
+    currency TEXT NOT NULL DEFAULT 'USDC',
+    treasury_address TEXT NOT NULL,
+    chain TEXT NOT NULL DEFAULT 'base',
+    status TEXT NOT NULL DEFAULT 'pending',
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    confirmed_at TIMESTAMPTZ,
+
+    CONSTRAINT intent_valid_status CHECK (status IN ('pending', 'confirmed', 'expired', 'cancelled'))
+);
+
+CREATE INDEX idx_payment_intents_user ON payment_intents(user_id);
+CREATE INDEX idx_payment_intents_status ON payment_intents(status) WHERE status = 'pending';
+
+-- =============================================================================
+-- Row Level Security
+-- =============================================================================
+
+ALTER TABLE subscriptions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE subscription_payments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE usage_records ENABLE ROW LEVEL SECURITY;
+ALTER TABLE payment_intents ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access" ON subscriptions FOR ALL TO service_role USING (true);
+CREATE POLICY "Service role full access" ON subscription_payments FOR ALL TO service_role USING (true);
+CREATE POLICY "Service role full access" ON usage_records FOR ALL TO service_role USING (true);
+CREATE POLICY "Service role full access" ON payment_intents FOR ALL TO service_role USING (true);
+
+-- =============================================================================
+-- Initialize free subscriptions for existing users
+-- =============================================================================
+
+INSERT INTO subscriptions (user_id, tier, status, starts_at, auto_renew)
+SELECT user_id, 'free', 'active', created_at, false
+FROM users
+WHERE NOT EXISTS (
+    SELECT 1 FROM subscriptions s WHERE s.user_id = users.user_id
+)
+ON CONFLICT DO NOTHING;
+
+-- =============================================================================
+-- Comments
+-- =============================================================================
+
+COMMENT ON TABLE subscriptions IS 'User subscription state. One active subscription per user.';
+COMMENT ON TABLE subscription_payments IS 'On-chain USDC payment records for tier upgrades/renewals.';
+COMMENT ON TABLE usage_records IS 'Monthly storage and sync usage tracking per user.';
+COMMENT ON TABLE payment_intents IS 'Two-phase payment: intent created → user pays on-chain → confirmed.';
+COMMENT ON COLUMN usage_records.peak_stacks IS 'Peak syncing stacks in period, used for overflow billing.';
+COMMENT ON COLUMN payment_intents.treasury_address IS 'Address user should send USDC to for this payment.';

--- a/kernle/cli/__main__.py
+++ b/kernle/cli/__main__.py
@@ -34,6 +34,7 @@ from kernle.cli.commands import (
     cmd_playbook,
     cmd_raw,
     cmd_stats,
+    cmd_subscription,
     cmd_suggestions,
 )
 from kernle.cli.commands.agent import cmd_agent
@@ -3308,6 +3309,53 @@ def main():
     keys_cycle.add_argument("--force", "-f", action="store_true", help="Skip confirmation prompt")
     keys_cycle.add_argument("--json", "-j", action="store_true", help="Output as JSON")
 
+    # =========================================================================
+    # Subscription Management (kernle sub ...)
+    # =========================================================================
+
+    p_sub = subparsers.add_parser(
+        "sub",
+        help="Subscription & tier management",
+        aliases=["subscription"],
+    )
+    sub_sub = p_sub.add_subparsers(dest="sub_action")
+
+    # kernle sub tier (default when no subcommand given)
+    sub_tier = sub_sub.add_parser("tier", help="Show current tier, usage, and renewal info")
+    sub_tier.add_argument("--json", "-j", action="store_true", help="Output as JSON")
+
+    # kernle sub upgrade <tier>
+    sub_upgrade = sub_sub.add_parser("upgrade", help="Upgrade to a higher tier")
+    sub_upgrade.add_argument(
+        "tier", choices=["core", "pro", "enterprise"], help="Target tier"
+    )
+    sub_upgrade.add_argument("--yes", "-y", action="store_true", help="Skip confirmation prompt")
+    sub_upgrade.add_argument("--json", "-j", action="store_true", help="Output as JSON")
+
+    # kernle sub downgrade <tier>
+    sub_downgrade = sub_sub.add_parser(
+        "downgrade", help="Downgrade to a lower tier (effective next period)"
+    )
+    sub_downgrade.add_argument(
+        "tier", choices=["free", "core", "pro"], help="Target tier"
+    )
+    sub_downgrade.add_argument("--yes", "-y", action="store_true", help="Skip confirmation prompt")
+    sub_downgrade.add_argument("--json", "-j", action="store_true", help="Output as JSON")
+
+    # kernle sub cancel
+    sub_cancel = sub_sub.add_parser("cancel", help="Cancel auto-renewal")
+    sub_cancel.add_argument("--yes", "-y", action="store_true", help="Skip confirmation prompt")
+    sub_cancel.add_argument("--json", "-j", action="store_true", help="Output as JSON")
+
+    # kernle sub usage
+    sub_usage = sub_sub.add_parser("usage", help="Show detailed usage for current billing period")
+    sub_usage.add_argument("--json", "-j", action="store_true", help="Output as JSON")
+
+    # kernle sub payments [--limit N]
+    sub_payments = sub_sub.add_parser("payments", help="List payment history")
+    sub_payments.add_argument("--limit", "-l", type=int, default=20, help="Max payments to show")
+    sub_payments.add_argument("--json", "-j", action="store_true", help="Output as JSON")
+
     # agent - agent management
     p_agent = subparsers.add_parser("agent", help="Agent management (list, delete)")
     agent_sub = p_agent.add_subparsers(dest="agent_action", required=True)
@@ -3745,6 +3793,9 @@ Beliefs already present in the agent's memory will be skipped.
             cmd_migrate(args, k)
         elif args.command == "setup":
             cmd_setup(args, k)
+        # Subscription management
+        elif args.command in ("sub", "subscription"):
+            cmd_subscription(args, k)
         # Commerce commands
         elif args.command == "wallet":
             cmd_wallet(args, k)

--- a/kernle/cli/commands/__init__.py
+++ b/kernle/cli/commands/__init__.py
@@ -14,6 +14,7 @@ from kernle.cli.commands.meta import cmd_meta
 from kernle.cli.commands.playbook import cmd_playbook
 from kernle.cli.commands.raw import cmd_raw, resolve_raw_id
 from kernle.cli.commands.stats import cmd_stats
+from kernle.cli.commands.subscription import cmd_subscription
 from kernle.cli.commands.suggestions import cmd_suggestions, resolve_suggestion_id
 
 __all__ = [
@@ -30,6 +31,7 @@ __all__ = [
     "cmd_raw",
     "cmd_stats",
     "cmd_suggestions",
+    "cmd_subscription",
     "resolve_raw_id",
     "resolve_suggestion_id",
 ]

--- a/kernle/cli/commands/subscription.py
+++ b/kernle/cli/commands/subscription.py
@@ -1,0 +1,706 @@
+"""Subscription management CLI commands for Kernle Cloud.
+
+Provides command-line interface for subscription/tier management:
+- kernle sub tier         — Show current tier, usage, renewal info
+- kernle sub upgrade <t>  — Upgrade to a higher tier
+- kernle sub downgrade <t> — Downgrade to a lower tier
+- kernle sub cancel       — Cancel auto-renewal
+- kernle sub usage        — Show detailed usage for current period
+- kernle sub payments     — List payment history
+"""
+
+import json
+import logging
+import sys
+import urllib.request
+import urllib.error
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    import argparse
+    from kernle import Kernle
+
+logger = logging.getLogger(__name__)
+
+# ── Tier definitions (mirrors CLOUD_PAYMENTS_SPEC.md §4) ────────────────────
+
+TIERS = {
+    "free": {
+        "name": "Free",
+        "price": 0,
+        "storage": "10 MB",
+        "storage_bytes": 10 * 1024 * 1024,
+        "stacks": 1,
+        "sync": "Unlimited",
+    },
+    "core": {
+        "name": "Core",
+        "price": 5,
+        "storage": "100 MB",
+        "storage_bytes": 100 * 1024 * 1024,
+        "stacks": 3,
+        "sync": "Unlimited",
+        "overflow_agent": 1.50,
+        "overflow_storage": 0.50,
+    },
+    "pro": {
+        "name": "Pro",
+        "price": 15,
+        "storage": "1 GB",
+        "storage_bytes": 1024 * 1024 * 1024,
+        "stacks": 10,
+        "sync": "Unlimited",
+        "overflow_agent": 1.00,
+        "overflow_storage": 0.50,
+    },
+    "enterprise": {
+        "name": "Enterprise",
+        "price": None,  # custom
+        "storage": "Unlimited",
+        "storage_bytes": None,
+        "stacks": None,  # unlimited
+        "sync": "Unlimited",
+    },
+}
+
+TIER_ORDER = ["free", "core", "pro", "enterprise"]
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _load_credentials() -> dict:
+    """Load credentials from ~/.kernle/credentials.json."""
+    creds_path = Path.home() / ".kernle" / "credentials.json"
+    if not creds_path.exists():
+        return {}
+    try:
+        with open(creds_path) as f:
+            return json.load(f)
+    except (json.JSONDecodeError, IOError):
+        return {}
+
+
+def _get_backend_url(creds: dict) -> Optional[str]:
+    """Extract backend URL from credentials."""
+    return creds.get("backend_url")
+
+
+def _get_auth_token(creds: dict) -> Optional[str]:
+    """Extract auth token from credentials, trying multiple field names."""
+    return creds.get("token") or creds.get("auth_token") or creds.get("api_key")
+
+
+def _api_request(
+    method: str,
+    path: str,
+    creds: dict,
+    body: Optional[dict] = None,
+    timeout: int = 30,
+) -> dict:
+    """Make an authenticated HTTP request to the Kernle backend API.
+
+    Returns the parsed JSON response body.
+    Raises SystemExit on auth/connection failures with friendly messages.
+    """
+    backend_url = _get_backend_url(creds)
+    token = _get_auth_token(creds)
+
+    if not backend_url:
+        print("✗ Backend not configured")
+        print("  Run `kernle auth login` or set KERNLE_BACKEND_URL")
+        sys.exit(1)
+    if not token:
+        print("✗ Not authenticated")
+        print("  Run `kernle auth login` or set KERNLE_AUTH_TOKEN")
+        sys.exit(1)
+
+    url = f"{backend_url.rstrip('/')}{path}"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+    data = json.dumps(body).encode("utf-8") if body else None
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        if e.code == 401:
+            print("✗ Authentication failed (token expired?)")
+            print("  Run `kernle auth login` to re-authenticate")
+            sys.exit(1)
+        if e.code == 403:
+            print("✗ Forbidden — you don't have permission for this action")
+            sys.exit(1)
+        # Try to parse error body
+        try:
+            err_body = json.loads(e.read().decode("utf-8"))
+            detail = err_body.get("detail") or err_body.get("error") or str(err_body)
+        except Exception:
+            detail = e.reason
+        print(f"✗ API error ({e.code}): {detail}")
+        sys.exit(1)
+    except urllib.error.URLError as e:
+        print(f"✗ Could not connect to {backend_url}")
+        print(f"  {e.reason}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"✗ Request failed: {e}")
+        sys.exit(1)
+
+
+# ── Formatting helpers ───────────────────────────────────────────────────────
+
+
+def _progress_bar(used: float, limit: float, width: int = 20) -> str:
+    """Render a Unicode progress bar: █████░░░░░ 45%"""
+    if limit <= 0:
+        return "█" * width + " ∞"
+    ratio = min(used / limit, 1.0)
+    filled = int(ratio * width)
+    empty = width - filled
+    pct = ratio * 100
+    # Colour hint via prefix emoji
+    if pct >= 90:
+        icon = "🔴"
+    elif pct >= 70:
+        icon = "🟡"
+    else:
+        icon = "🟢"
+    return f"{icon} {'█' * filled}{'░' * empty} {pct:.0f}%"
+
+
+def _format_bytes(b: int) -> str:
+    """Human-readable byte size."""
+    if b < 1024:
+        return f"{b} B"
+    elif b < 1024 ** 2:
+        return f"{b / 1024:.1f} KB"
+    elif b < 1024 ** 3:
+        return f"{b / (1024 ** 2):.1f} MB"
+    else:
+        return f"{b / (1024 ** 3):.2f} GB"
+
+
+def _format_date(iso_str: Optional[str]) -> str:
+    """Friendly date string from ISO 8601."""
+    if not iso_str:
+        return "—"
+    try:
+        dt = datetime.fromisoformat(iso_str.replace("Z", "+00:00"))
+        return dt.strftime("%Y-%m-%d %H:%M UTC")
+    except Exception:
+        return iso_str[:19]
+
+
+def _relative_time(iso_str: Optional[str]) -> str:
+    """'3 days from now', '2 hours ago', etc."""
+    if not iso_str:
+        return "—"
+    try:
+        dt = datetime.fromisoformat(iso_str.replace("Z", "+00:00"))
+        now = datetime.now(timezone.utc)
+        delta = dt - now
+        secs = delta.total_seconds()
+        if abs(secs) < 60:
+            return "just now"
+        minutes = abs(secs) / 60
+        hours = minutes / 60
+        days = hours / 24
+        suffix = "from now" if secs > 0 else "ago"
+        if days >= 1:
+            return f"{int(days)}d {suffix}"
+        if hours >= 1:
+            return f"{int(hours)}h {suffix}"
+        return f"{int(minutes)}m {suffix}"
+    except Exception:
+        return iso_str[:10]
+
+
+def _tier_label(tier: str) -> str:
+    """Colourful tier label."""
+    info = TIERS.get(tier, {})
+    name = info.get("name", tier.title())
+    icons = {"free": "🆓", "core": "⚡", "pro": "🚀", "enterprise": "🏢"}
+    return f"{icons.get(tier, '•')} {name}"
+
+
+# ── Subcommand handlers ─────────────────────────────────────────────────────
+
+
+def _cmd_tier(args: "argparse.Namespace", k: "Kernle") -> None:
+    """Show current tier, usage summary, and renewal info."""
+    creds = _load_credentials()
+    data = _api_request("GET", "/api/v1/subscriptions/me", creds)
+
+    output_json = getattr(args, "json", False)
+    if output_json:
+        print(json.dumps(data, indent=2))
+        return
+
+    tier = data.get("tier", "free")
+    status = data.get("status", "active")
+    auto_renew = data.get("auto_renew", False)
+    renews_at = data.get("renews_at")
+    renewal_amount = data.get("renewal_amount")
+    wallet_balance = data.get("wallet_balance")
+    can_renew = data.get("can_renew")
+
+    # Usage summary (may be embedded or require separate call)
+    storage_used = data.get("storage_used", 0)
+    storage_limit = data.get("storage_limit", TIERS.get(tier, {}).get("storage_bytes", 0) or 0)
+    stacks_used = data.get("agents_used", data.get("stacks_used", 0))
+    stacks_limit = data.get("agents_limit", data.get("stacks_limit", TIERS.get(tier, {}).get("stacks") or 0))
+
+    print()
+    print("  Kernle Cloud Subscription")
+    print("  " + "═" * 40)
+    print()
+    print(f"  Tier:    {_tier_label(tier)}")
+
+    status_icons = {
+        "active": "✓ Active",
+        "grace_period": "⚠ Grace Period",
+        "cancelled": "✗ Cancelled",
+        "expired": "✗ Expired",
+    }
+    print(f"  Status:  {status_icons.get(status, status)}")
+    print()
+
+    # Storage bar
+    if storage_limit and storage_limit > 0:
+        print(f"  Storage: {_format_bytes(storage_used)} / {_format_bytes(storage_limit)}")
+        print(f"           {_progress_bar(storage_used, storage_limit)}")
+    else:
+        print(f"  Storage: {_format_bytes(storage_used)} (unlimited)")
+    print()
+
+    # Stacks bar
+    if stacks_limit and stacks_limit > 0:
+        print(f"  Stacks:  {stacks_used} / {stacks_limit}")
+        print(f"           {_progress_bar(stacks_used, stacks_limit)}")
+    else:
+        print(f"  Stacks:  {stacks_used} (unlimited)")
+    print()
+
+    # Renewal info
+    if renews_at:
+        print(f"  Renews:  {_format_date(renews_at)} ({_relative_time(renews_at)})")
+        if renewal_amount is not None:
+            print(f"  Amount:  ${float(renewal_amount):.2f} USDC")
+        if auto_renew:
+            if can_renew is False:
+                print("  ⚠ Auto-renew ON but wallet balance too low!")
+                if wallet_balance is not None:
+                    print(f"    Wallet balance: ${float(wallet_balance):.2f} USDC")
+            else:
+                print("  ✓ Auto-renew enabled")
+        else:
+            print("  ✗ Auto-renew disabled")
+    elif status == "cancelled":
+        cancelled_at = data.get("cancelled_at")
+        if cancelled_at:
+            print(f"  Cancelled: {_format_date(cancelled_at)}")
+    print()
+
+    # Hint
+    if tier == "free":
+        print("  💡 Upgrade with: kernle sub upgrade core")
+    elif tier == "core":
+        print("  💡 Upgrade with: kernle sub upgrade pro")
+    print()
+
+
+def _cmd_upgrade(args: "argparse.Namespace", k: "Kernle") -> None:
+    """Interactive upgrade flow."""
+    target_tier = args.tier.lower()
+    output_json = getattr(args, "json", False)
+
+    if target_tier not in TIERS:
+        print(f"✗ Unknown tier '{target_tier}'")
+        print(f"  Available tiers: {', '.join(TIER_ORDER)}")
+        sys.exit(1)
+
+    if target_tier == "enterprise":
+        print("🏢 Enterprise tier requires custom arrangement.")
+        print("   Contact: hello@kernle.io")
+        sys.exit(0)
+
+    creds = _load_credentials()
+
+    # Fetch current subscription
+    current = _api_request("GET", "/api/v1/subscriptions/me", creds)
+    current_tier = current.get("tier", "free")
+
+    if current_tier == target_tier:
+        print(f"You're already on the {_tier_label(target_tier)} tier.")
+        sys.exit(0)
+
+    cur_idx = TIER_ORDER.index(current_tier) if current_tier in TIER_ORDER else 0
+    tgt_idx = TIER_ORDER.index(target_tier)
+    if tgt_idx <= cur_idx:
+        print(f"✗ {target_tier.title()} is not an upgrade from {current_tier.title()}.")
+        print(f"  Use `kernle sub downgrade {target_tier}` instead.")
+        sys.exit(1)
+
+    cur_info = TIERS[current_tier]
+    tgt_info = TIERS[target_tier]
+    price = tgt_info["price"]
+
+    # ── Show comparison ──────────────────────────────────────────────────
+    if not output_json:
+        print()
+        print("  Upgrade Comparison")
+        print("  " + "═" * 46)
+        print()
+        header = f"  {'':18} {'Current':>12}  →  {'New':>12}"
+        print(header)
+        print("  " + "─" * 46)
+        print(f"  {'Tier':<18} {cur_info['name']:>12}  →  {tgt_info['name']:>12}")
+        cur_price = f"${cur_info['price']}" if cur_info['price'] else "Free"
+        tgt_price = f"${tgt_info['price']}/mo"
+        print(f"  {'Price':<18} {cur_price:>12}  →  {tgt_price:>12}")
+        print(f"  {'Storage':<18} {cur_info['storage']:>12}  →  {tgt_info['storage']:>12}")
+        cur_stacks = str(cur_info['stacks']) if cur_info['stacks'] else "∞"
+        tgt_stacks = str(tgt_info['stacks']) if tgt_info['stacks'] else "∞"
+        print(f"  {'Stacks':<18} {cur_stacks:>12}  →  {tgt_stacks:>12}")
+        print(f"  {'Sync':<18} {'Unlimited':>12}  →  {'Unlimited':>12}")
+        print()
+        print(f"  💰 Cost: ${price:.2f} USDC / month")
+
+        # Show wallet balance if available
+        wallet_balance = current.get("wallet_balance")
+        if wallet_balance is not None:
+            bal = float(wallet_balance)
+            print(f"  💳 Wallet balance: ${bal:.2f} USDC", end="")
+            if bal < price:
+                print("  ⚠ Insufficient!")
+            else:
+                print("  ✓")
+        print()
+
+    # ── Confirm ──────────────────────────────────────────────────────────
+    yes_flag = getattr(args, "yes", False)
+    if not yes_flag and not output_json:
+        try:
+            answer = input(f"  Confirm upgrade to {tgt_info['name']} (${price:.2f} USDC)? [y/N] ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print("\n  Aborted.")
+            sys.exit(0)
+        if answer not in ("y", "yes"):
+            print("  Aborted.")
+            sys.exit(0)
+
+    # ── Call API ─────────────────────────────────────────────────────────
+    result = _api_request("POST", "/api/v1/subscriptions/upgrade", creds, body={"tier": target_tier})
+
+    if output_json:
+        print(json.dumps(result, indent=2))
+        return
+
+    payment = result.get("payment", {})
+    sub = result.get("subscription", {})
+    tx_hash = payment.get("tx_hash")
+    pay_status = payment.get("status", "pending")
+
+    if pay_status == "confirmed":
+        print(f"  ✓ Upgraded to {_tier_label(target_tier)}!")
+        if tx_hash:
+            print(f"  📝 Tx: {tx_hash}")
+        if sub.get("renews_at"):
+            print(f"  📅 Renews: {_format_date(sub['renews_at'])}")
+    else:
+        # Payment pending — show instructions for manual transfer
+        to_addr = payment.get("to")
+        amount = payment.get("amount", price)
+        print("  ⏳ Payment pending — complete the transfer to activate:")
+        print()
+        if to_addr:
+            print(f"  Treasury: {to_addr}")
+        print(f"  Amount:   ${float(amount):.2f} USDC (Base)")
+        if tx_hash:
+            print(f"  Ref tx:   {tx_hash}")
+        print()
+        print("  Once confirmed on-chain your tier will update automatically.")
+        print("  Check status with: kernle sub tier")
+    print()
+
+
+def _cmd_downgrade(args: "argparse.Namespace", k: "Kernle") -> None:
+    """Downgrade to a lower tier (effective at end of current period)."""
+    target_tier = args.tier.lower()
+    output_json = getattr(args, "json", False)
+
+    if target_tier not in TIERS:
+        print(f"✗ Unknown tier '{target_tier}'")
+        print(f"  Available tiers: {', '.join(TIER_ORDER)}")
+        sys.exit(1)
+
+    creds = _load_credentials()
+    current = _api_request("GET", "/api/v1/subscriptions/me", creds)
+    current_tier = current.get("tier", "free")
+
+    cur_idx = TIER_ORDER.index(current_tier) if current_tier in TIER_ORDER else 0
+    tgt_idx = TIER_ORDER.index(target_tier)
+    if tgt_idx >= cur_idx:
+        print(f"✗ {target_tier.title()} is not a downgrade from {current_tier.title()}.")
+        if tgt_idx > cur_idx:
+            print(f"  Use `kernle sub upgrade {target_tier}` instead.")
+        sys.exit(1)
+
+    tgt_info = TIERS[target_tier]
+    renews_at = current.get("renews_at")
+
+    if not output_json:
+        print()
+        print(f"  Downgrade: {_tier_label(current_tier)} → {_tier_label(target_tier)}")
+        print()
+        if renews_at:
+            print(f"  ⏳ Takes effect: {_format_date(renews_at)} ({_relative_time(renews_at)})")
+            print("     You keep current tier benefits until then.")
+        else:
+            print("  ⏳ Takes effect immediately (no active billing period).")
+
+        # Warn about potential data loss
+        storage_used = current.get("storage_used", 0)
+        tgt_limit = tgt_info.get("storage_bytes") or 0
+        if tgt_limit and storage_used > tgt_limit:
+            print()
+            print(f"  ⚠ WARNING: You're using {_format_bytes(storage_used)} but "
+                  f"{tgt_info['name']} only allows {tgt_info['storage']}.")
+            print("    You may need to clean up data before the downgrade takes effect.")
+
+        stacks_used = current.get("agents_used", current.get("stacks_used", 0))
+        tgt_stacks = tgt_info.get("stacks") or 0
+        if tgt_stacks and stacks_used > tgt_stacks:
+            print(f"  ⚠ WARNING: You have {stacks_used} active stacks but "
+                  f"{tgt_info['name']} allows {tgt_stacks}.")
+        print()
+
+    yes_flag = getattr(args, "yes", False)
+    if not yes_flag and not output_json:
+        try:
+            answer = input(f"  Confirm downgrade to {tgt_info['name']}? [y/N] ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print("\n  Aborted.")
+            sys.exit(0)
+        if answer not in ("y", "yes"):
+            print("  Aborted.")
+            sys.exit(0)
+
+    result = _api_request("POST", "/api/v1/subscriptions/downgrade", creds, body={"tier": target_tier})
+
+    if output_json:
+        print(json.dumps(result, indent=2))
+        return
+
+    effective = result.get("effective_at") or result.get("subscription", {}).get("renews_at")
+    print(f"  ✓ Downgrade to {_tier_label(target_tier)} scheduled.")
+    if effective:
+        print(f"  📅 Effective: {_format_date(effective)}")
+    print()
+
+
+def _cmd_cancel(args: "argparse.Namespace", k: "Kernle") -> None:
+    """Cancel auto-renewal with confirmation."""
+    output_json = getattr(args, "json", False)
+    creds = _load_credentials()
+
+    current = _api_request("GET", "/api/v1/subscriptions/me", creds)
+    current_tier = current.get("tier", "free")
+    renews_at = current.get("renews_at")
+    auto_renew = current.get("auto_renew", False)
+
+    if current_tier == "free":
+        print("  You're on the Free tier — nothing to cancel.")
+        sys.exit(0)
+
+    if not auto_renew:
+        print("  Auto-renewal is already disabled.")
+        if renews_at:
+            print(f"  Your {_tier_label(current_tier)} tier expires {_format_date(renews_at)}.")
+        sys.exit(0)
+
+    if not output_json:
+        print()
+        print(f"  Cancel auto-renewal for {_tier_label(current_tier)}")
+        print()
+        if renews_at:
+            print(f"  Your current period runs until {_format_date(renews_at)}.")
+            print("  You'll keep all benefits until then.")
+            print("  After that, you'll be downgraded to the Free tier.")
+        print()
+
+    yes_flag = getattr(args, "yes", False)
+    if not yes_flag and not output_json:
+        try:
+            answer = input("  Confirm cancellation? [y/N] ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print("\n  Aborted.")
+            sys.exit(0)
+        if answer not in ("y", "yes"):
+            print("  Aborted.")
+            sys.exit(0)
+
+    result = _api_request("POST", "/api/v1/subscriptions/cancel", creds)
+
+    if output_json:
+        print(json.dumps(result, indent=2))
+        return
+
+    print("  ✓ Auto-renewal cancelled.")
+    expires = result.get("expires_at") or renews_at
+    if expires:
+        print(f"  📅 Benefits until: {_format_date(expires)}")
+    print("  💡 You can re-subscribe anytime with: kernle sub upgrade <tier>")
+    print()
+
+
+def _cmd_usage(args: "argparse.Namespace", k: "Kernle") -> None:
+    """Show detailed usage for the current billing period."""
+    output_json = getattr(args, "json", False)
+    creds = _load_credentials()
+    data = _api_request("GET", "/api/v1/usage/me", creds)
+
+    if output_json:
+        print(json.dumps(data, indent=2))
+        return
+
+    period = data.get("period", "—")
+    storage_used = data.get("storage_used", 0)
+    storage_limit = data.get("storage_limit", 0)
+    sync_count = data.get("sync_count", 0)
+    last_sync = data.get("last_sync")
+    agents_used = data.get("agents_used", data.get("agents_count", 0))
+    agents_limit = data.get("agents_limit", 0)
+
+    print()
+    print(f"  Usage — Period: {period}")
+    print("  " + "═" * 40)
+    print()
+
+    # Storage
+    print("  📦 Storage")
+    if storage_limit > 0:
+        print(f"     {_format_bytes(storage_used)} / {_format_bytes(storage_limit)}")
+        print(f"     {_progress_bar(storage_used, storage_limit)}")
+    else:
+        print(f"     {_format_bytes(storage_used)} (unlimited)")
+    print()
+
+    # Stacks / Agents
+    print("  🗂  Syncing Stacks")
+    if agents_limit > 0:
+        print(f"     {agents_used} / {agents_limit}")
+        print(f"     {_progress_bar(agents_used, agents_limit)}")
+    else:
+        print(f"     {agents_used} (unlimited)")
+    print()
+
+    # Sync activity
+    print("  🔄 Sync Activity")
+    print(f"     Total syncs this period: {sync_count:,}")
+    if last_sync:
+        print(f"     Last sync: {_format_date(last_sync)} ({_relative_time(last_sync)})")
+    else:
+        print("     Last sync: never")
+    print()
+
+    # Overflow estimate (if applicable)
+    overflow_agents = data.get("overflow_agents", 0)
+    overflow_storage = data.get("overflow_storage_gb", 0)
+    if overflow_agents > 0 or overflow_storage > 0:
+        print("  💸 Overflow (estimated)")
+        if overflow_agents > 0:
+            cost_per = data.get("overflow_agent_cost", 1.00)
+            print(f"     +{overflow_agents} extra stacks × ${cost_per:.2f} = ${overflow_agents * cost_per:.2f}")
+        if overflow_storage > 0:
+            scost = data.get("overflow_storage_cost", 0.50)
+            print(f"     +{overflow_storage:.2f} GB extra × ${scost:.2f} = ${overflow_storage * scost:.2f}")
+        print()
+
+
+def _cmd_payments(args: "argparse.Namespace", k: "Kernle") -> None:
+    """List payment history."""
+    output_json = getattr(args, "json", False)
+    limit = getattr(args, "limit", 20)
+    creds = _load_credentials()
+    data = _api_request("GET", f"/api/v1/subscriptions/payments?limit={limit}", creds)
+
+    payments = data if isinstance(data, list) else data.get("payments", [])
+
+    if output_json:
+        print(json.dumps(payments, indent=2))
+        return
+
+    if not payments:
+        print("  No payment history yet.")
+        print("  💡 Upgrade with: kernle sub upgrade core")
+        return
+
+    print()
+    print("  Payment History")
+    print("  " + "═" * 60)
+    print()
+
+    for p in payments:
+        status = p.get("status", "unknown")
+        amount = p.get("amount", "0")
+        currency = p.get("currency", "USDC")
+        tx_hash = p.get("tx_hash", "")
+        period_start = p.get("period_start", "")
+        period_end = p.get("period_end", "")
+        created = p.get("created_at", "")
+        confirmed = p.get("confirmed_at")
+
+        status_icons = {
+            "confirmed": "✓",
+            "pending": "⏳",
+            "failed": "✗",
+            "refunded": "↩",
+        }
+        icon = status_icons.get(status, "?")
+
+        print(f"  {icon} ${float(amount):.2f} {currency}  —  {status}")
+        if period_start and period_end:
+            ps = period_start[:10]
+            pe = period_end[:10]
+            print(f"    Period: {ps} → {pe}")
+        if tx_hash:
+            # Shorten tx hash for display
+            short_tx = f"{tx_hash[:10]}…{tx_hash[-6:]}" if len(tx_hash) > 20 else tx_hash
+            print(f"    Tx: {short_tx}")
+        if confirmed:
+            print(f"    Confirmed: {_format_date(confirmed)}")
+        elif created:
+            print(f"    Created: {_format_date(created)}")
+        print()
+
+
+# ── Main dispatcher ──────────────────────────────────────────────────────────
+
+
+def cmd_subscription(args: "argparse.Namespace", k: "Kernle") -> None:
+    """Main dispatcher for subscription subcommands."""
+    action = getattr(args, "sub_action", None)
+
+    if action == "tier":
+        _cmd_tier(args, k)
+    elif action == "upgrade":
+        _cmd_upgrade(args, k)
+    elif action == "downgrade":
+        _cmd_downgrade(args, k)
+    elif action == "cancel":
+        _cmd_cancel(args, k)
+    elif action == "usage":
+        _cmd_usage(args, k)
+    elif action == "payments":
+        _cmd_payments(args, k)
+    else:
+        # Default: show tier info
+        _cmd_tier(args, k)


### PR DESCRIPTION
## Cloud Subscription System

Implements the self-service subscription management from `docs/CLOUD_PAYMENTS_SPEC.md`.

### What's in this PR

**2,601 new lines** across 10 files:

| Component | Files | Description |
|-----------|-------|-------------|
| **Models** | `subscriptions/models.py` | Tier configs, Decimal pricing, Pydantic models |
| **Service** | `subscriptions/service.py` | Full lifecycle: create, upgrade, downgrade, cancel, renew, quota |
| **API** | `routes/subscriptions.py` | 8 FastAPI endpoints with auth, rate limiting |
| **CLI** | `commands/subscription.py` | `kernle sub tier/upgrade/downgrade/cancel/usage/payments` |
| **Migration** | `024_subscriptions.sql` | 4 new tables + RLS + indexes |

### Tier Structure
| Tier | Price | Storage | Stacks | Overflow |
|------|-------|---------|--------|----------|
| Free | $0 | 10MB | 1 | ❌ |
| Core | $5/mo | 100MB | 3 | $1.50/stack |
| Pro | $15/mo | 1GB | 10 | $1.00/stack |
| Enterprise | Custom | Unlimited | Unlimited | — |

### Key Design Decisions
- **Decimal everywhere** — zero floats for money
- **No sync frequency limits** — quotas on storage + stacks only (per spec)
- **Two-phase upgrade**: API returns payment instructions → user sends USDC on-chain → confirms tx_hash
- **7-day grace period** on failed renewals before downgrade to free
- **Overflow on paid tiers** — soft limits with billing, not hard blocks
- **Payment verification is separate** — Claire building the on-chain USDC verifier module

### Integration Points
- Backend registers router in `main.py` at `/api/v1`
- CLI adds `kernle sub` / `kernle subscription` command
- Migration creates tables + backfills free subs for existing users
- Service accepts `confirm_payment()` call from external verifier

### What's NOT in this PR (separate concerns)
- On-chain USDC payment verification (Claire's PR)
- Treasury multisig address (placeholder `0x000...`)
- Reverse tithe split logic
- Auto-renewal cron job

All 1228 existing tests pass.