### PR TITLE
chore: bump version to 0.2.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kernle"
-version = "0.2.2"
+version = "0.2.3"
 description = "Stratified memory for synthetic intelligences"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Changes
- Bump version to 0.2.3

## Includes (already merged)
- PR #59: export-cache command for MEMORY.md bootstrap cache
- PR #60: export-cache audit P2 hardening (input validation, test isolation)

## Tests
- 13/13 export-cache tests passing
- Ready for PyPI release