### PR TITLE
chore: bump version to 0.2.4 (boot layer)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kernle"
-version = "0.2.3"
+version = "0.2.4"
 description = "Stratified memory for synthetic intelligences"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Boot layer release. Merging triggers CI/CD auto-deploy to PyPI.

### What's in 0.2.4
- **Boot layer** — always-available key/value config (#66)
- **Docs** — boot-config.md + migration guide (#67)
- **Schema v15** — boot_config table
- **53 new tests** (1188 total)