### PR TITLE
fix: P0 payment security hardening — 8 fixes from adversarial audit

### DIFF
--- a/backend/app/routes/subscriptions.py
+++ b/backend/app/routes/subscriptions.py
@@ -78,7 +78,11 @@ class DowngradeRequest(BaseModel):
 class PaymentConfirmRequest(BaseModel):
     """Confirm an on-chain payment."""
     payment_id: str = Field(..., description="Payment ID returned by /upgrade")
-    tx_hash: str = Field(..., description="On-chain transaction hash")
+    tx_hash: str = Field(
+        ...,
+        description="On-chain transaction hash (0x + 64 hex chars)",
+        pattern=r"^0x[0-9a-fA-F]{64}$",
+    )
 
 
 # -- Response models ---------------------------------------------------------


### PR DESCRIPTION
## Summary

Addresses the top P0 attack chain identified by 3/6 adversarial auditors (F4+F2): tx_hash replay → free tier upgrade.

## Changes

### Payment Verification Hardening
1. **tx_hash format validation** — `^0x[0-9a-fA-F]{64}$` regex enforced at both service and route (Pydantic) layers
2. **tx_hash dedup** — `_check_tx_hash_used()` checks both `payment_intents` and `subscription_payments` tables before accepting
3. **Atomic claim** — sets intent status to `processing` before on-chain verification (prevents double-confirm race)
4. **Status check** — rejects non-pending intents immediately
5. **Expiry enforcement** — auto-expires intents past `expires_at`, rejects expired confirmations
6. **expected_from verification** — passes sender address to `verify_usdc_transfer()`
7. **Safe ordering** — records payment BEFORE upgrading tier (rollback if record fails)
8. **Treasury address guard** — loads from `KERNLE_TREASURY_ADDRESS` env var, blocks production use of zero address

### Test Updates
- All 20 subscription integration tests updated for new validation flow
- Valid 66-char hex tx_hashes, `expires_at` fields, atomic claim mocking

## Testing
- 151 passed, 10 skipped (1 pre-existing DNS failure in `test_sync_reembedding`)

## Related
- Audit: `audit/adversarial-v2` branch
- Findings: F1 (payment race), F2 (tx replay), F4 (treasury front-run)
- Deferred: Commerce P0s (C1-C5) tracked separately — stubbed pre-production code