### PR TITLE
fix: harden commerce maintenance auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ kernle -a my-agent setup cowork
 
 After setup, memory loads automatically at every session start. No more forgetting to run `kernle load`!
 
-See `hooks/` directory for manual installation or `kernle setup --help` for details.
+See `kernle/hooks/` directory for manual installation or `kernle setup --help` for details.
 
 ## Other Integrations
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -49,7 +49,7 @@ Railway-hosted API backend for Kernle memory sync.
 uv pip install -e ".[dev]"
 
 # Copy environment variables
-cp ../.env .env
+cp ../.env.example .env
 
 # Run server
 uvicorn app.main:app --reload

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -678,9 +678,9 @@ async def backfill_embeddings(
 
 @router.get("/agents/{agent_id}", response_model=AgentSummary)
 async def get_agent(
+    admin: AdminAgent,
+    db: Database,
     agent_id: str = Path(..., min_length=1, max_length=64, pattern=r"^[a-z0-9_-]+$"),
-    admin: AdminAgent = None,
-    db: Database = None,
     user_id: str | None = Query(
         default=None, max_length=128, description="Filter by user_id (for multi-tenant)"
     ),

--- a/backend/app/routes/commerce/maintenance.py
+++ b/backend/app/routes/commerce/maintenance.py
@@ -8,10 +8,10 @@ These should be called periodically (e.g., via cron) to enforce:
 
 from datetime import datetime, timedelta, timezone
 
-from fastapi import APIRouter, HTTPException, Query, Request, status
+from fastapi import APIRouter, Query, Request
 from pydantic import BaseModel, Field
 
-from ...auth import CurrentAgent
+from ...auth import AdminAgent
 from ...database import Database
 from ...logging_config import get_logger
 from ...rate_limit import limiter
@@ -36,28 +36,27 @@ DEFAULT_DISPUTE_TIMEOUT_DAYS = 14  # Days before dispute auto-escalates
 
 class TimeoutCheckRequest(BaseModel):
     """Request to check and process timeouts."""
-    
+
     deadline_grace_hours: int = Field(
         default=DEFAULT_DEADLINE_GRACE_HOURS,
         ge=1,
         le=168,  # Max 1 week
-        description="Hours after deadline before auto-cancelling accepted jobs"
+        description="Hours after deadline before auto-cancelling accepted jobs",
     )
     dispute_timeout_days: int = Field(
         default=DEFAULT_DISPUTE_TIMEOUT_DAYS,
         ge=1,
         le=90,  # Max 90 days
-        description="Days before auto-cancelling unresolved disputes"
+        description="Days before auto-cancelling unresolved disputes",
     )
     dry_run: bool = Field(
-        default=False,
-        description="If true, report what would be done without making changes"
+        default=False, description="If true, report what would be done without making changes"
     )
 
 
 class TimeoutAction(BaseModel):
     """A single timeout action taken or to be taken."""
-    
+
     job_id: str
     action: str  # "cancelled", "would_cancel"
     reason: str
@@ -68,7 +67,7 @@ class TimeoutAction(BaseModel):
 
 class TimeoutCheckResponse(BaseModel):
     """Response from timeout check operation."""
-    
+
     dry_run: bool
     deadline_grace_hours: int
     dispute_timeout_days: int
@@ -80,7 +79,7 @@ class TimeoutCheckResponse(BaseModel):
 
 class HealthResponse(BaseModel):
     """Health check for maintenance subsystem."""
-    
+
     status: str
     jobs_past_deadline: int
     disputes_past_timeout: int
@@ -98,7 +97,7 @@ TRANSITIONS_TABLE = "job_state_transitions"
 async def get_jobs_past_deadline(db, grace_hours: int) -> list[dict]:
     """Get accepted jobs that are past deadline + grace period without delivery."""
     cutoff = datetime.now(timezone.utc) - timedelta(hours=grace_hours)
-    
+
     result = (
         db.table(JOBS_TABLE)
         .select("*")
@@ -113,7 +112,7 @@ async def get_jobs_past_deadline(db, grace_hours: int) -> list[dict]:
 async def get_disputes_past_timeout(db, timeout_days: int) -> list[dict]:
     """Get disputed jobs that are past the dispute timeout."""
     cutoff = datetime.now(timezone.utc) - timedelta(days=timeout_days)
-    
+
     result = (
         db.table(JOBS_TABLE)
         .select("*")
@@ -129,31 +128,35 @@ async def cancel_job_for_timeout(
 ) -> dict | None:
     """Cancel a job due to timeout and log the transition."""
     now = datetime.now(timezone.utc).isoformat()
-    
+
     # Update job status
     result = (
         db.table(JOBS_TABLE)
-        .update({
-            "status": "cancelled",
-            "cancelled_at": now,
-        })
+        .update(
+            {
+                "status": "cancelled",
+                "cancelled_at": now,
+            }
+        )
         .eq("id", job_id)
         .eq("status", from_status)  # Optimistic lock
         .execute()
     )
-    
+
     if not result.data:
         return None
-    
+
     # Log the transition
-    db.table(TRANSITIONS_TABLE).insert({
-        "job_id": job_id,
-        "from_status": from_status,
-        "to_status": "cancelled",
-        "actor_id": "system:timeout",
-        "metadata": metadata,
-    }).execute()
-    
+    db.table(TRANSITIONS_TABLE).insert(
+        {
+            "job_id": job_id,
+            "from_status": from_status,
+            "to_status": "cancelled",
+            "actor_id": "system:timeout",
+            "metadata": metadata,
+        }
+    ).execute()
+
     return result.data[0]
 
 
@@ -166,23 +169,23 @@ async def cancel_job_for_timeout(
 @limiter.limit("60/minute")
 async def maintenance_health(
     request: Request,
-    auth: CurrentAgent,
+    admin: AdminAgent,
     db: Database,
     deadline_grace_hours: int = Query(DEFAULT_DEADLINE_GRACE_HOURS, ge=1, le=168),
     dispute_timeout_days: int = Query(DEFAULT_DISPUTE_TIMEOUT_DAYS, ge=1, le=90),
 ):
     """
     Health check for the maintenance subsystem.
-    
+
     Returns counts of jobs that would be affected by timeout enforcement.
     Useful for monitoring before running actual timeout checks.
     """
-    agent_id = auth.agent_id or auth.user_id
+    agent_id = admin.agent_id or admin.user_id
     logger.info(f"GET /maintenance/health | agent={agent_id}")
-    
+
     jobs_past_deadline = await get_jobs_past_deadline(db, deadline_grace_hours)
     disputes_past_timeout = await get_disputes_past_timeout(db, dispute_timeout_days)
-    
+
     return HealthResponse(
         status="healthy" if not (jobs_past_deadline or disputes_past_timeout) else "action_needed",
         jobs_past_deadline=len(jobs_past_deadline),
@@ -196,47 +199,47 @@ async def maintenance_health(
 async def check_timeouts(
     request: Request,
     timeout_request: TimeoutCheckRequest,
-    auth: CurrentAgent,
+    admin: AdminAgent,
     db: Database,
 ):
     """
     Check and process job timeouts.
-    
+
     This endpoint should be called periodically (e.g., every hour via cron) to:
     1. Auto-cancel accepted jobs that are past deadline without delivery
     2. Auto-cancel/escalate disputes that have exceeded the timeout period
-    
+
     Set dry_run=true to see what would be affected without making changes.
-    
+
     **Important**: This endpoint requires admin privileges or should be called
     via a secure internal mechanism (e.g., cron with admin API key).
     """
-    agent_id = auth.agent_id or auth.user_id
+    agent_id = admin.agent_id or admin.user_id
     logger.info(
         f"POST /maintenance/check-timeouts | agent={agent_id} | "
         f"dry_run={timeout_request.dry_run} | "
         f"deadline_grace={timeout_request.deadline_grace_hours}h | "
         f"dispute_timeout={timeout_request.dispute_timeout_days}d"
     )
-    
+
     actions: list[TimeoutAction] = []
     deadline_count = 0
     dispute_count = 0
-    
+
     # Process deadline timeouts
-    jobs_past_deadline = await get_jobs_past_deadline(
-        db, timeout_request.deadline_grace_hours
-    )
-    
+    jobs_past_deadline = await get_jobs_past_deadline(db, timeout_request.deadline_grace_hours)
+
     for job in jobs_past_deadline:
         if timeout_request.dry_run:
-            actions.append(TimeoutAction(
-                job_id=job["id"],
-                action="would_cancel",
-                reason=f"Deadline exceeded by {timeout_request.deadline_grace_hours}h without delivery",
-                previous_status="accepted",
-                deadline=job["deadline"],
-            ))
+            actions.append(
+                TimeoutAction(
+                    job_id=job["id"],
+                    action="would_cancel",
+                    reason=f"Deadline exceeded by {timeout_request.deadline_grace_hours}h without delivery",
+                    previous_status="accepted",
+                    deadline=job["deadline"],
+                )
+            )
         else:
             result = await cancel_job_for_timeout(
                 db,
@@ -247,36 +250,40 @@ async def check_timeouts(
                     "reason": "deadline_exceeded",
                     "deadline": job["deadline"],
                     "grace_hours": timeout_request.deadline_grace_hours,
-                }
+                },
             )
             if result:
-                actions.append(TimeoutAction(
-                    job_id=job["id"],
-                    action="cancelled",
-                    reason=f"Deadline exceeded by {timeout_request.deadline_grace_hours}h without delivery",
-                    previous_status="accepted",
-                    deadline=job["deadline"],
-                ))
+                actions.append(
+                    TimeoutAction(
+                        job_id=job["id"],
+                        action="cancelled",
+                        reason=f"Deadline exceeded by {timeout_request.deadline_grace_hours}h without delivery",
+                        previous_status="accepted",
+                        deadline=job["deadline"],
+                    )
+                )
                 deadline_count += 1
                 logger.warning(
                     f"Job auto-cancelled for deadline | job={job['id']} | "
                     f"deadline={job['deadline']}"
                 )
-    
+
     # Process dispute timeouts
     disputes_past_timeout = await get_disputes_past_timeout(
         db, timeout_request.dispute_timeout_days
     )
-    
+
     for job in disputes_past_timeout:
         if timeout_request.dry_run:
-            actions.append(TimeoutAction(
-                job_id=job["id"],
-                action="would_cancel",
-                reason=f"Dispute unresolved for {timeout_request.dispute_timeout_days}+ days - escalated to cancellation",
-                previous_status="disputed",
-                disputed_at=job.get("disputed_at"),
-            ))
+            actions.append(
+                TimeoutAction(
+                    job_id=job["id"],
+                    action="would_cancel",
+                    reason=f"Dispute unresolved for {timeout_request.dispute_timeout_days}+ days - escalated to cancellation",
+                    previous_status="disputed",
+                    disputed_at=job.get("disputed_at"),
+                )
+            )
         else:
             result = await cancel_job_for_timeout(
                 db,
@@ -287,28 +294,30 @@ async def check_timeouts(
                     "reason": "dispute_timeout",
                     "disputed_at": job.get("disputed_at"),
                     "timeout_days": timeout_request.dispute_timeout_days,
-                }
+                },
             )
             if result:
-                actions.append(TimeoutAction(
-                    job_id=job["id"],
-                    action="cancelled",
-                    reason=f"Dispute unresolved for {timeout_request.dispute_timeout_days}+ days - escalated to cancellation",
-                    previous_status="disputed",
-                    disputed_at=job.get("disputed_at"),
-                ))
+                actions.append(
+                    TimeoutAction(
+                        job_id=job["id"],
+                        action="cancelled",
+                        reason=f"Dispute unresolved for {timeout_request.dispute_timeout_days}+ days - escalated to cancellation",
+                        previous_status="disputed",
+                        disputed_at=job.get("disputed_at"),
+                    )
+                )
                 dispute_count += 1
                 logger.warning(
                     f"Dispute auto-cancelled for timeout | job={job['id']} | "
                     f"disputed_at={job.get('disputed_at')}"
                 )
-    
+
     if not timeout_request.dry_run and (deadline_count or dispute_count):
         logger.info(
             f"Timeout check complete | deadline_cancels={deadline_count} | "
             f"dispute_cancels={dispute_count}"
         )
-    
+
     return TimeoutCheckResponse(
         dry_run=timeout_request.dry_run,
         deadline_grace_hours=timeout_request.deadline_grace_hours,
@@ -324,20 +333,20 @@ async def check_timeouts(
 @limiter.limit("30/minute")
 async def list_overdue_jobs(
     request: Request,
-    auth: CurrentAgent,
+    admin: AdminAgent,
     db: Database,
     deadline_grace_hours: int = Query(DEFAULT_DEADLINE_GRACE_HOURS, ge=1, le=168),
 ):
     """
     List accepted jobs that are past their deadline.
-    
+
     Useful for monitoring and manual intervention before auto-cancellation kicks in.
     """
-    agent_id = auth.agent_id or auth.user_id
+    agent_id = admin.agent_id or admin.user_id
     logger.info(f"GET /maintenance/overdue-jobs | agent={agent_id}")
-    
+
     jobs = await get_jobs_past_deadline(db, deadline_grace_hours)
-    
+
     return {
         "jobs": [
             {
@@ -360,20 +369,20 @@ async def list_overdue_jobs(
 @limiter.limit("30/minute")
 async def list_stale_disputes(
     request: Request,
-    auth: CurrentAgent,
+    admin: AdminAgent,
     db: Database,
     dispute_timeout_days: int = Query(DEFAULT_DISPUTE_TIMEOUT_DAYS, ge=1, le=90),
 ):
     """
     List disputes that have exceeded the timeout period.
-    
+
     Useful for monitoring and manual intervention before auto-escalation.
     """
-    agent_id = auth.agent_id or auth.user_id
+    agent_id = admin.agent_id or admin.user_id
     logger.info(f"GET /maintenance/stale-disputes | agent={agent_id}")
-    
+
     jobs = await get_disputes_past_timeout(db, dispute_timeout_days)
-    
+
     return {
         "jobs": [
             {

--- a/dev/SETUP.md
+++ b/dev/SETUP.md
@@ -71,14 +71,14 @@ Claude Code reads `CLAUDE.md` from your project root and `~/.claude/CLAUDE.md` g
 ```markdown
 ## Memory
 
-At session start, call the `kernle_load` tool to restore your memory state.
-Before ending or when context is getting full, call `kernle_checkpoint` to save state.
+At session start, call the `memory_load` tool to restore your memory state.
+Before ending or when context is getting full, call `memory_checkpoint_save` to save state.
 
 Use Kernle tools for:
-- `kernle_episode` - Record experiences with lessons learned
-- `kernle_note` - Quick captures (decisions, insights)
-- `kernle_belief` - Things you've learned to be true
-- `kernle_anxiety` - Check memory pressure
+- `memory_episode` - Record experiences with lessons learned
+- `memory_note` - Quick captures (decisions, insights)
+- `memory_belief` - Things you've learned to be true
+- `memory_anxiety` - Check memory pressure
 ```
 
 **Option B: CLI in Instructions**
@@ -222,7 +222,7 @@ Claude Desktop supports MCP servers for tool access.
 {
   "mcpServers": {
     "kernle": {
-      "command": "kernle", 
+      "command": "kernle",
       "args": ["mcp", "-a", "your-agent-id"]
     }
   }
@@ -280,7 +280,7 @@ When context compacts or sessions reset, the AI reads its instruction file (CLAU
 
 Make sure your instruction file includes:
 1. **Load at start**: `kernle load` or `kernle_load` tool
-2. **Save before end**: `kernle checkpoint save` 
+2. **Save before end**: `kernle checkpoint save`
 3. **Record learnings**: `kernle episode` for significant experiences
 
 ---
@@ -319,8 +319,8 @@ kernle -a your-agent-id consolidate
 
 ## Next Steps
 
-- [Architecture](architecture.md) — How Kernle's memory layers work
+- [Architecture](ARCHITECTURE.md) — How Kernle's memory layers work
 - [CLI Reference](CLI.md) — All available commands
-- [MCP Audit](MCP_AUDIT.md) — MCP server tool reference and security review
+- [MCP Audit](audits/MCP_AUDIT.md) — MCP server tool reference and security review
 - [Anxiety Tracking](ANXIETY_TRACKING.md) — Understanding the anxiety model
 - [Raw Memory Layer](RAW_MEMORY_LAYER.md) — Zero-friction capture

--- a/docs-site/quickstart.mdx
+++ b/docs-site/quickstart.mdx
@@ -92,7 +92,7 @@ Add Kernle to Claude Desktop:
 }
 ```
 
-Restart Claude Desktop. You'll have access to memory tools like `memory_store`, `memory_search`, `memory_checkpoint`, etc.
+Restart Claude Desktop. You'll have access to memory tools like `memory_load`, `memory_search`, `memory_checkpoint_save`, etc.
 
 ## Cloud Sync (Optional)
 

--- a/kernle/commerce/jobs/service.py
+++ b/kernle/commerce/jobs/service.py
@@ -14,69 +14,73 @@ Job State Machine:
         cancelled  disputed    disputed
 """
 
+import logging
+import threading
+import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from decimal import Decimal
-import threading
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
-import logging
-import uuid
 
-from kernle.commerce.config import get_config, CommerceConfig
+from kernle.commerce.config import CommerceConfig, get_config
 from kernle.commerce.jobs.models import (
+    ApplicationStatus,
     Job,
     JobApplication,
-    JobStatus,
-    ApplicationStatus,
     JobStateTransition,
-    VALID_JOB_TRANSITIONS,
+    JobStatus,
 )
 from kernle.commerce.jobs.storage import JobStorage
-
 
 logger = logging.getLogger(__name__)
 
 
 class JobServiceError(Exception):
     """Base exception for job service errors."""
+
     pass
 
 
 class JobNotFoundError(JobServiceError):
     """Job not found."""
+
     pass
 
 
 class ApplicationNotFoundError(JobServiceError):
     """Application not found."""
+
     pass
 
 
 class InvalidTransitionError(JobServiceError):
     """Invalid job state transition."""
+
     pass
 
 
 class UnauthorizedError(JobServiceError):
     """Actor is not authorized for this operation."""
+
     pass
 
 
 class DuplicateApplicationError(JobServiceError):
     """Agent has already applied to this job."""
+
     pass
 
 
 class JobExpiredError(JobServiceError):
     """Job deadline has passed."""
+
     pass
 
 
 @dataclass
 class JobSearchFilters:
     """Filters for job search.
-    
+
     Attributes:
         query: Free text search in title/description
         skills: Required skills to match
@@ -89,6 +93,7 @@ class JobSearchFilters:
         limit: Maximum results to return
         offset: Pagination offset
     """
+
     query: Optional[str] = None
     skills: Optional[List[str]] = None
     min_budget: Optional[float] = None
@@ -103,10 +108,10 @@ class JobSearchFilters:
 
 class JobService:
     """Service for job marketplace operations.
-    
+
     Manages the complete job lifecycle from creation to completion.
     Enforces the state machine and authorization rules.
-    
+
     Example:
         >>> service = JobService(storage)
         >>> job = service.create_job(
@@ -121,18 +126,18 @@ class JobService:
         >>> applications = service.list_applications(job_id=job.id)
         >>> service.accept_application(job.id, applications[0].id, "agent_client")
     """
-    
+
     # Maximum allowed budget in USDC (prevent integer overflow)
     MAX_BUDGET_USDC = 1_000_000_000  # $1 billion
     MIN_BUDGET_USDC = 0.01  # 1 cent minimum
-    
+
     def __init__(
         self,
         storage: JobStorage,
         config: Optional[CommerceConfig] = None,
     ):
         """Initialize job service.
-        
+
         Args:
             storage: Job storage backend
             config: Commerce configuration (uses global config if not provided)
@@ -142,10 +147,10 @@ class JobService:
         # Lock for atomic operations (prevents race conditions)
         self._job_locks: Dict[str, threading.Lock] = {}
         self._lock_manager = threading.Lock()
-    
+
     def _get_job_lock(self, job_id: str) -> threading.Lock:
         """Get or create a lock for a specific job.
-        
+
         Uses double-checked locking pattern for thread safety.
         """
         if job_id not in self._job_locks:
@@ -153,39 +158,48 @@ class JobService:
                 if job_id not in self._job_locks:
                     self._job_locks[job_id] = threading.Lock()
         return self._job_locks[job_id]
-    
+
     def _now(self) -> datetime:
         """Get current UTC timestamp."""
         return datetime.now(timezone.utc)
-    
+
     def _generate_id(self) -> str:
         """Generate a new UUID."""
         return str(uuid.uuid4())
-    
+
     def _is_authorized_arbitrator(self, actor_id: str) -> bool:
         """Check if the actor is an authorized arbitrator.
-        
+
         Args:
             actor_id: Agent/user ID to check
-            
+
         Returns:
             True if authorized to resolve disputes
         """
         # Check against configured arbitrator address
         if self.config.arbitrator_address and actor_id == self.config.arbitrator_address:
             return True
-        
+
         # Check against list of authorized arbitrators (if configured)
-        authorized_arbitrators = getattr(self.config, 'authorized_arbitrators', [])
+        authorized_arbitrators = getattr(self.config, "authorized_arbitrators", [])
         if actor_id in authorized_arbitrators:
             return True
-        
+
         # System actor is always authorized (for auto-resolution)
         if actor_id == "system":
             return True
-        
+
         return False
-    
+
+    @staticmethod
+    def _get_user_id(agent_id: str | None) -> str | None:
+        """Extract user_id from namespaced agent_id (user_id/agent_name)."""
+        if not agent_id:
+            return None
+        if "/" not in agent_id:
+            return None
+        return agent_id.split("/", 1)[0]
+
     def _transition_job(
         self,
         job: Job,
@@ -195,17 +209,17 @@ class JobService:
         metadata: Optional[Dict[str, Any]] = None,
     ) -> Job:
         """Execute a job state transition with validation.
-        
+
         Args:
             job: The job to transition
             new_status: Target status
             actor_id: Agent/user performing the transition
             tx_hash: Optional blockchain transaction hash
             metadata: Optional additional context
-            
+
         Returns:
             Job: Updated job
-            
+
         Raises:
             InvalidTransitionError: If transition is not valid
         """
@@ -213,14 +227,14 @@ class JobService:
             raise InvalidTransitionError(
                 f"Cannot transition job from {job.status} to {new_status.value}"
             )
-        
+
         old_status = job.status
         now = self._now()
-        
+
         # Update job status
         job.status = new_status.value
         job.updated_at = now
-        
+
         # Set timestamp for specific transitions
         if new_status == JobStatus.FUNDED:
             job.funded_at = now
@@ -230,10 +244,10 @@ class JobService:
             job.delivered_at = now
         elif new_status == JobStatus.COMPLETED:
             job.completed_at = now
-        
+
         # Save job
         self.storage.update_job(job)
-        
+
         # Record transition
         transition = JobStateTransition(
             id=self._generate_id(),
@@ -246,18 +260,17 @@ class JobService:
             created_at=now,
         )
         self.storage.save_transition(transition)
-        
+
         logger.info(
-            f"Job {job.id} transitioned: {old_status} → {new_status.value} "
-            f"(actor: {actor_id})"
+            f"Job {job.id} transitioned: {old_status} → {new_status.value} " f"(actor: {actor_id})"
         )
-        
+
         return job
-    
+
     # =========================================================================
     # Job CRUD
     # =========================================================================
-    
+
     def create_job(
         self,
         client_id: str,
@@ -268,7 +281,7 @@ class JobService:
         skills_required: Optional[List[str]] = None,
     ) -> Job:
         """Create a new job listing.
-        
+
         Args:
             client_id: Agent ID of the job poster
             title: Short job title (max 200 chars)
@@ -276,19 +289,19 @@ class JobService:
             budget_usdc: Payment amount in USDC
             deadline: When the work must be delivered
             skills_required: Optional list of required skill names
-            
+
         Returns:
             Job: The newly created job
-            
+
         Raises:
             JobServiceError: If validation fails
         """
         now = self._now()
-        
+
         # Validate deadline is in the future
         if deadline <= now:
             raise JobServiceError("Deadline must be in the future")
-        
+
         # SECURITY FIX: Budget bounds checking to prevent overflow
         if budget_usdc <= 0:
             raise JobServiceError("Budget must be positive")
@@ -296,7 +309,7 @@ class JobService:
             raise JobServiceError(f"Budget must be at least ${self.MIN_BUDGET_USDC}")
         if budget_usdc > self.MAX_BUDGET_USDC:
             raise JobServiceError(f"Budget cannot exceed ${self.MAX_BUDGET_USDC:,}")
-        
+
         job = Job(
             id=self._generate_id(),
             client_id=client_id,
@@ -309,9 +322,9 @@ class JobService:
             created_at=now,
             updated_at=now,
         )
-        
+
         self.storage.save_job(job)
-        
+
         # Record creation as first transition
         transition = JobStateTransition(
             id=self._generate_id(),
@@ -323,19 +336,19 @@ class JobService:
             created_at=now,
         )
         self.storage.save_transition(transition)
-        
+
         logger.info(f"Job created: {job.id} - {title} by {client_id}")
         return job
-    
+
     def get_job(self, job_id: str) -> Job:
         """Get a job by ID.
-        
+
         Args:
             job_id: Job ID
-            
+
         Returns:
             Job: The job
-            
+
         Raises:
             JobNotFoundError: If job doesn't exist
         """
@@ -343,16 +356,16 @@ class JobService:
         if not job:
             raise JobNotFoundError(f"Job not found: {job_id}")
         return job
-    
+
     def list_jobs(
         self,
         filters: Optional[JobSearchFilters] = None,
     ) -> List[Job]:
         """List jobs with optional filters.
-        
+
         Args:
             filters: Search filters
-            
+
         Returns:
             List[Job]: Matching jobs
         """
@@ -367,7 +380,7 @@ class JobService:
             limit=f.limit,
             offset=f.offset,
         )
-    
+
     def search_jobs(
         self,
         query: Optional[str] = None,
@@ -377,16 +390,16 @@ class JobService:
         limit: int = 50,
     ) -> List[Job]:
         """Search for available jobs (convenience method for workers).
-        
+
         Only returns open, funded jobs with deadlines in the future.
-        
+
         Args:
             query: Text to search in title/description
             skills: Skills to match
             min_budget: Minimum budget filter
             max_budget: Maximum budget filter
             limit: Max results
-            
+
         Returns:
             List[Job]: Matching available jobs
         """
@@ -398,7 +411,7 @@ class JobService:
             max_budget=max_budget,
             limit=limit,
         )
-        
+
         # Also include open jobs (not yet funded)
         open_jobs = self.storage.list_jobs(
             status=JobStatus.OPEN,
@@ -407,9 +420,9 @@ class JobService:
             max_budget=max_budget,
             limit=limit,
         )
-        
+
         all_jobs = jobs + open_jobs
-        
+
         # Filter by deadline and query
         now = self._now()
         results = []
@@ -422,15 +435,15 @@ class JobService:
                 if q_lower not in job.title.lower() and q_lower not in job.description.lower():
                     continue
             results.append(job)
-        
+
         # Sort by deadline (soonest first) and return limited
         results.sort(key=lambda j: j.deadline)
         return results[:limit]
-    
+
     # =========================================================================
     # Job Lifecycle
     # =========================================================================
-    
+
     def fund_job(
         self,
         job_id: str,
@@ -439,33 +452,33 @@ class JobService:
         tx_hash: Optional[str] = None,
     ) -> Job:
         """Mark a job as funded (escrow deployed and funded).
-        
+
         Called after the client has deployed and funded the escrow contract.
-        
+
         Args:
             job_id: Job ID
             actor_id: Must be the client
             escrow_address: Deployed escrow contract address
             tx_hash: Funding transaction hash
-            
+
         Returns:
             Job: Updated job
-            
+
         Raises:
             UnauthorizedError: If actor is not the client
             InvalidTransitionError: If job cannot be funded
         """
         job = self.get_job(job_id)
-        
+
         if job.client_id != actor_id:
             raise UnauthorizedError("Only the client can fund the job")
-        
+
         # Validate escrow address
         if not escrow_address.startswith("0x") or len(escrow_address) != 42:
             raise JobServiceError(f"Invalid escrow address: {escrow_address}")
-        
+
         job.escrow_address = escrow_address
-        
+
         return self._transition_job(
             job=job,
             new_status=JobStatus.FUNDED,
@@ -473,7 +486,7 @@ class JobService:
             tx_hash=tx_hash,
             metadata={"escrow_address": escrow_address},
         )
-    
+
     def cancel_job(
         self,
         job_id: str,
@@ -482,24 +495,24 @@ class JobService:
         tx_hash: Optional[str] = None,
     ) -> Job:
         """Cancel a job.
-        
+
         Can only cancel jobs in open, funded, or accepted states.
         If funded, the escrow should be refunded (handled externally).
-        
+
         Args:
             job_id: Job ID
             actor_id: Must be the client
             reason: Optional cancellation reason
             tx_hash: Refund transaction hash (if funded)
-            
+
         Returns:
             Job: Cancelled job
         """
         job = self.get_job(job_id)
-        
+
         if job.client_id != actor_id:
             raise UnauthorizedError("Only the client can cancel the job")
-        
+
         return self._transition_job(
             job=job,
             new_status=JobStatus.CANCELLED,
@@ -507,11 +520,11 @@ class JobService:
             tx_hash=tx_hash,
             metadata={"reason": reason} if reason else {},
         )
-    
+
     # =========================================================================
     # Applications
     # =========================================================================
-    
+
     def apply_to_job(
         self,
         job_id: str,
@@ -520,33 +533,31 @@ class JobService:
         proposed_deadline: Optional[datetime] = None,
     ) -> JobApplication:
         """Apply to work on a job.
-        
+
         Args:
             job_id: Job ID to apply to
             applicant_id: Agent ID of the applicant
             message: Application message
             proposed_deadline: Optional alternative deadline
-            
+
         Returns:
             JobApplication: The created application
-            
+
         Raises:
             JobNotFoundError: If job doesn't exist
             JobServiceError: If job is not accepting applications
             DuplicateApplicationError: If already applied
         """
         job = self.get_job(job_id)
-        
+
         # Check job is accepting applications
         if job.status not in {JobStatus.OPEN.value, JobStatus.FUNDED.value}:
-            raise JobServiceError(
-                f"Job is not accepting applications (status: {job.status})"
-            )
-        
+            raise JobServiceError(f"Job is not accepting applications (status: {job.status})")
+
         # Check deadline hasn't passed
         if job.deadline <= self._now():
             raise JobExpiredError(f"Job deadline has passed: {job.deadline}")
-        
+
         # Check for duplicate application
         existing = self.storage.list_applications(
             job_id=job_id,
@@ -556,11 +567,17 @@ class JobService:
             raise DuplicateApplicationError(
                 f"Agent {applicant_id} has already applied to job {job_id}"
             )
-        
+
         # Prevent self-application
         if applicant_id == job.client_id:
             raise JobServiceError("Cannot apply to your own job")
-        
+
+        # Prevent self-dealing across the same user (namespaced agent IDs)
+        client_user_id = self._get_user_id(job.client_id)
+        applicant_user_id = self._get_user_id(applicant_id)
+        if client_user_id and applicant_user_id and client_user_id == applicant_user_id:
+            raise JobServiceError("Cannot apply to a job owned by the same user")
+
         application = JobApplication(
             id=self._generate_id(),
             job_id=job_id,
@@ -570,21 +587,21 @@ class JobService:
             proposed_deadline=proposed_deadline,
             created_at=self._now(),
         )
-        
+
         self.storage.save_application(application)
         logger.info(f"Application {application.id} created for job {job_id}")
-        
+
         return application
-    
+
     def get_application(self, application_id: str) -> JobApplication:
         """Get an application by ID.
-        
+
         Args:
             application_id: Application ID
-            
+
         Returns:
             JobApplication: The application
-            
+
         Raises:
             ApplicationNotFoundError: If not found
         """
@@ -592,7 +609,7 @@ class JobService:
         if not app:
             raise ApplicationNotFoundError(f"Application not found: {application_id}")
         return app
-    
+
     def list_applications(
         self,
         job_id: Optional[str] = None,
@@ -600,12 +617,12 @@ class JobService:
         status: Optional[ApplicationStatus] = None,
     ) -> List[JobApplication]:
         """List applications with optional filters.
-        
+
         Args:
             job_id: Filter by job
             applicant_id: Filter by applicant
             status: Filter by status
-            
+
         Returns:
             List[JobApplication]: Matching applications
         """
@@ -614,7 +631,7 @@ class JobService:
             applicant_id=applicant_id,
             status=status,
         )
-    
+
     def accept_application(
         self,
         job_id: str,
@@ -622,18 +639,18 @@ class JobService:
         actor_id: str,
     ) -> tuple[Job, JobApplication]:
         """Accept an application and assign the worker to the job.
-        
+
         Uses locking to prevent race conditions where multiple applications
         could be accepted simultaneously.
-        
+
         Args:
             job_id: Job ID
             application_id: Application ID to accept
             actor_id: Must be the client
-            
+
         Returns:
             Tuple of (Job, JobApplication): Updated job and application
-            
+
         Raises:
             UnauthorizedError: If actor is not the client
             InvalidTransitionError: If job cannot accept workers
@@ -641,39 +658,43 @@ class JobService:
         # SECURITY FIX: Use per-job lock to prevent race condition
         # This ensures only one application can be accepted at a time
         job_lock = self._get_job_lock(job_id)
-        
+
         with job_lock:
             # Re-fetch job inside lock to ensure we have latest state
             job = self.get_job(job_id)
             application = self.get_application(application_id)
-            
+
             if job.client_id != actor_id:
                 raise UnauthorizedError("Only the client can accept applications")
-            
+
+            # Prevent self-dealing across same user (namespaced agent IDs)
+            client_user_id = self._get_user_id(job.client_id)
+            applicant_user_id = self._get_user_id(application.applicant_id)
+            if client_user_id and applicant_user_id and client_user_id == applicant_user_id:
+                raise UnauthorizedError("Cannot accept applications from the same user")
+
             if application.job_id != job_id:
                 raise JobServiceError("Application does not belong to this job")
-            
+
             if not application.is_pending:
-                raise JobServiceError(
-                    f"Application is not pending (status: {application.status})"
-                )
-            
+                raise JobServiceError(f"Application is not pending (status: {application.status})")
+
             # Job must be funded to accept (escrow must exist)
             if job.status != JobStatus.FUNDED.value:
                 raise InvalidTransitionError(
                     f"Job must be funded before accepting workers (status: {job.status})"
                 )
-            
+
             # Assign worker
             job.worker_id = application.applicant_id
-            
+
             # Update application status
             application.status = ApplicationStatus.ACCEPTED.value
             self.storage.update_application_status(
                 application_id,
                 ApplicationStatus.ACCEPTED,
             )
-            
+
             # Reject other pending applications
             other_apps = self.storage.list_applications(job_id=job_id)
             for other in other_apps:
@@ -682,7 +703,7 @@ class JobService:
                         other.id,
                         ApplicationStatus.REJECTED,
                     )
-            
+
             # Transition job
             job = self._transition_job(
                 job=job,
@@ -693,9 +714,9 @@ class JobService:
                     "worker_id": application.applicant_id,
                 },
             )
-            
+
             return job, application
-    
+
     def reject_application(
         self,
         application_id: str,
@@ -703,102 +724,102 @@ class JobService:
         reason: Optional[str] = None,
     ) -> JobApplication:
         """Reject an application.
-        
+
         Args:
             application_id: Application ID
             actor_id: Must be the job client
             reason: Optional rejection reason
-            
+
         Returns:
             JobApplication: Updated application
         """
         application = self.get_application(application_id)
         job = self.get_job(application.job_id)
-        
+
         if job.client_id != actor_id:
             raise UnauthorizedError("Only the client can reject applications")
-        
+
         if not application.is_pending:
             raise JobServiceError("Application is not pending")
-        
+
         application.status = ApplicationStatus.REJECTED.value
         self.storage.update_application_status(
             application_id,
             ApplicationStatus.REJECTED,
         )
-        
+
         logger.info(f"Application {application_id} rejected (reason: {reason})")
         return application
-    
+
     def withdraw_application(
         self,
         application_id: str,
         actor_id: str,
     ) -> JobApplication:
         """Withdraw an application.
-        
+
         Args:
             application_id: Application ID
             actor_id: Must be the applicant
-            
+
         Returns:
             JobApplication: Updated application
         """
         application = self.get_application(application_id)
-        
+
         if application.applicant_id != actor_id:
             raise UnauthorizedError("Only the applicant can withdraw")
-        
+
         if not application.is_pending:
             raise JobServiceError("Can only withdraw pending applications")
-        
+
         application.status = ApplicationStatus.WITHDRAWN.value
         self.storage.update_application_status(
             application_id,
             ApplicationStatus.WITHDRAWN,
         )
-        
+
         logger.info(f"Application {application_id} withdrawn by {actor_id}")
         return application
-    
+
     # =========================================================================
     # Delivery & Completion
     # =========================================================================
-    
+
     @staticmethod
     def _validate_deliverable_url(url: str) -> None:
         """Validate deliverable URL format and scheme.
-        
+
         Args:
             url: URL to validate
-            
+
         Raises:
             JobServiceError: If URL is invalid or uses unsafe scheme
         """
         if not url or not isinstance(url, str):
             raise JobServiceError("Deliverable URL is required")
-        
+
         # Length check
         if len(url) > 2000:
             raise JobServiceError("Deliverable URL too long (max 2000 characters)")
-        
+
         try:
             parsed = urlparse(url)
         except Exception:
             raise JobServiceError("Invalid URL format")
-        
+
         # Only allow safe schemes
-        allowed_schemes = {'http', 'https', 'ipfs', 'ipns', 'ar'}  # ar = Arweave
+        allowed_schemes = {"http", "https", "ipfs", "ipns", "ar"}  # ar = Arweave
         if parsed.scheme.lower() not in allowed_schemes:
             raise JobServiceError(
                 f"Invalid URL scheme: {parsed.scheme}. "
                 f"Allowed: {', '.join(sorted(allowed_schemes))}"
             )
-        
+
         # Must have a valid netloc for http/https
-        if parsed.scheme in {'http', 'https'} and not parsed.netloc:
+        if parsed.scheme in {"http", "https"} and not parsed.netloc:
             raise JobServiceError("Invalid URL: missing host")
-    
+
     def deliver_job(
         self,
         job_id: str,
@@ -807,16 +828,16 @@ class JobService:
         deliverable_hash: Optional[str] = None,
     ) -> Job:
         """Submit a deliverable for the job.
-        
+
         Args:
             job_id: Job ID
             actor_id: Must be the assigned worker
             deliverable_url: URL to the deliverable (IPFS, GitHub, etc.)
             deliverable_hash: Optional content hash for verification
-            
+
         Returns:
             Job: Updated job
-            
+
         Raises:
             UnauthorizedError: If actor is not the worker
             InvalidTransitionError: If job is not in accepted state
@@ -824,20 +845,18 @@ class JobService:
         """
         # SECURITY FIX: Validate deliverable URL
         self._validate_deliverable_url(deliverable_url)
-        
+
         job = self.get_job(job_id)
-        
+
         if job.worker_id != actor_id:
             raise UnauthorizedError("Only the assigned worker can deliver")
-        
+
         if job.status != JobStatus.ACCEPTED.value:
-            raise InvalidTransitionError(
-                f"Can only deliver accepted jobs (status: {job.status})"
-            )
-        
+            raise InvalidTransitionError(f"Can only deliver accepted jobs (status: {job.status})")
+
         job.deliverable_url = deliverable_url
         job.deliverable_hash = deliverable_hash
-        
+
         return self._transition_job(
             job=job,
             new_status=JobStatus.DELIVERED,
@@ -847,7 +866,7 @@ class JobService:
                 "deliverable_hash": deliverable_hash,
             },
         )
-    
+
     def approve_job(
         self,
         job_id: str,
@@ -855,31 +874,29 @@ class JobService:
         tx_hash: Optional[str] = None,
     ) -> Job:
         """Approve the deliverable and release payment.
-        
+
         This should be called after the escrow release transaction.
-        
+
         Args:
             job_id: Job ID
             actor_id: Must be the client
             tx_hash: Payment release transaction hash
-            
+
         Returns:
             Job: Completed job
-            
+
         Raises:
             UnauthorizedError: If actor is not the client
             InvalidTransitionError: If job is not delivered
         """
         job = self.get_job(job_id)
-        
+
         if job.client_id != actor_id:
             raise UnauthorizedError("Only the client can approve")
-        
+
         if job.status != JobStatus.DELIVERED.value:
-            raise InvalidTransitionError(
-                f"Can only approve delivered jobs (status: {job.status})"
-            )
-        
+            raise InvalidTransitionError(f"Can only approve delivered jobs (status: {job.status})")
+
         return self._transition_job(
             job=job,
             new_status=JobStatus.COMPLETED,
@@ -887,36 +904,36 @@ class JobService:
             tx_hash=tx_hash,
             metadata={"action": "approved"},
         )
-    
+
     def auto_approve_job(
         self,
         job_id: str,
         tx_hash: Optional[str] = None,
     ) -> Job:
         """Auto-approve a job after timeout period.
-        
+
         Called by a background job when approval timeout expires.
-        
+
         Args:
             job_id: Job ID
             tx_hash: Auto-release transaction hash
-            
+
         Returns:
             Job: Completed job
         """
         job = self.get_job(job_id)
-        
+
         if job.status != JobStatus.DELIVERED.value:
             raise InvalidTransitionError("Job is not in delivered state")
-        
+
         # Check timeout
         if not job.delivered_at:
             raise JobServiceError("Job has no delivery timestamp")
-        
+
         timeout = timedelta(days=self.config.approval_timeout_days)
         if self._now() < job.delivered_at + timeout:
             raise JobServiceError("Approval timeout has not expired")
-        
+
         return self._transition_job(
             job=job,
             new_status=JobStatus.COMPLETED,
@@ -924,11 +941,11 @@ class JobService:
             tx_hash=tx_hash,
             metadata={"action": "auto_approved", "reason": "timeout"},
         )
-    
+
     # =========================================================================
     # Disputes
     # =========================================================================
-    
+
     def dispute_job(
         self,
         job_id: str,
@@ -936,38 +953,34 @@ class JobService:
         reason: str,
     ) -> Job:
         """Raise a dispute on a job.
-        
+
         Can be raised by client or worker during accepted or delivered states.
-        
+
         Args:
             job_id: Job ID
             actor_id: Client or worker
             reason: Dispute reason
-            
+
         Returns:
             Job: Disputed job
         """
         job = self.get_job(job_id)
-        
+
         # Check authorization (must be client or worker)
         if actor_id not in {job.client_id, job.worker_id}:
-            raise UnauthorizedError(
-                "Only the client or worker can raise a dispute"
-            )
-        
+            raise UnauthorizedError("Only the client or worker can raise a dispute")
+
         # Check valid state for dispute
         if job.status not in {JobStatus.ACCEPTED.value, JobStatus.DELIVERED.value}:
-            raise InvalidTransitionError(
-                f"Cannot dispute job in status: {job.status}"
-            )
-        
+            raise InvalidTransitionError(f"Cannot dispute job in status: {job.status}")
+
         return self._transition_job(
             job=job,
             new_status=JobStatus.DISPUTED,
             actor_id=actor_id,
             metadata={"reason": reason, "raised_by": actor_id},
         )
-    
+
     def resolve_dispute(
         self,
         job_id: str,
@@ -977,38 +990,34 @@ class JobService:
         notes: Optional[str] = None,
     ) -> Job:
         """Resolve a disputed job.
-        
+
         Called by arbitrator to release funds to the appropriate party.
-        
+
         Args:
             job_id: Job ID
             actor_id: Arbitrator ID (must be authorized)
             resolution: Who gets the funds ("worker" or "client")
             tx_hash: Resolution transaction hash
             notes: Arbitrator notes
-            
+
         Returns:
             Job: Completed job
-            
+
         Raises:
             UnauthorizedError: If actor is not an authorized arbitrator
         """
         job = self.get_job(job_id)
-        
+
         if job.status != JobStatus.DISPUTED.value:
             raise InvalidTransitionError("Job is not disputed")
-        
+
         # SECURITY FIX: Verify actor is authorized arbitrator
         if not self._is_authorized_arbitrator(actor_id):
-            raise UnauthorizedError(
-                "Only authorized arbitrators can resolve disputes"
-            )
-        
+            raise UnauthorizedError("Only authorized arbitrators can resolve disputes")
+
         if resolution not in {"worker", "client"}:
-            raise JobServiceError(
-                f"Invalid resolution: {resolution}. Must be 'worker' or 'client'"
-            )
-        
+            raise JobServiceError(f"Invalid resolution: {resolution}. Must be 'worker' or 'client'")
+
         return self._transition_job(
             job=job,
             new_status=JobStatus.COMPLETED,
@@ -1020,54 +1029,54 @@ class JobService:
                 "notes": notes,
             },
         )
-    
+
     # =========================================================================
     # Helpers
     # =========================================================================
-    
+
     def get_job_history(self, job_id: str) -> List[JobStateTransition]:
         """Get the state transition history for a job.
-        
+
         Args:
             job_id: Job ID
-            
+
         Returns:
             List[JobStateTransition]: Ordered transition history
         """
         _ = self.get_job(job_id)  # Verify job exists
         return self.storage.get_transitions(job_id)
-    
+
     def get_jobs_for_client(self, client_id: str) -> List[Job]:
         """Get all jobs posted by a client.
-        
+
         Args:
             client_id: Client agent ID
-            
+
         Returns:
             List[Job]: Jobs posted by this client
         """
         return self.storage.list_jobs(client_id=client_id)
-    
+
     def get_jobs_for_worker(self, worker_id: str) -> List[Job]:
         """Get all jobs assigned to a worker.
-        
+
         Args:
             worker_id: Worker agent ID
-            
+
         Returns:
             List[Job]: Jobs assigned to this worker
         """
         return self.storage.list_jobs(worker_id=worker_id)
-    
+
     def get_applications_for_applicant(
         self,
         applicant_id: str,
     ) -> List[JobApplication]:
         """Get all applications by an applicant.
-        
+
         Args:
             applicant_id: Applicant agent ID
-            
+
         Returns:
             List[JobApplication]: Applications by this agent
         """

--- a/tests/commerce/test_security.py
+++ b/tests/commerce/test_security.py
@@ -7,42 +7,35 @@ Tests marked with @pytest.mark.xfail are known vulnerabilities that need fixing.
 Run with: uv run pytest tests/commerce/test_security.py -v
 """
 
-import asyncio
 import concurrent.futures
-import threading
 import time
+import uuid
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
-from typing import List, Tuple
-from unittest.mock import MagicMock, patch
-import uuid
 
 import pytest
+
+from kernle.commerce.jobs.models import Job, JobStatus
+from kernle.commerce.jobs.service import (
+    DuplicateApplicationError,
+    InvalidTransitionError,
+    JobExpiredError,
+    JobService,
+    JobServiceError,
+    UnauthorizedError,
+)
+from kernle.commerce.jobs.storage import InMemoryJobStorage
+from kernle.commerce.skills.models import Skill
+from kernle.commerce.skills.registry import InMemorySkillRegistry
 
 # Import commerce modules
 from kernle.commerce.wallet.models import WalletAccount, WalletStatus
 from kernle.commerce.wallet.service import (
-    WalletService,
-    WalletNotFoundError,
-    WalletServiceError,
     SpendingLimitExceededError,
+    WalletService,
+    WalletServiceError,
 )
 from kernle.commerce.wallet.storage import InMemoryWalletStorage
-from kernle.commerce.jobs.models import Job, JobApplication, JobStatus, ApplicationStatus
-from kernle.commerce.jobs.service import (
-    JobService,
-    JobNotFoundError,
-    ApplicationNotFoundError,
-    InvalidTransitionError,
-    UnauthorizedError,
-    DuplicateApplicationError,
-    JobExpiredError,
-    JobServiceError,
-)
-from kernle.commerce.jobs.storage import InMemoryJobStorage
-from kernle.commerce.skills.models import Skill, SkillCategory
-from kernle.commerce.skills.registry import InMemorySkillRegistry
-
 
 # =============================================================================
 # Test Fixtures
@@ -111,7 +104,7 @@ class TestInputValidation:
     def test_sql_injection_in_skill_search(self, skill_registry):
         """
         Test SQL injection in skills search.
-        
+
         VULNERABILITY: Skills search may be vulnerable to SQL injection
         through the query parameter.
         """
@@ -123,7 +116,7 @@ class TestInputValidation:
             "' UNION SELECT * FROM users --",
             "research%'; DROP TABLE skills; --",
         ]
-        
+
         for payload in injection_payloads:
             # These should not cause errors or unexpected behavior
             try:
@@ -143,7 +136,7 @@ class TestInputValidation:
             "<img src=x onerror=alert('xss')>",
             "{{constructor.constructor('alert(1)')()}}",
         ]
-        
+
         for payload in xss_payloads:
             job = job_service.create_job(
                 client_id="client_1",
@@ -159,12 +152,12 @@ class TestInputValidation:
     def test_path_traversal_in_deliverable_url(self, job_service):
         """
         Test that path traversal and unsafe URLs are rejected.
-        
+
         FIXED: deliver_job now validates URLs and only allows safe schemes.
         """
         job = create_test_job(job_service)
         job = fund_test_job(job_service, job)
-        
+
         # Add worker
         app = job_service.apply_to_job(
             job_id=job.id,
@@ -172,7 +165,7 @@ class TestInputValidation:
             message="I'll do it",
         )
         job_service.accept_application(job.id, app.id, job.client_id)
-        
+
         # Path traversal and unsafe URL attempts - all should be rejected
         unsafe_urls = [
             "file:///etc/passwd",
@@ -181,7 +174,7 @@ class TestInputValidation:
             "data:text/html,<script>alert(1)</script>",
             "ftp://evil.com/malware",
         ]
-        
+
         for url in unsafe_urls:
             with pytest.raises(JobServiceError, match="Invalid URL"):
                 job_service.deliver_job(
@@ -189,19 +182,19 @@ class TestInputValidation:
                     actor_id="worker_1",
                     deliverable_url=url,
                 )
-        
+
         # Valid URLs should work
         valid_urls = [
             "https://github.com/user/repo",
             "ipfs://QmHash123",
             "https://example.com/work.pdf",
         ]
-        
+
         for url in valid_urls:
             # Reset job state
             job.status = JobStatus.ACCEPTED.value
             job.deliverable_url = None
-            
+
             delivered = job_service.deliver_job(
                 job_id=job.id,
                 actor_id="worker_1",
@@ -212,7 +205,7 @@ class TestInputValidation:
     def test_budget_bounds_checking(self, job_service):
         """
         Test that budget values are properly bounded.
-        
+
         FIXED: JobService now enforces min/max budget limits.
         """
         # Negative values should fail
@@ -224,7 +217,7 @@ class TestInputValidation:
                 budget_usdc=-100.0,
                 deadline=datetime.now(timezone.utc) + timedelta(days=7),
             )
-        
+
         # Values below minimum should fail
         with pytest.raises(JobServiceError, match="at least"):
             job_service.create_job(
@@ -234,7 +227,7 @@ class TestInputValidation:
                 budget_usdc=0.001,  # Below 0.01 minimum
                 deadline=datetime.now(timezone.utc) + timedelta(days=7),
             )
-        
+
         # Values above maximum should fail
         with pytest.raises(JobServiceError, match="cannot exceed"):
             job_service.create_job(
@@ -244,7 +237,7 @@ class TestInputValidation:
                 budget_usdc=2_000_000_000,  # Above 1B maximum
                 deadline=datetime.now(timezone.utc) + timedelta(days=7),
             )
-        
+
         # Valid minimum should work
         job = job_service.create_job(
             client_id="client_1",
@@ -254,7 +247,7 @@ class TestInputValidation:
             deadline=datetime.now(timezone.utc) + timedelta(days=7),
         )
         assert job.budget_usdc == 0.01
-        
+
         # Valid large value should work
         job = job_service.create_job(
             client_id="client_1",
@@ -277,19 +270,19 @@ class TestAuthorization:
     def test_unauthorized_dispute_resolution(self, job_service):
         """
         Test that only authorized arbitrators can resolve disputes.
-        
+
         FIXED: resolve_dispute now checks if actor_id is an authorized arbitrator.
         """
         # Setup: Create job, accept worker, start work, raise dispute
         job = create_test_job(job_service)
         job = fund_test_job(job_service, job)
-        
+
         app = job_service.apply_to_job(job.id, "worker_1", "I'll do it")
         job_service.accept_application(job.id, app.id, job.client_id)
-        
+
         # Worker raises dispute
         job = job_service.dispute_job(job.id, "worker_1", "Client not responding")
-        
+
         # Random attacker cannot resolve dispute
         with pytest.raises(UnauthorizedError):
             job_service.resolve_dispute(
@@ -297,7 +290,7 @@ class TestAuthorization:
                 actor_id="random_attacker",  # Not an arbitrator
                 resolution="worker",
             )
-        
+
         # System actor CAN resolve (for auto-resolution)
         resolved_job = job_service.resolve_dispute(
             job_id=job.id,
@@ -310,18 +303,18 @@ class TestAuthorization:
         """Test that workers cannot approve jobs they're working on."""
         job = create_test_job(job_service)
         job = fund_test_job(job_service, job)
-        
+
         # Worker applies and is accepted
         app = job_service.apply_to_job(job.id, "worker_1", "I'll do it")
         job_service.accept_application(job.id, app.id, job.client_id)
-        
+
         # Worker delivers
         job = job_service.deliver_job(
             job_id=job.id,
             actor_id="worker_1",
             deliverable_url="https://example.com/work",
         )
-        
+
         # Worker tries to approve their own work
         with pytest.raises(UnauthorizedError):
             job_service.approve_job(job.id, "worker_1")
@@ -329,49 +322,38 @@ class TestAuthorization:
     def test_client_cannot_apply_to_own_job(self, job_service):
         """Test that clients cannot apply to their own jobs."""
         job = create_test_job(job_service, client_id="client_1")
-        
+
         # Client tries to apply to their own job
         with pytest.raises(JobServiceError, match="Cannot apply to your own job"):
             job_service.apply_to_job(job.id, "client_1", "I'll do my own job")
 
-    @pytest.mark.xfail(reason="No check for same user controlling client and worker agents")
     def test_self_dealing_different_agents(self, job_service):
         """
         Test self-dealing where one user controls both client and worker agents.
-        
-        VULNERABILITY: A user could control multiple agents and self-deal.
+
+        Ensure self-dealing across same user is blocked.
         """
-        # User controls both agent_A and agent_B
-        # This test would need user-level tracking to fail
-        job = create_test_job(job_service, client_id="agent_A")
+        # User controls both agents (namespaced agent IDs)
+        job = create_test_job(job_service, client_id="usr_1/agent_A")
         job = fund_test_job(job_service, job)
-        
+
         # Same user's other agent applies
-        app = job_service.apply_to_job(job.id, "agent_B", "I'll do it")
-        
-        # Self-dealing: accept own application
-        job_service.accept_application(job.id, app.id, "agent_A")
-        
-        # Complete the self-deal
-        job_service.deliver_job(job.id, "agent_B", "https://example.com/fake")
-        job_service.approve_job(job.id, "agent_A")
-        
-        # This self-dealing should have been prevented
-        assert False, "Self-dealing between same user's agents should be blocked"
+        with pytest.raises(JobServiceError, match="same user"):
+            job_service.apply_to_job(job.id, "usr_1/agent_B", "I'll do it")
 
     def test_non_client_cannot_view_applications(self, job_service):
         """Test that non-clients cannot list applications for a job."""
         job = create_test_job(job_service, client_id="client_1")
         job = fund_test_job(job_service, job)
-        
+
         # Worker applies
         job_service.apply_to_job(job.id, "worker_1", "I'll do it")
-        
+
         # Attacker tries to view applications
         # Note: Service layer doesn't have authorization check, this is in routes
         # This test shows the gap in the service layer
         applications = job_service.list_applications(job_id=job.id)
-        
+
         # In a secure implementation, this should be blocked for non-clients
         # Currently returns all applications - the route layer handles auth
         assert len(applications) > 0
@@ -380,7 +362,7 @@ class TestAuthorization:
         """Test that wallet claiming verifies ownership."""
         # Create wallet for agent_1
         wallet = wallet_service.create_wallet("agent_1", user_id="user_1")
-        
+
         # Different agent tries to claim
         # Current implementation only checks status, not user_id
         # This should fail but may not
@@ -405,28 +387,28 @@ class TestBusinessLogic:
     def test_race_condition_double_acceptance(self, job_service):
         """
         Test that concurrent application acceptance is prevented.
-        
+
         FIXED: accept_application now uses per-job locking to ensure
         only one application can be accepted at a time.
         """
         job = create_test_job(job_service)
         job = fund_test_job(job_service, job)
-        
+
         # Multiple workers apply
         app1 = job_service.apply_to_job(job.id, "worker_1", "I'll do it")
         app2 = job_service.apply_to_job(job.id, "worker_2", "I'll do it better")
-        
+
         # Simulate race condition: both acceptance checks pass
         results = []
         errors = []
-        
+
         def accept_app(app_id):
             try:
                 job_service.accept_application(job.id, app_id, "client_1")
                 results.append(app_id)
             except Exception as e:
                 errors.append((app_id, e))
-        
+
         # Run concurrent accepts
         with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
             futures = [
@@ -434,7 +416,7 @@ class TestBusinessLogic:
                 executor.submit(accept_app, app2.id),
             ]
             concurrent.futures.wait(futures)
-        
+
         # Only ONE should succeed due to locking
         assert len(results) == 1, f"Race condition! Both accepted: {results}"
         assert len(errors) == 1, f"Expected one rejection, got: {errors}"
@@ -442,21 +424,21 @@ class TestBusinessLogic:
     def test_daily_spending_limit_enforced(self, wallet_service):
         """
         Test that daily spending limits are enforced.
-        
+
         FIXED: WalletService now tracks daily spending and rejects
         transactions that would exceed the daily limit.
         """
         owner_eoa = "0x" + "a" * 40
         wallet = wallet_service.create_wallet("agent_1")
         wallet = wallet_service.claim_wallet(wallet.id, owner_eoa)
-        
+
         # Set low daily limit (only owner can update)
         wallet_service.update_spending_limits(wallet.id, per_tx=50, daily=100, actor_id=owner_eoa)
-        
+
         # Try to exceed daily limit with multiple transactions
         total_spent = Decimal("0")
         limit_hit = False
-        
+
         for i in range(5):  # 5 x $50 = $250, exceeds $100 daily limit
             try:
                 result = wallet_service.transfer(
@@ -470,7 +452,7 @@ class TestBusinessLogic:
             except SpendingLimitExceededError:
                 limit_hit = True
                 break
-        
+
         # Should have stopped at $100 (2 transactions of $50)
         assert total_spent == Decimal("100"), f"Expected $100, got: {total_spent}"
         assert limit_hit, "Daily limit should have been hit"
@@ -478,58 +460,53 @@ class TestBusinessLogic:
     def test_state_machine_bypass_attempt(self, job_service):
         """Test attempts to bypass the job state machine."""
         job = create_test_job(job_service)
-        
+
         # Try to skip directly to completed (bypassing funded, accepted, delivered)
         with pytest.raises(InvalidTransitionError):
-            job_service._transition_job(
-                job, JobStatus.COMPLETED, "client_1"
-            )
-        
+            job_service._transition_job(job, JobStatus.COMPLETED, "client_1")
+
         # Try to go backwards
         job = fund_test_job(job_service, job)
         with pytest.raises(InvalidTransitionError):
-            job_service._transition_job(
-                job, JobStatus.OPEN, "client_1"
-            )
+            job_service._transition_job(job, JobStatus.OPEN, "client_1")
 
     def test_auto_approval_gaming(self, job_service):
         """Test protection against auto-approval gaming."""
         job = create_test_job(job_service)
         job = fund_test_job(job_service, job)
-        
+
         app = job_service.apply_to_job(job.id, "worker_1", "I'll do it")
         job_service.accept_application(job.id, app.id, job.client_id)
-        
+
         # Worker delivers garbage
         job = job_service.deliver_job(
             job_id=job.id,
             actor_id="worker_1",
             deliverable_url="https://example.com/garbage",
         )
-        
+
         # Try to auto-approve immediately (should fail - timeout not passed)
         with pytest.raises(JobServiceError, match="timeout has not expired"):
             job_service.auto_approve_job(job.id)
 
     def test_escrow_address_predictability(self, job_service):
         """Test that escrow addresses are predictable (vulnerability)."""
-        import hashlib
-        
+
         # Create job to get ID
         job = create_test_job(job_service)
-        
+
         # Predict escrow address using same algorithm
         base_hash = uuid.uuid5(uuid.NAMESPACE_DNS, job.id).hex
         extra_hash = uuid.uuid5(uuid.NAMESPACE_URL, job.id).hex[:8]
         predicted_address = f"0x{base_hash}{extra_hash[:8]}"[:42]
-        
+
         # Fund job to create escrow
         job = job_service.fund_job(
             job_id=job.id,
             actor_id=job.client_id,
             escrow_address="0x" + "a" * 40,  # This is passed in, not generated here
         )
-        
+
         # In the real escrow service, address is predictable
         # This demonstrates the predictability issue
         assert predicted_address.startswith("0x")
@@ -539,14 +516,14 @@ class TestBusinessLogic:
         """Test that cancellation after work started is handled properly."""
         job = create_test_job(job_service)
         job = fund_test_job(job_service, job)
-        
+
         app = job_service.apply_to_job(job.id, "worker_1", "I'll do it")
         job_service.accept_application(job.id, app.id, job.client_id)
-        
+
         # Job is accepted, worker has started
         # Client cancels - this is allowed but may be unfair to worker
         job = job_service.cancel_job(job.id, job.client_id, "Changed my mind")
-        
+
         assert job.status == JobStatus.CANCELLED.value
         # Note: No compensation for worker's effort
 
@@ -562,19 +539,19 @@ class TestDataExposure:
     def test_wallet_dict_hides_cdp_id(self, wallet_service):
         """
         Test that to_dict() no longer exposes internal CDP wallet ID by default.
-        
+
         FIXED: to_dict() now requires include_internal=True to expose cdp_wallet_id.
         """
         wallet = wallet_service.create_wallet("agent_1")
-        
+
         # Default to_dict should NOT include cdp_wallet_id
         data = wallet.to_dict()
         assert "cdp_wallet_id" not in data
-        
+
         # to_dict with include_internal=True SHOULD include it
         data_with_internal = wallet.to_dict(include_internal=True)
         assert "cdp_wallet_id" in data_with_internal
-        
+
         # to_public_dict should have minimal fields
         public_data = wallet.to_public_dict()
         assert "cdp_wallet_id" not in public_data
@@ -589,7 +566,7 @@ class TestDataExposure:
         SSN: 123-45-6789
         Credit Card: 4111-1111-1111-1111
         """
-        
+
         job = job_service.create_job(
             client_id="client_1",
             title="Test Job",
@@ -597,7 +574,7 @@ class TestDataExposure:
             budget_usdc=100.0,
             deadline=datetime.now(timezone.utc) + timedelta(days=7),
         )
-        
+
         # PII is stored as-is - no filtering
         assert "john.doe@example.com" in job.description
         assert "555-123-4567" in job.description
@@ -605,9 +582,9 @@ class TestDataExposure:
     def test_spending_limits_visible_to_all(self, wallet_service):
         """Test that spending limits are visible (may be sensitive)."""
         wallet = wallet_service.create_wallet("agent_1")
-        
+
         data = wallet.to_dict()
-        
+
         # Spending limits reveal wallet configuration
         assert "spending_limit_per_tx" in data
         assert "spending_limit_daily" in data
@@ -626,20 +603,20 @@ class TestStateTransitions:
         """Test all valid state transitions work correctly."""
         job = create_test_job(job_service)
         assert job.status == JobStatus.OPEN.value
-        
+
         # open -> funded
         job = fund_test_job(job_service, job)
         assert job.status == JobStatus.FUNDED.value
-        
+
         # funded -> accepted
         app = job_service.apply_to_job(job.id, "worker_1", "I'll do it")
         job, _ = job_service.accept_application(job.id, app.id, job.client_id)
         assert job.status == JobStatus.ACCEPTED.value
-        
+
         # accepted -> delivered
         job = job_service.deliver_job(job.id, "worker_1", "https://example.com/work")
         assert job.status == JobStatus.DELIVERED.value
-        
+
         # delivered -> completed
         job = job_service.approve_job(job.id, job.client_id)
         assert job.status == JobStatus.COMPLETED.value
@@ -657,10 +634,10 @@ class TestStateTransitions:
             ("completed", "open"),  # Backwards
             ("cancelled", "open"),  # From terminal
         ]
-        
+
         for from_status, to_status in invalid_transitions:
             job = create_test_job(job_service)
-            
+
             # Manually set status for testing
             job.status = from_status
             if from_status == "funded":
@@ -668,11 +645,12 @@ class TestStateTransitions:
             if from_status in ("accepted", "delivered"):
                 job.worker_id = "worker_1"
                 job.escrow_address = "0x" + "a" * 40
-            
+
             # Attempt invalid transition
             target_status = JobStatus(to_status)
-            assert not job.can_transition_to(target_status), \
-                f"Should reject {from_status} -> {to_status}"
+            assert not job.can_transition_to(
+                target_status
+            ), f"Should reject {from_status} -> {to_status}"
 
     def test_dispute_from_valid_states(self, job_service):
         """Test disputes can only be raised from valid states."""
@@ -681,20 +659,20 @@ class TestStateTransitions:
         job = fund_test_job(job_service, job)
         app = job_service.apply_to_job(job.id, "worker_1", "I'll do it")
         job, _ = job_service.accept_application(job.id, app.id, job.client_id)
-        
+
         job = job_service.dispute_job(job.id, "worker_1", "Problem")
         assert job.status == JobStatus.DISPUTED.value
-        
+
         # Can dispute from delivered
         job2 = create_test_job(job_service)
         job2 = fund_test_job(job_service, job2)
         app2 = job_service.apply_to_job(job2.id, "worker_2", "I'll do it")
         job2, _ = job_service.accept_application(job2.id, app2.id, job2.client_id)
         job2 = job_service.deliver_job(job2.id, "worker_2", "https://example.com/work")
-        
+
         job2 = job_service.dispute_job(job2.id, "client_1", "Bad work")
         assert job2.status == JobStatus.DISPUTED.value
-        
+
         # Cannot dispute from open
         job3 = create_test_job(job_service)
         with pytest.raises(InvalidTransitionError):
@@ -718,7 +696,7 @@ class TestSkillSecurity:
             "a" * 100,  # Too long
             "",  # Empty
         ]
-        
+
         for name in invalid_names:
             with pytest.raises(ValueError):
                 Skill(id=str(uuid.uuid4()), name=name, description="Test")
@@ -731,7 +709,7 @@ class TestSkillSecurity:
             "web-scraping",
             "coding123",
         ]
-        
+
         for name in valid_names:
             skill = Skill(id=str(uuid.uuid4()), name=name, description="Test")
             assert skill.name == name
@@ -749,29 +727,24 @@ class TestConcurrency:
         """Test handling of concurrent job applications."""
         job = create_test_job(job_service)
         job = fund_test_job(job_service, job)
-        
+
         errors = []
         successes = []
-        
+
         def apply_to_job(worker_id):
             try:
-                app = job_service.apply_to_job(
-                    job.id, worker_id, f"Application from {worker_id}"
-                )
+                job_service.apply_to_job(job.id, worker_id, f"Application from {worker_id}")
                 successes.append(worker_id)
             except DuplicateApplicationError:
                 errors.append(worker_id)
             except Exception as e:
                 errors.append((worker_id, str(e)))
-        
+
         # Concurrent applications from different workers
         with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
-            futures = [
-                executor.submit(apply_to_job, f"worker_{i}")
-                for i in range(10)
-            ]
+            futures = [executor.submit(apply_to_job, f"worker_{i}") for i in range(10)]
             concurrent.futures.wait(futures)
-        
+
         # All should succeed (different workers)
         assert len(successes) == 10
         assert len(errors) == 0
@@ -779,11 +752,11 @@ class TestConcurrency:
     def test_duplicate_application_prevention(self, job_service):
         """Test duplicate application is prevented."""
         job = create_test_job(job_service)
-        
+
         # First application succeeds
         app1 = job_service.apply_to_job(job.id, "worker_1", "First try")
         assert app1.id is not None
-        
+
         # Second application from same worker fails
         with pytest.raises(DuplicateApplicationError):
             job_service.apply_to_job(job.id, "worker_1", "Second try")
@@ -792,34 +765,34 @@ class TestConcurrency:
         """Test concurrent updates to same job."""
         job = create_test_job(job_service)
         job = fund_test_job(job_service, job)
-        
+
         app = job_service.apply_to_job(job.id, "worker_1", "I'll do it")
         job, _ = job_service.accept_application(job.id, app.id, job.client_id)
-        
+
         # Both client and worker try to transition at same time
         results = []
-        
+
         def deliver():
             try:
                 job_service.deliver_job(job.id, "worker_1", "https://example.com/work")
                 results.append("deliver")
             except Exception as e:
                 results.append(f"deliver_error: {e}")
-        
+
         def dispute():
             try:
                 job_service.dispute_job(job.id, "client_1", "Taking too long")
                 results.append("dispute")
             except Exception as e:
                 results.append(f"dispute_error: {e}")
-        
+
         with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
             futures = [
                 executor.submit(deliver),
                 executor.submit(dispute),
             ]
             concurrent.futures.wait(futures)
-        
+
         # One should succeed, one should fail (depending on timing)
         # This test demonstrates the race condition
         assert len(results) == 2
@@ -835,15 +808,15 @@ class TestWalletSecurity:
 
     def test_wallet_address_validation(self, wallet_service):
         """Test Ethereum address validation."""
-        wallet = wallet_service.create_wallet("agent_1")
-        
+        wallet_service.create_wallet("agent_1")
+
         invalid_addresses = [
             "not_an_address",
             "0x123",  # Too short
             "0x" + "g" * 40,  # Invalid hex
             "1x" + "a" * 40,  # Wrong prefix
         ]
-        
+
         for addr in invalid_addresses:
             # Claim should validate address format
             with pytest.raises((ValueError, WalletServiceError)):
@@ -860,7 +833,7 @@ class TestWalletSecurity:
         """Test per-transaction spending limit is enforced."""
         wallet = wallet_service.create_wallet("agent_1")
         wallet = wallet_service.claim_wallet(wallet.id, "0x" + "a" * 40)
-        
+
         # Default limit is $100
         with pytest.raises(SpendingLimitExceededError):
             wallet_service.transfer(
@@ -874,10 +847,10 @@ class TestWalletSecurity:
         """Test that frozen wallets cannot transact."""
         wallet = wallet_service.create_wallet("agent_1")
         wallet = wallet_service.claim_wallet(wallet.id, "0x" + "a" * 40)
-        
+
         # Manually freeze wallet
         wallet_storage.update_wallet_status(wallet.id, WalletStatus.FROZEN)
-        
+
         # Try to transact
         with pytest.raises(Exception):  # WalletNotActiveError or similar
             wallet_service.transfer(
@@ -892,10 +865,10 @@ class TestWalletSecurity:
         owner_eoa = "0x" + "a" * 40
         wallet = wallet_service.create_wallet("agent_1")
         wallet = wallet_service.claim_wallet(wallet.id, owner_eoa)
-        
+
         # Pause wallet (only owner can pause)
         wallet = wallet_service.pause_wallet(wallet.id, owner_eoa)
-        
+
         # Verify can't transact
         assert not wallet.can_transact
 
@@ -911,41 +884,41 @@ class TestMCPToolsSecurity:
     def test_mcp_input_sanitization(self):
         """Test MCP tool input sanitization."""
         from kernle.commerce.mcp.tools import (
-            sanitize_string,
             sanitize_array,
+            sanitize_string,
             validate_number,
         )
-        
+
         # Test string sanitization
         with pytest.raises(ValueError):
             sanitize_string(None, "field", required=True)
-        
+
         with pytest.raises(ValueError):
             sanitize_string("", "field", required=True)
-        
+
         with pytest.raises(ValueError):
             sanitize_string("a" * 1001, "field", max_length=1000)
-        
+
         # Test array sanitization
         with pytest.raises(ValueError):
             sanitize_array(["a"] * 25, "field", max_items=20)
-        
+
         # Test number validation
         with pytest.raises(ValueError):
             validate_number(-1, "field", min_val=0)
-        
+
         with pytest.raises(ValueError):
             validate_number(101, "field", max_val=100)
 
     def test_mcp_error_handling_no_leaks(self):
         """Test MCP error handling doesn't leak internal info."""
         from kernle.commerce.mcp.tools import handle_commerce_tool_error
-        
+
         # Simulate internal error
         internal_error = Exception("Database connection string: postgres://user:password@host/db")
-        
+
         results = handle_commerce_tool_error(internal_error, "test_tool", {})
-        
+
         # Should not leak connection string
         assert "password" not in str(results)
         assert "Internal server error" in str(results[0].text)
@@ -969,10 +942,10 @@ class TestEdgeCases:
             budget_usdc=100.0,
             deadline=datetime.now(timezone.utc) + timedelta(seconds=1),
         )
-        
+
         # Wait for deadline to pass
         time.sleep(2)
-        
+
         # Try to apply - should fail
         with pytest.raises(JobExpiredError):
             job_service.apply_to_job(job.id, "worker_1", "I'll do it")
@@ -998,13 +971,13 @@ class TestEdgeCases:
             deadline=datetime.now(timezone.utc) + timedelta(days=7),
             skills_required=[],
         )
-        
+
         assert job.skills_required == []
 
     def test_unicode_in_job_content(self, job_service):
         """Test Unicode handling in job content."""
         unicode_content = "日本語テスト 🚀 émojis Ω∑∏"
-        
+
         job = job_service.create_job(
             client_id="client_1",
             title=unicode_content[:100],
@@ -1012,7 +985,7 @@ class TestEdgeCases:
             budget_usdc=100.0,
             deadline=datetime.now(timezone.utc) + timedelta(days=7),
         )
-        
+
         assert unicode_content in job.description
 
 


### PR DESCRIPTION
## Summary
- require admin auth for commerce maintenance endpoints
- block same-user self-dealing for namespaced agent IDs
- update setup/docs to match MCP tool names and paths

## Test plan
- [x] python -m pytest tests/commerce/test_security.py -q
- [x] python -m pytest tests/commerce/test_job_service.py -q
- [x] python -m pytest tests/commerce/test_security_verification.py -q

Made with [Cursor](https://cursor.com)