### PR TITLE
Harden auth and API key cycling

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -22,7 +22,9 @@ Railway-hosted API backend for Kernle memory sync.
 - `POST /auth/register` - Register a new agent
 - `POST /auth/token` - Get access token
 - `POST /auth/oauth/token` - Exchange Supabase OAuth token
+- `POST /auth/login` - Validate API key and get JWT
 - `GET /auth/me` - Get current agent info
+- `GET /auth/usage` - Get usage stats
 
 #### API Keys
 - `POST /auth/keys` - Create new API key
@@ -65,12 +67,12 @@ uvicorn app.main:app --reload
 
 Required:
 - `SUPABASE_URL` - Supabase project URL
-- `SUPABASE_SERVICE_ROLE_KEY` - Service role key for backend operations
-- `SUPABASE_ANON_KEY` - Anon key
+- `SUPABASE_SECRET_KEY` or `SUPABASE_SERVICE_ROLE_KEY` - Backend/admin access key
+- `JWT_SECRET_KEY` - Secret for JWT signing (required)
 - `DATABASE_URL` - PostgreSQL connection string
 
 Optional:
-- `JWT_SECRET_KEY` - Secret for JWT signing (auto-generated if not set)
+- `SUPABASE_PUBLISHABLE_KEY` or `SUPABASE_ANON_KEY` - Client/public access key
 - `OPENAI_API_KEY` - Required for embeddings endpoints
-- `DEBUG` - Enable debug mode
-- `CORS_ORIGINS` - Allowed CORS origins (default: *)
+- `DEBUG` - Enable debug mode (adds localhost to allowed origins)
+- `CORS_ORIGINS` - Allowed CORS origins (defaults to production domains)

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -370,7 +370,7 @@ async def get_current_agent(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    # Get tier and is_admin from users table (fail gracefully)
+    # Get tier and is_admin from users table (fail closed)
     tier = "free"
     is_admin = False
     try:
@@ -383,9 +383,20 @@ async def get_current_agent(
             is_admin = user.get("is_admin", False)
         else:
             logger.warning(f"User not found in database: {user_id}")
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="User not found",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+    except HTTPException:
+        raise
     except Exception as e:
-        # Log but continue with defaults - don't block auth
-        logger.warning(f"User lookup failed for {user_id}, defaulting to free/non-admin: {e}")
+        logger.warning(f"User lookup failed for {user_id}: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication service unavailable",
+            headers={"Retry-After": "60"},
+        )
 
     return AuthContext(user_id=user_id, tier=tier, is_admin=is_admin, agent_id=agent_id)
 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -813,6 +813,28 @@ async def deactivate_api_key(db: Client, key_id: str, user_id: str) -> bool:
     return len(result.data) > 0
 
 
+async def cycle_api_key_atomic(
+    db: Client,
+    key_id: str,
+    user_id: str,
+    key_hash: str,
+    key_prefix: str,
+    name: str,
+) -> dict | None:
+    """Atomically deactivate an API key and create a replacement."""
+    result = db.rpc(
+        "cycle_api_key",
+        {
+            "p_key_id": key_id,
+            "p_user_id": user_id,
+            "p_key_hash": key_hash,
+            "p_key_prefix": key_prefix,
+            "p_name": name,
+        },
+    ).execute()
+    return result.data[0] if result.data else None
+
+
 async def update_api_key_last_used(db: Client, key_id: str) -> None:
     """Update the last_used_at timestamp for an API key."""
     from datetime import datetime, timezone

--- a/backend/docs/API.md
+++ b/backend/docs/API.md
@@ -118,8 +118,8 @@ Exchange a Supabase OAuth access token for a Kernle access token. Supports accou
 ```
 
 **Side Effects:**
-- Creates new agent if not exists (with seed beliefs)
-- Merges accounts if email matches existing agent
+- Creates/merges user records based on email
+- Agents are created separately when memory features are used
 
 **Errors:**
 - `401 Unauthorized`: Invalid or expired Supabase token
@@ -144,6 +144,56 @@ Get information about the currently authenticated agent.
   "created_at": "2024-01-01T00:00:00Z",
   "last_sync_at": "2024-01-01T00:00:00Z | null",
   "user_id": "string | null"
+}
+```
+
+---
+
+### Login With API Key
+
+```
+POST /auth/login
+```
+
+Validate an API key and return a fresh JWT token. Also sets an httpOnly cookie.
+
+🔒 **Requires Authentication** (via API key)
+
+**Response (200):**
+```json
+{
+  "user_id": "string",
+  "agent_id": "string",
+  "token": "string",
+  "token_expires": "2024-01-01T00:00:00Z"
+}
+```
+
+---
+
+### Usage Stats
+
+```
+GET /auth/usage
+```
+
+Get current usage statistics for the authenticated user.
+
+🔒 **Requires Authentication**
+
+**Response (200):**
+```json
+{
+  "tier": "string",
+  "limits": { "daily_limit": 1000, "monthly_limit": 20000 },
+  "usage": {
+    "daily_requests": 12,
+    "monthly_requests": 340,
+    "daily_reset_at": "2024-01-01T00:00:00Z",
+    "monthly_reset_at": "2024-02-01T00:00:00Z"
+  },
+  "daily_remaining": 988,
+  "monthly_remaining": 19660
 }
 ```
 
@@ -479,7 +529,7 @@ Create embeddings for multiple texts in a single request.
 **Request Body:**
 ```json
 {
-  "texts": ["string", "string", ...] 
+  "texts": ["string", "string", ...]
 }
 ```
 

--- a/backend/supabase/migrations/025_atomic_api_key_cycle.sql
+++ b/backend/supabase/migrations/025_atomic_api_key_cycle.sql
@@ -1,0 +1,69 @@
+-- =============================================================================
+-- Migration 025: Atomic API Key Cycle
+-- =============================================================================
+-- Deactivate an existing API key and create a replacement in a single transaction.
+
+CREATE OR REPLACE FUNCTION cycle_api_key(
+    p_key_id UUID,
+    p_user_id TEXT,
+    p_key_hash TEXT,
+    p_key_prefix TEXT,
+    p_name TEXT
+)
+RETURNS TABLE (
+    id UUID,
+    user_id TEXT,
+    key_prefix TEXT,
+    name TEXT,
+    created_at TIMESTAMPTZ,
+    last_used_at TIMESTAMPTZ,
+    is_active BOOLEAN
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    -- Lock the existing key row to prevent concurrent cycles
+    PERFORM 1
+    FROM api_keys
+    WHERE id = p_key_id
+      AND user_id = p_user_id
+      AND is_active = TRUE
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'API key not found or inactive';
+    END IF;
+
+    UPDATE api_keys
+    SET is_active = FALSE
+    WHERE id = p_key_id
+      AND user_id = p_user_id
+      AND is_active = TRUE;
+
+    RETURN QUERY
+    INSERT INTO api_keys (
+        user_id,
+        key_hash,
+        key_prefix,
+        name,
+        is_active
+    )
+    VALUES (
+        p_user_id,
+        p_key_hash,
+        p_key_prefix,
+        p_name,
+        TRUE
+    )
+    RETURNING
+        api_keys.id,
+        api_keys.user_id,
+        api_keys.key_prefix,
+        api_keys.name,
+        api_keys.created_at,
+        api_keys.last_used_at,
+        api_keys.is_active;
+END;
+$$;
+
+COMMENT ON FUNCTION cycle_api_key IS 'Atomically deactivates an API key and creates a replacement.';

--- a/kernle/storage/sqlite.py
+++ b/kernle/storage/sqlite.py
@@ -822,6 +822,24 @@ class SQLiteStorage:
 
     # === Cloud Search Methods ===
 
+    def _validate_backend_url(self, backend_url: str) -> Optional[str]:
+        """Validate backend URL to avoid leaking auth tokens to unsafe endpoints."""
+        from urllib.parse import urlparse
+
+        parsed = urlparse(backend_url)
+        if parsed.scheme not in {"https", "http"}:
+            logger.warning("Invalid backend_url scheme; only http/https allowed.")
+            return None
+        if not parsed.netloc:
+            logger.warning("Invalid backend_url; missing host.")
+            return None
+        if parsed.scheme == "http":
+            host = parsed.hostname or ""
+            if host not in {"localhost", "127.0.0.1"}:
+                logger.warning("Refusing non-local http backend_url for security.")
+                return None
+        return backend_url
+
     def _load_cloud_credentials(self) -> Optional[Dict[str, str]]:
         """Load cloud credentials from config files or environment variables.
 
@@ -869,6 +887,9 @@ class SQLiteStorage:
                         auth_token = auth_token or config.get("auth_token")
                 except (json.JSONDecodeError, OSError):
                     pass
+
+        if backend_url:
+            backend_url = self._validate_backend_url(backend_url)
 
         if backend_url and auth_token:
             self._cloud_credentials = {
@@ -1569,8 +1590,13 @@ class SQLiteStorage:
 
         # v13: Add source_entity column for entity-neutral provenance (Phase 5)
         source_entity_tables = [
-            "episodes", "beliefs", "agent_values", "goals", "notes",
-            "drives", "relationships",
+            "episodes",
+            "beliefs",
+            "agent_values",
+            "goals",
+            "notes",
+            "drives",
+            "relationships",
         ]
         for table in source_entity_tables:
             if table in table_names:
@@ -1586,8 +1612,15 @@ class SQLiteStorage:
 
         # v14: Add privacy fields (Phase 8a) - subject_ids, access_grants, consent_grants
         privacy_tables = [
-            "episodes", "beliefs", "agent_values", "goals", "notes",
-            "drives", "relationships", "playbooks", "raw_entries",
+            "episodes",
+            "beliefs",
+            "agent_values",
+            "goals",
+            "notes",
+            "drives",
+            "relationships",
+            "playbooks",
+            "raw_entries",
         ]
         privacy_fields = ["subject_ids", "access_grants", "consent_grants"]
         for table in privacy_tables:
@@ -4735,9 +4768,9 @@ class SQLiteStorage:
             params.append(verification_count)
         if confidence_history is not None:
             # Cap confidence_history to prevent unbounded growth
-            MAX_CONFIDENCE_HISTORY = 100
-            if len(confidence_history) > MAX_CONFIDENCE_HISTORY:
-                confidence_history = confidence_history[-MAX_CONFIDENCE_HISTORY:]
+            max_confidence_history = 100
+            if len(confidence_history) > max_confidence_history:
+                confidence_history = confidence_history[-max_confidence_history:]
             updates.append("confidence_history = ?")
             params.append(self._to_json(confidence_history))
 


### PR DESCRIPTION
## Summary
- add atomic API key cycling via RPC and route wiring
- enforce RS256-only OAuth token verification and fail-closed user lookup
- tighten cloud credential backend URL validation and update tests/docs

## Test plan
- [x] pytest backend/tests -q
- [ ] pytest tests -q (fails: 19 failures incl. test_belief_revision, test_mcp, test_metacognition, test_playbooks, test_sqlite_storage)

Made with [Cursor](https://cursor.com)