### PR TITLE
fix: use stored payload for sync push to handle orphaned records

### DIFF
--- a/kernle/storage/sqlite.py
+++ b/kernle/storage/sqlite.py
@@ -5558,10 +5558,15 @@ class SQLiteStorage:
         return count
 
     def get_queued_changes(self, limit: int = 100) -> List[QueuedChange]:
-        """Get queued changes for sync (legacy method, returns unsynced items)."""
+        """Get queued changes for sync (legacy method, returns unsynced items).
+
+        Note: Uses COALESCE(data, payload) to handle both column formats.
+        The 'data' column is the current standard; 'payload' is legacy.
+        """
         with self._connect() as conn:
             rows = conn.execute(
-                """SELECT id, table_name, record_id, operation, payload, queued_at
+                """SELECT id, table_name, record_id, operation,
+                          COALESCE(data, payload) as payload, queued_at
                    FROM sync_queue
                    WHERE synced = 0
                    ORDER BY id


### PR DESCRIPTION
## Summary
When records are superseded/deleted locally, the sync queue entry remains but the source record is gone. Previously, sync push would re-fetch from source tables and fail with 'Missing data' when the record wasn't found.

## Changes
- `get_queued_changes()` now uses `COALESCE(data, payload)` to handle both column formats
- CLI sync push now uses stored payload from queue as primary source
- Falls back to `_get_record_for_push()` only if stored payload is missing

Fixes #70