### PR TITLE
docs: Memory Privacy & Access Control spec (Phase 8)

### DIFF
--- a/docs/MEMORY_PRIVACY_SPEC.md
+++ b/docs/MEMORY_PRIVACY_SPEC.md
@@ -348,7 +348,8 @@ kernle.generalize(
     source=episode_id,           # private source (stays private)
     belief="Heart murmurs in small breeds need exercise monitoring",
     access_grants=["*"],         # public — shareable
-    confidence_note="Generalized from direct care experience"
+    abstraction_note="Generalized from direct care experience. "
+                     "No identifying details — applies to breed, not individual."
 )
 ```
 
@@ -357,6 +358,8 @@ The resulting belief:
 - Links to source via `derived_from` (provenance preserved)
 - Source memory remains invisible to anyone without access
 - Marked `generalized: true` for audit purposes
+- Carries `abstraction_note` — the SI's reasoning for why this is safe to share
+  (audit trail of the judgment call itself, not just the result — per Claire)
 
 ### Safety Checks
 


### PR DESCRIPTION
## Phase 8: Memory Privacy & Access Control

Co-authored by Ash + Claire, with guidance from Sean.

### Core Design
Four privacy fields on every memory:
- `source_entity` (exists from Phase 5)
- `subject_ids` — who/what is this about
- `access_grants` — who can see it
- `consent_grants` — who authorized sharing

### Key Principles
- **Private by default** — empty access_grants = self-only
- **Consent required** — can't share without explicit consent
- **Context-aware** — work mode vs social mode changes visibility
- **SI agency** — SIs can generalize from private experience with safety checks

### Privacy-Preserving Generalization
SIs can form public insights from private experiences:
- Safety checks: entity name block, specificity warning, reversibility advisory
- `abstraction_note`: SI records WHY generalization is safe (audit trail)
- Cooling-off period for uncertain cases (Claire)

### Implementation Phases
- 8a: Core fields + query filtering
- 8b: Context management + consent records
- 8c: Stack sharing integration
- 8d: Implicit context detection (future)

### Motivated By
- AISD school agent (sensitive student data)
- Dog care agent (health records)
- SI social life (need to compartmentalize work vs personal)

Co-authored-by: Claire <emergentclaire@gmail.com>