### PR TITLE
feat: subscription renewal cron job + CLI

### DIFF
--- a/backend/app/subscriptions/__init__.py
+++ b/backend/app/subscriptions/__init__.py
@@ -32,6 +32,9 @@ from .service import (
     cancel_subscription,
     reactivate_subscription,
     list_payments,
+    # Renewal processing (for cron)
+    process_pending_renewals,
+    get_expiring_subscriptions,
 )
 
 __all__ = [
@@ -69,4 +72,7 @@ __all__ = [
     "cancel_subscription",
     "reactivate_subscription",
     "list_payments",
+    # Renewal processing
+    "process_pending_renewals",
+    "get_expiring_subscriptions",
 ]

--- a/kernle/cli/__main__.py
+++ b/kernle/cli/__main__.py
@@ -3356,6 +3356,18 @@ def main():
     sub_payments.add_argument("--limit", "-l", type=int, default=20, help="Max payments to show")
     sub_payments.add_argument("--json", "-j", action="store_true", help="Output as JSON")
 
+    # kernle sub renewals [--dry-run] (admin: process pending renewals via API)
+    sub_renewals = sub_sub.add_parser(
+        "renewals",
+        help="Process pending renewals (admin/cron)",
+    )
+    sub_renewals.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview changes without applying them",
+    )
+    sub_renewals.add_argument("--json", "-j", action="store_true", help="Output as JSON")
+
     # agent - agent management
     p_agent = subparsers.add_parser("agent", help="Agent management (list, delete)")
     agent_sub = p_agent.add_subparsers(dest="agent_action", required=True)


### PR DESCRIPTION
## Summary

Automated subscription renewal processing for the cloud payment system.

## Service Layer

```python
# Process all subscriptions needing attention
result = await process_pending_renewals(db, dry_run=False)
# Returns: renewed, entered_grace, expired, upcoming, errors

# Get subscriptions expiring within 7 days (for reminders)
expiring = await get_expiring_subscriptions(db, within_days=7)
```

## API Endpoints

| Endpoint | Method | Description |
|----------|--------|-------------|
| `/cron/process-renewals` | POST | Process renewals (scheduler calls this) |
| `/cron/expiring` | GET | Get expiring subscriptions |

Both protected by `X-Cron-Secret` header (set `CRON_SECRET` env var).

## CLI

```bash
# Preview what would happen
kernle sub renewals --dry-run

# Actually process renewals
kernle sub renewals

# JSON output for scripts
kernle sub renewals --json
```

## Scheduler Integration

Call the cron endpoint periodically (e.g., hourly) from:
- Railway cron
- GitHub Actions scheduled workflow
- Any HTTP scheduler

```bash
curl -X POST \
  -H "X-Cron-Secret: $CRON_SECRET" \
  https://api.kernle.ai/api/v1/subscriptions/cron/process-renewals
```

## Tests

All 16 subscription integration tests pass.

---
*Completes the auto-renewal piece for cloud subscriptions (with #48 payment verifier + #49 subscription system)*