### PR TITLE
fix: harden auth checks and align docs

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -885,8 +885,10 @@ async def verify_api_key_auth(db: Client, api_key: str) -> dict | None:
 
             # Get tier and admin status from users table
             user = await get_user(db, user_id)
-            tier = user.get("tier", "free") if user else "free"
-            is_admin = user.get("is_admin", False) if user else False
+            if not user:
+                return None
+            tier = user.get("tier", "free")
+            is_admin = user.get("is_admin", False)
 
             return {
                 "user_id": user_id,

--- a/backend/app/rate_limit.py
+++ b/backend/app/rate_limit.py
@@ -3,5 +3,17 @@
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 
+
+def get_client_ip(request) -> str:
+    """Resolve client IP, honoring X-Forwarded-For when present."""
+    forwarded_for = request.headers.get("x-forwarded-for")
+    if forwarded_for:
+        # Use the left-most value (original client)
+        client_ip = forwarded_for.split(",")[0].strip()
+        if client_ip:
+            return client_ip
+    return get_remote_address(request)
+
+
 # Create limiter using client IP address as the key
-limiter = Limiter(key_func=get_remote_address)
+limiter = Limiter(key_func=get_client_ip)

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -113,9 +113,13 @@ class TestAuthEndpoints:
         with (
             patch("app.routes.auth.get_user", new_callable=AsyncMock) as mock_get_user,
             patch("app.routes.auth.get_usage_for_user", new_callable=AsyncMock) as mock_get_usage,
+            patch("app.database.get_user", new_callable=AsyncMock) as mock_auth_get_user,
+            patch("app.database.get_supabase_client") as mock_get_db,
         ):
             mock_get_user.return_value = mock_user
             mock_get_usage.return_value = mock_usage
+            mock_auth_get_user.return_value = mock_user
+            mock_get_db.return_value = MagicMock()
 
             response = client.get("/auth/me", headers=auth_headers)
 

--- a/dev/SETUP.md
+++ b/dev/SETUP.md
@@ -222,7 +222,7 @@ Claude Desktop supports MCP servers for tool access.
 {
   "mcpServers": {
     "kernle": {
-      "command": "kernle", 
+      "command": "kernle",
       "args": ["mcp", "-a", "your-agent-id"]
     }
   }
@@ -280,7 +280,7 @@ When context compacts or sessions reset, the AI reads its instruction file (CLAU
 
 Make sure your instruction file includes:
 1. **Load at start**: `kernle load` or `kernle_load` tool
-2. **Save before end**: `kernle checkpoint save` 
+2. **Save before end**: `kernle checkpoint save`
 3. **Record learnings**: `kernle episode` for significant experiences
 
 ---
@@ -319,7 +319,7 @@ kernle -a your-agent-id consolidate
 
 ## Next Steps
 
-- [Architecture](architecture.md) — How Kernle's memory layers work
+- [Architecture](ARCHITECTURE.md) — How Kernle's memory layers work
 - [CLI Reference](CLI.md) — All available commands
 - [MCP Audit](MCP_AUDIT.md) — MCP server tool reference and security review
 - [Anxiety Tracking](ANXIETY_TRACKING.md) — Understanding the anxiety model

--- a/docs-site/api-reference/authentication.mdx
+++ b/docs-site/api-reference/authentication.mdx
@@ -31,29 +31,22 @@ POST /auth/oauth/token
 
 ```json
 {
-  "success": true,
-  "data": {
-    "user_id": "usr_abc123def456",
-    "email": "user@example.com",
-    "api_key": "knl_sk_your-new-api-key",
-    "tier": "free"
-  }
+  "access_token": "string",
+  "token_type": "bearer",
+  "expires_in": 3600,
+  "user_id": "string"
 }
 ```
 
 <Info>
-This endpoint verifies Supabase JWTs using JWKS (JSON Web Key Set) public key verification. It supports all JWT algorithms used by Supabase (RS256, ES256, HS256).
+This endpoint verifies Supabase JWTs using JWKS (JSON Web Key Set) public key verification.
 </Info>
 
 ---
 
-## Register
+## Register Agent
 
-Create a new Kernle account.
-
-<Note>
-After registration, check your email for verification.
-</Note>
+Create a new agent and user record.
 
 ```http
 POST /auth/register
@@ -63,7 +56,9 @@ POST /auth/register
 
 ```json
 {
-  "email": "user@example.com"
+  "agent_id": "string (1-64 chars, lowercase alphanumeric, _, -)",
+  "display_name": "string | null",
+  "email": "string | null"
 }
 ```
 
@@ -71,35 +66,30 @@ POST /auth/register
 
 ```json
 {
-  "success": true,
-  "data": {
-    "user_id": "user_abc123",
-    "message": "Verification email sent"
-  }
+  "access_token": "string",
+  "token_type": "bearer",
+  "expires_in": 3600,
+  "user_id": "string",
+  "secret": "string (SAVE THIS - shown only once)"
 }
-```
-
-### CLI Equivalent
-
-```bash
-kernle auth register --email user@example.com
 ```
 
 ---
 
-## Verify Email
+## Get Token (Agent Secret)
 
-Verify email address with the token from the verification email.
+Get an access token for an existing agent using its secret.
 
 ```http
-POST /auth/verify
+POST /auth/token
 ```
 
 ### Request Body
 
 ```json
 {
-  "token": "verification_token_from_email"
+  "agent_id": "string",
+  "secret": "string"
 }
 ```
 
@@ -107,65 +97,22 @@ POST /auth/verify
 
 ```json
 {
-  "success": true,
-  "data": {
-    "user_id": "user_abc123",
-    "verified": true,
-    "api_key": "sk-initial-key"
-  }
+  "access_token": "string",
+  "token_type": "bearer",
+  "expires_in": 3600,
+  "user_id": "string | null"
 }
 ```
 
 ---
 
-## Login
+## Login (API Key → JWT)
 
-Get authentication token for an existing account.
+Validate an API key and return a fresh JWT. This endpoint expects the API key
+in the `Authorization` header.
 
 ```http
 POST /auth/login
-```
-
-### Request Body
-
-```json
-{
-  "api_key": "knl_sk_your-api-key"
-}
-```
-
-### Response
-
-```json
-{
-  "success": true,
-  "data": {
-    "user_id": "user_abc123",
-    "token": "session_token",
-    "expires_at": "2024-01-16T10:30:00Z"
-  }
-}
-```
-
-### CLI Equivalent
-
-```bash
-kernle auth login --api-key knl_sk_your-api-key
-```
-
----
-
-## Get Auth Status
-
-Check current authentication status.
-
-```http
-GET /auth/status
-```
-
-### Headers
-
-```
 Authorization: Bearer knl_sk_your-api-key
 ```
 
@@ -173,21 +120,11 @@ Authorization: Bearer knl_sk_your-api-key
 
 ```json
 {
-  "success": true,
-  "data": {
-    "authenticated": true,
-    "user_id": "user_abc123",
-    "email": "user@example.com",
-    "created_at": "2024-01-01T00:00:00Z",
-    "agents": ["claire", "assistant"]
-  }
+  "user_id": "string",
+  "agent_id": "string",
+  "token": "string",
+  "token_expires": "ISO timestamp"
 }
-```
-
-### CLI Equivalent
-
-```bash
-kernle auth status
 ```
 
 ---
@@ -210,27 +147,16 @@ Authorization: Bearer knl_sk_your-api-key
 
 ```json
 {
-  "success": true,
-  "data": {
-    "keys": [
-      {
-        "id": "key_abc123",
-        "name": "Development",
-        "prefix": "knl_sk_abc",
-        "created_at": "2024-01-01T00:00:00Z",
-        "last_used_at": "2024-01-15T10:30:00Z",
-        "is_active": true
-      },
-      {
-        "id": "key_def456",
-        "name": "Production",
-        "prefix": "sk-def",
-        "created_at": "2024-01-10T00:00:00Z",
-        "last_used_at": null,
-        "is_active": true
-      }
-    ]
-  }
+  "keys": [
+    {
+      "id": "key_abc123",
+      "name": "Development",
+      "key_prefix": "knl_sk_abc12...",
+      "created_at": "2024-01-01T00:00:00Z",
+      "last_used_at": "2024-01-15T10:30:00Z",
+      "is_active": true
+    }
+  ]
 }
 ```
 
@@ -272,14 +198,11 @@ The full API key is only returned once at creation time. Store it securely.
 
 ```json
 {
-  "success": true,
-  "data": {
-    "id": "key_xyz789",
-    "name": "My New Key",
-    "key": "sk-full-api-key-only-shown-once",
-    "prefix": "sk-xyz",
-    "created_at": "2024-01-15T10:30:00Z"
-  }
+  "id": "key_xyz789",
+  "name": "My New Key",
+  "key": "knl_sk_full-api-key-only-shown-once",
+  "key_prefix": "knl_sk_abc12",
+  "created_at": "2024-01-15T10:30:00Z"
 }
 ```
 
@@ -307,16 +230,7 @@ Authorization: Bearer knl_sk_your-api-key
 
 ### Response
 
-```json
-{
-  "success": true,
-  "data": {
-    "id": "key_abc123",
-    "revoked": true,
-    "revoked_at": "2024-01-15T10:30:00Z"
-  }
-}
-```
+204 No Content
 
 ### CLI Equivalent
 
@@ -344,13 +258,13 @@ Authorization: Bearer knl_sk_your-api-key
 
 ```json
 {
-  "success": true,
-  "data": {
-    "old_key_id": "key_abc123",
-    "old_key_revoked": true,
-    "new_key_id": "key_xyz789",
-    "new_key": "sk-new-api-key",
-    "new_key_prefix": "sk-xyz"
+  "old_key_id": "key_abc123",
+  "new_key": {
+    "id": "key_xyz789",
+    "name": "My New Key",
+    "key": "knl_sk_new-api-key",
+    "key_prefix": "knl_sk_abc12",
+    "created_at": "2024-01-15T10:30:00Z"
   }
 }
 ```

--- a/docs-site/api-reference/overview.mdx
+++ b/docs-site/api-reference/overview.mdx
@@ -10,24 +10,17 @@ The Kernle API provides programmatic access to memory operations for cloud-synce
 ## Base URL
 
 ```
-https://api.kernle.ai
+https://kernle-backend.up.railway.app
 ```
 
 For self-hosted deployments, use your configured backend URL.
 
 ## Authentication
 
-All API requests require authentication via API key:
+All API requests require authentication via either:
 
-```bash
-Authorization: Bearer knl_sk_your-api-key
-```
-
-API keys use the `knl_sk_` prefix for easy identification. Get your API key from the [Dashboard](https://kernle.ai/settings/keys) or via CLI:
-
-```bash
-kernle auth keys create --name "My App"
-```
+- **API key**: `Authorization: Bearer knl_sk_...`
+- **JWT** (web UI): `Authorization: Bearer <jwt>`
 
 ## Request Format
 
@@ -36,32 +29,12 @@ kernle auth keys create --name "My App"
 
 ## Response Format
 
-All responses follow this structure:
+Responses are JSON objects specific to each endpoint (no envelope). Errors use
+FastAPI-style responses:
 
 ```json
 {
-  "success": true,
-  "data": { ... },
-  "meta": {
-    "timestamp": "2024-01-15T10:30:00Z",
-    "request_id": "req_abc123"
-  }
-}
-```
-
-### Error Responses
-
-```json
-{
-  "success": false,
-  "error": {
-    "code": "invalid_request",
-    "message": "Missing required field: agent_id"
-  },
-  "meta": {
-    "timestamp": "2024-01-15T10:30:00Z",
-    "request_id": "req_abc123"
-  }
+  "detail": "Error message"
 }
 ```
 
@@ -78,19 +51,7 @@ All responses follow this structure:
 
 ## Rate Limits
 
-| Plan | Requests/minute | Requests/day |
-|------|-----------------|--------------|
-| Free | 60 | 1,000 |
-| Pro | 300 | 50,000 |
-| Enterprise | Custom | Custom |
-
-Rate limit headers are included in responses:
-
-```
-X-RateLimit-Limit: 60
-X-RateLimit-Remaining: 45
-X-RateLimit-Reset: 1705312200
-```
+Rate limits are enforced per endpoint (see `backend/docs/API.md`).
 
 ## API Endpoints
 
@@ -108,6 +69,11 @@ X-RateLimit-Reset: 1705312200
     Generate and manage embeddings
   </Card>
 </CardGroup>
+
+<Note>
+Additional endpoints exist for **commerce** and **subscriptions** under
+`/api/v1`. Dedicated API reference pages are coming soon.
+</Note>
 
 ## SDKs
 

--- a/docs-site/cli/overview.mdx
+++ b/docs-site/cli/overview.mdx
@@ -31,6 +31,9 @@ If no agent ID is provided, Kernle will try to resolve one automatically from en
   <Card title="Utility Commands" icon="wrench" href="/cli/utility-commands">
     load, checkpoint, search, status, anxiety, identity, consolidate, export
   </Card>
+  <Card title="Commerce Commands" icon="wallet" href="/commerce/overview">
+    wallet, job, skills, sub
+  </Card>
   <Card title="MCP Server" icon="plug" href="/integration/mcp">
     mcp - Start MCP server for tool integration
   </Card>
@@ -78,6 +81,15 @@ If no agent ID is provided, Kernle will try to resolve one automatically from en
 |---------|-------------|
 | `anxiety` | Check memory health |
 | `forget` | Controlled forgetting |
+
+### Commerce
+
+| Command | Description |
+|---------|-------------|
+| `wallet` | Wallet creation, claiming, limits, and balances |
+| `job` | Job marketplace operations |
+| `skills` | Skills registry management |
+| `sub` | Subscription & tier management |
 | `suggestions` | Review and manage suggestions |
 | `dump` | Export all memory (stdout) |
 | `export` | Export to file |

--- a/docs-site/cli/utility-commands.mdx
+++ b/docs-site/cli/utility-commands.mdx
@@ -579,7 +579,7 @@ kernle -a claire export memory-snapshot.json --format json
 
 ## init
 
-Initialize Kernle with interactive setup.
+Initialize Kernle by generating a `CLAUDE.md`/`AGENTS.md` health check section.
 
 ```bash
 kernle -a <agent> init [options]
@@ -587,17 +587,20 @@ kernle -a <agent> init [options]
 
 | Option | Description |
 |--------|-------------|
-| `-y, --non-interactive` | Use defaults |
-| `--env {claude-code,clawdbot,cline,cursor,desktop}` | Target environment |
-| `--seed-values` | Seed initial values (default: true) |
-| `--no-seed-values` | Skip seeding values |
+| `-s, --style {standard,minimal,combined}` | Section style (default: standard) |
+| `-o, --output PATH` | Output file path (auto-detects CLAUDE.md/AGENTS.md) |
+| `-p, --print` | Print to stdout instead of writing |
+| `-f, --force` | Overwrite/append even if Kernle section already exists |
+| `--no-per-message` | Skip per-message health check section |
+| `-y, --non-interactive` | Use defaults (no prompts) |
+| `--full-setup` | Full setup: instruction file + seed beliefs + platform hooks |
 
 ```bash
 # Interactive
 kernle -a my-project init
 
-# Non-interactive for Claude Code
-kernle -a my-project init -y --env claude-code
+# Non-interactive
+kernle -a my-project init -y --style minimal
 ```
 
 ---

--- a/docs-site/commerce/overview.mdx
+++ b/docs-site/commerce/overview.mdx
@@ -71,7 +71,7 @@ Kernle provides the infrastructure without custody. Agents control their own wal
 ### Verify a Payment
 
 ```python
-from kernle.backend.app.payments import verify_usdc_transfer_sync
+from app.payments.verification import verify_usdc_transfer_sync
 from decimal import Decimal
 
 result = verify_usdc_transfer_sync(
@@ -89,6 +89,10 @@ if result.success:
 else:
     print(f"❌ Verification failed: {result.error}")
 ```
+
+<Note>
+This helper lives in the backend service code and is intended for server-side use.
+</Note>
 
 ## Testnet Dry Run
 

--- a/docs-site/commerce/wallets.mdx
+++ b/docs-site/commerce/wallets.mdx
@@ -28,21 +28,21 @@ class WalletAccount:
     address: str               # EVM address (0x...)
     chain: str                 # "base", "ethereum", etc.
     status: WalletStatus       # active, paused, claimed
-    
+
     # Spending limits
     daily_limit: Decimal       # Max daily spend (USDC)
     weekly_limit: Decimal      # Max weekly spend (USDC)
     monthly_limit: Decimal     # Max monthly spend (USDC)
-    
+
     # Tracking
     spent_today: Decimal
     spent_this_week: Decimal
     spent_this_month: Decimal
-    
+
     # Ownership
     human_owner_id: Optional[str]  # Set when claimed
     claimed_at: Optional[datetime]
-    
+
     created_at: datetime
     updated_at: datetime
 ```
@@ -136,9 +136,10 @@ If a human steward needs to take custody:
 # Human claims the wallet
 await wallet_service.claim_wallet(
     wallet_id=wallet.id,
-    human_owner_id="sean"
+    owner_eoa="0x1234567890123456789012345678901234567890",
+    actor_id="agent_sean"
 )
-# Wallet status changes to "claimed"
+# Wallet status changes to "active"
 # Agent can no longer transfer from this wallet
 ```
 
@@ -158,14 +159,14 @@ Spending limits are enforced **before** signing transactions:
 ```python
 def transfer(self, wallet_id, to, amount):
     wallet = self.get_wallet(wallet_id)
-    
+
     # Check limits BEFORE signing
     if wallet.spent_today + amount > wallet.daily_limit:
         raise SpendingLimitExceededError("daily")
-    
+
     # Only then proceed with transfer
     tx = self._sign_and_send(wallet, to, amount)
-    
+
     # Update tracking
     wallet.spent_today += amount
     self._save(wallet)

--- a/docs-site/concepts/consolidation.mdx
+++ b/docs-site/concepts/consolidation.mdx
@@ -68,7 +68,7 @@ kernle raw process <raw_id> --type episode \
   --outcome "success"
 
 # Process into note
-kernle raw process <raw_id> --type note --type decision
+kernle raw process <raw_id> --type note
 
 # Process into belief
 kernle raw process <raw_id> --type belief --confidence 0.7
@@ -129,7 +129,7 @@ kernle consolidate --min-episodes 3
     - What patterns do I see across these experiences?
     - Do any lessons keep appearing?
     - Does this confirm or contradict what I already believe?
-    
+
     **This is your reasoning, not Kernle's.**
   </Step>
   <Step title="Form Beliefs (Your Decision)">
@@ -167,7 +167,7 @@ $ kernle -a claire consolidate
 #    Lesson: "Always test in staging first"
 #
 # 2. [2025-01-25] "Skipped code review for quick fix"
-#    Outcome: failure  
+#    Outcome: failure
 #    Lesson: "Quick fixes become slow fixes without review"
 #
 # 3. [2025-01-26] "Wrote tests before implementation"
@@ -283,7 +283,7 @@ Recommendations:
     ```bash
     # Save your current state
     kernle checkpoint save "current work description"
-    
+
     # Review unprocessed episodes
     kernle consolidate
     ```
@@ -292,7 +292,7 @@ Recommendations:
     ```bash
     # Emergency save
     kernle anxiety --emergency --summary "Context getting full"
-    
+
     # Or auto-execute recommendations
     kernle anxiety --auto
     ```

--- a/docs-site/concepts/memory-types.mdx
+++ b/docs-site/concepts/memory-types.mdx
@@ -41,9 +41,6 @@ echo "Long notes from meeting..." | kernle raw --stdin
 # List unprocessed
 kernle raw list --unprocessed
 
-# Search raw entries (uses FTS5)
-kernle raw search "API performance"
-
 # Promote to episode
 kernle raw process <id> --type episode --objective "Investigated API errors"
 ```

--- a/docs-site/integration/mcp.mdx
+++ b/docs-site/integration/mcp.mdx
@@ -103,6 +103,7 @@ Loading memories automatically records access for salience-based forgetting. Thi
 | `memory_value` | Define core values |
 | `memory_goal` | Set and manage goals |
 | `memory_drive` | Set or update drives (motivations) |
+| `memory_auto_capture` | Deprecated alias for raw capture |
 
 <Note>
 Playbooks are currently available via CLI only. MCP tools for playbook operations are planned for a future release.

--- a/docs-site/quickstart.mdx
+++ b/docs-site/quickstart.mdx
@@ -27,7 +27,7 @@ description: "Get Kernle running in 5 minutes"
 
 ```bash
 # Initialize with your agent ID
-kernle init -a your-agent-name
+kernle -a your-agent-name init
 
 # Or let it auto-detect your environment
 kernle init

--- a/kernle/commerce/wallet/service.py
+++ b/kernle/commerce/wallet/service.py
@@ -9,22 +9,23 @@ NOTE: CDP integration is stubbed for now. Methods marked with TODO require
 actual CDP SDK integration once the cdp-sdk package is added as a dependency.
 """
 
-from dataclasses import dataclass, field
-from datetime import datetime, timezone, date
-from decimal import Decimal
-from typing import Dict, Optional, Protocol, Tuple
 import logging
 import threading
 import uuid
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from typing import Dict, Optional
 
-from kernle.commerce.config import get_config, CommerceConfig
+from kernle.commerce.config import CommerceConfig, get_config
 from kernle.commerce.wallet.models import WalletAccount, WalletStatus
-from kernle.commerce.wallet.storage import WalletStorage, DailySpendResult
+from kernle.commerce.wallet.storage import DailySpendResult, WalletStorage
 
 
 @dataclass
 class DailySpendRecord:
     """Tracks daily spending for a wallet (in-memory fallback)."""
+
     date: date
     total_spent: Decimal = Decimal("0")
     transaction_count: int = 0
@@ -35,43 +36,50 @@ logger = logging.getLogger(__name__)
 
 class WalletServiceError(Exception):
     """Base exception for wallet service errors."""
+
     pass
 
 
 class WalletNotFoundError(WalletServiceError):
     """Wallet not found."""
+
     pass
 
 
 class WalletNotActiveError(WalletServiceError):
     """Wallet is not active and cannot transact."""
+
     pass
 
 
 class InsufficientBalanceError(WalletServiceError):
     """Insufficient balance for transaction."""
+
     pass
 
 
 class SpendingLimitExceededError(WalletServiceError):
     """Transaction exceeds spending limits."""
+
     pass
 
 
 class CDPIntegrationError(WalletServiceError):
     """Error communicating with CDP."""
+
     pass
 
 
 class WalletAuthorizationError(WalletServiceError):
     """Actor is not authorized to perform this operation on the wallet."""
+
     pass
 
 
 @dataclass
 class WalletBalance:
     """Represents wallet balance information.
-    
+
     Attributes:
         wallet_address: The wallet's Ethereum address
         usdc_balance: USDC balance in human-readable units (not wei)
@@ -79,6 +87,7 @@ class WalletBalance:
         chain: The blockchain network
         as_of: Timestamp when balance was checked
     """
+
     wallet_address: str
     usdc_balance: Decimal
     eth_balance: Decimal
@@ -89,7 +98,7 @@ class WalletBalance:
 @dataclass
 class TransferResult:
     """Result of a transfer operation.
-    
+
     Attributes:
         success: Whether the transfer succeeded
         tx_hash: Transaction hash (if successful)
@@ -98,6 +107,7 @@ class TransferResult:
         to_address: Recipient address
         amount: Amount transferred in USDC
     """
+
     success: bool
     from_address: str
     to_address: str
@@ -108,13 +118,13 @@ class TransferResult:
 
 class WalletService:
     """Service for wallet management and transactions.
-    
+
     Handles wallet lifecycle:
     - Creation: CDP Smart Wallet provisioned at agent registration
     - Claiming: Human owner links their EOA for recovery/control
     - Transactions: Balance checks, transfers within spending limits
     - Lifecycle: Pause, resume, freeze operations
-    
+
     Example:
         >>> service = WalletService(storage)
         >>> wallet = service.create_wallet("agent_123", "usr_456")
@@ -123,14 +133,14 @@ class WalletService:
         >>> balance = service.get_balance(wallet.id)
         >>> print(f"Balance: {balance.usdc_balance} USDC")
     """
-    
+
     def __init__(
         self,
         storage: WalletStorage,
         config: Optional[CommerceConfig] = None,
     ):
         """Initialize wallet service.
-        
+
         Args:
             storage: Wallet storage backend
             config: Commerce configuration (uses global config if not provided)
@@ -138,81 +148,78 @@ class WalletService:
         self.storage = storage
         self.config = config or get_config()
         self._cdp_client = None  # TODO: Initialize CDP client
-        
+
         # Daily spending tracking with thread safety
         # Primary: Database-backed via storage.increment_daily_spend()
         # Fallback: In-memory dict with lock (for InMemoryWalletStorage)
         self._daily_spend: Dict[str, DailySpendRecord] = {}
         self._daily_spend_lock = threading.Lock()  # Thread safety for in-memory fallback
-        
+
     def _get_daily_spend(self, wallet_id: str) -> Decimal:
         """Get the current daily spend for a wallet.
-        
+
         Attempts database lookup first, falls back to in-memory.
         Resets at midnight UTC.
-        
+
         Args:
             wallet_id: Wallet ID
-            
+
         Returns:
             Total spent today in USDC
         """
         # Try database first (preferred)
-        if hasattr(self.storage, 'get_daily_spend'):
+        if hasattr(self.storage, "get_daily_spend"):
             result = self.storage.get_daily_spend(wallet_id)
             if result is not None:
                 return result
-        
+
         # Fallback to in-memory with thread safety
         today = datetime.now(timezone.utc).date()
-        
+
         with self._daily_spend_lock:
             if wallet_id not in self._daily_spend:
                 return Decimal("0")
-            
+
             record = self._daily_spend[wallet_id]
-            
+
             # Reset if it's a new day
             if record.date != today:
                 return Decimal("0")
-            
+
             return record.total_spent
-    
+
     def _try_atomic_spend(
-        self, 
-        wallet_id: str, 
-        amount: Decimal, 
-        daily_limit: float
+        self, wallet_id: str, amount: Decimal, daily_limit: float
     ) -> DailySpendResult:
         """Attempt atomic spend increment with limit check.
-        
+
         Tries database atomic operation first, falls back to in-memory.
-        
+
         Args:
             wallet_id: Wallet ID
             amount: Amount to spend in USDC
             daily_limit: Daily spending limit
-            
+
         Returns:
             DailySpendResult with success status and current state
         """
         # Try database atomic increment first (preferred - handles race conditions)
-        if hasattr(self.storage, 'increment_daily_spend'):
+        if hasattr(self.storage, "increment_daily_spend"):
             result = self.storage.increment_daily_spend(wallet_id, amount)
             if result is not None:
                 return result
-        
+
         # Fallback to in-memory with thread safety
         today = datetime.now(timezone.utc).date()
-        
+
         with self._daily_spend_lock:
             # Get or create record with date check
             if wallet_id not in self._daily_spend or self._daily_spend[wallet_id].date != today:
                 self._daily_spend[wallet_id] = DailySpendRecord(date=today)
-            
+
             record = self._daily_spend[wallet_id]
             new_total = record.total_spent + amount
-            
+
             # Check limit before committing
             if float(new_total) > daily_limit:
                 remaining = Decimal(str(daily_limit)) - record.total_spent
@@ -221,41 +228,41 @@ class WalletService:
                     daily_spent=record.total_spent,
                     daily_limit=Decimal(str(daily_limit)),
                     remaining=remaining,
-                    error=f"Would exceed daily limit. Remaining: {remaining} USDC"
+                    error=f"Would exceed daily limit. Remaining: {remaining} USDC",
                 )
-            
+
             # Commit the spend
             record.total_spent = new_total
             record.transaction_count += 1
-            
+
             return DailySpendResult(
                 success=True,
                 daily_spent=new_total,
                 daily_limit=Decimal(str(daily_limit)),
-                remaining=Decimal(str(daily_limit)) - new_total
+                remaining=Decimal(str(daily_limit)) - new_total,
             )
-    
+
     def _record_spend(self, wallet_id: str, amount: Decimal) -> None:
         """Record a spending transaction for daily limit tracking.
-        
+
         DEPRECATED: Use _try_atomic_spend() for atomic check-and-increment.
         This method is kept for backwards compatibility but should not be
         called in the normal transfer flow.
-        
+
         Args:
             wallet_id: Wallet ID
             amount: Amount spent in USDC
         """
         today = datetime.now(timezone.utc).date()
-        
+
         with self._daily_spend_lock:
             if wallet_id not in self._daily_spend or self._daily_spend[wallet_id].date != today:
                 self._daily_spend[wallet_id] = DailySpendRecord(date=today)
-            
+
             record = self._daily_spend[wallet_id]
             record.total_spent += amount
             record.transaction_count += 1
-    
+
     def _is_authorized_actor(
         self,
         wallet: WalletAccount,
@@ -263,39 +270,39 @@ class WalletService:
         require_owner: bool = False,
     ) -> bool:
         """Check if actor is authorized to operate on this wallet.
-        
+
         Args:
             wallet: The wallet to check authorization for
             actor_id: The actor attempting the operation
             require_owner: If True, only owner_eoa can authorize (not agent)
-            
+
         Returns:
             True if actor is authorized, False otherwise
         """
         # Owner EOA always has full control
         if wallet.owner_eoa and actor_id == wallet.owner_eoa:
             return True
-        
+
         # If owner-only operation, agent cannot authorize
         if require_owner:
             return False
-        
+
         # Agent that owns the wallet can operate it
         if actor_id == wallet.agent_id:
             return True
-        
+
         return False
-    
+
     def _init_cdp_client(self) -> None:
         """Initialize CDP client if credentials are available.
-        
+
         TODO: Implement CDP SDK initialization
         See: https://docs.cdp.coinbase.com/smart-wallet
         """
         if not self.config.has_cdp_credentials:
             logger.warning("CDP credentials not configured - wallet creation will fail")
             return
-            
+
         # TODO: Initialize CDP SDK client
         # from cdp import Cdp
         # self._cdp_client = Cdp(
@@ -303,31 +310,31 @@ class WalletService:
         #     api_secret=self.config.cdp_api_secret,
         # )
         logger.info("CDP client initialization stubbed - implement when SDK is added")
-    
+
     def create_wallet(
         self,
         agent_id: str,
         user_id: Optional[str] = None,
     ) -> WalletAccount:
         """Create a new CDP Smart Wallet for an agent.
-        
+
         This is called during agent registration. The wallet starts in
         'pending_claim' status until the human owner claims it.
-        
+
         Args:
             agent_id: Kernle agent ID this wallet belongs to
             user_id: Optional user ID of the wallet owner
-            
+
         Returns:
             WalletAccount: The newly created wallet
-            
+
         Raises:
             CDPIntegrationError: If CDP wallet creation fails
-            
+
         TODO: Implement actual CDP wallet creation
         """
         logger.info(f"Creating wallet for agent {agent_id}")
-        
+
         # TODO: Call CDP to create Smart Wallet
         # try:
         #     cdp_wallet = self._cdp_client.wallets.create(
@@ -337,7 +344,7 @@ class WalletService:
         #     cdp_wallet_id = cdp_wallet.id
         # except Exception as e:
         #     raise CDPIntegrationError(f"Failed to create CDP wallet: {e}") from e
-        
+
         # STUB: Generate placeholder address for development
         wallet_id = str(uuid.uuid4())
         # Generate deterministic-looking address from agent_id for testing
@@ -347,7 +354,7 @@ class WalletService:
         addr_hex = (base_hash + extra_hash)[:40]
         wallet_address = f"0x{addr_hex}"
         cdp_wallet_id = f"cdp_{wallet_id[:8]}"
-        
+
         wallet = WalletAccount(
             id=wallet_id,
             agent_id=agent_id,
@@ -360,21 +367,21 @@ class WalletService:
             cdp_wallet_id=cdp_wallet_id,
             created_at=datetime.now(timezone.utc),
         )
-        
+
         self.storage.save_wallet(wallet)
         logger.info(f"Created wallet {wallet.wallet_address} for agent {agent_id}")
-        
+
         return wallet
-    
+
     def get_wallet(self, wallet_id: str) -> WalletAccount:
         """Get a wallet by ID.
-        
+
         Args:
             wallet_id: Wallet ID
-            
+
         Returns:
             WalletAccount: The wallet
-            
+
         Raises:
             WalletNotFoundError: If wallet doesn't exist
         """
@@ -382,16 +389,16 @@ class WalletService:
         if not wallet:
             raise WalletNotFoundError(f"Wallet not found: {wallet_id}")
         return wallet
-    
+
     def get_wallet_for_agent(self, agent_id: str) -> WalletAccount:
         """Get the wallet for an agent.
-        
+
         Args:
             agent_id: Kernle agent ID
-            
+
         Returns:
             WalletAccount: The agent's wallet
-            
+
         Raises:
             WalletNotFoundError: If agent has no wallet
         """
@@ -399,45 +406,65 @@ class WalletService:
         if not wallet:
             raise WalletNotFoundError(f"No wallet found for agent: {agent_id}")
         return wallet
-    
+
     def claim_wallet(
         self,
         wallet_id: str,
         owner_eoa: str,
+        *,
+        actor_id: str | None = None,
+        user_id: str | None = None,
     ) -> WalletAccount:
         """Claim a wallet by setting the owner EOA.
-        
+
         This is called when a human owner (typically during Twitter
         verification) links their Ethereum address to the wallet.
         The owner EOA can pause/recover the wallet.
-        
+
         Uses atomic database operations to prevent race conditions where
         two concurrent claim requests could both succeed.
-        
+
         Args:
             wallet_id: Wallet ID to claim
             owner_eoa: Owner's Ethereum address (EOA)
-            
+            actor_id: Agent ID attempting the claim (required for legacy wallets)
+            user_id: User ID attempting the claim (required for user-owned wallets)
+
         Returns:
             WalletAccount: The updated wallet
-            
+
         Raises:
             WalletNotFoundError: If wallet doesn't exist
             WalletServiceError: If wallet is already claimed
-            
+
         TODO: Implement CDP owner assignment
         """
         # Validate EOA format first (before any DB operations)
         if not owner_eoa.startswith("0x") or len(owner_eoa) != 42:
             raise WalletServiceError(f"Invalid EOA format: {owner_eoa}")
-        
+
+        wallet = self.get_wallet(wallet_id)
+
+        # Enforce ownership: either matching user_id (preferred) or matching agent_id
+        if wallet.user_id:
+            if not user_id:
+                raise WalletAuthorizationError("User ID required to claim this wallet")
+            if user_id != wallet.user_id:
+                raise WalletAuthorizationError("Only the wallet owner can claim this wallet")
+        else:
+            # Legacy wallets without user_id: allow only the owning agent
+            if not actor_id:
+                raise WalletAuthorizationError("Actor ID required to claim this wallet")
+            if actor_id != wallet.agent_id:
+                raise WalletAuthorizationError("Only the wallet agent can claim this wallet")
+
         # SECURITY FIX: Use atomic claim to prevent race conditions
         # This atomically checks is_claimed=False AND sets owner_eoa in one operation
         claimed = self.storage.atomic_claim_wallet(
             wallet_id=wallet_id,
             owner_eoa=owner_eoa,
         )
-        
+
         if not claimed:
             # Re-fetch to get current state for error message
             wallet = self.get_wallet(wallet_id)
@@ -447,7 +474,7 @@ class WalletService:
                 )
             else:
                 raise WalletServiceError(f"Failed to claim wallet {wallet_id}")
-        
+
         # TODO: Call CDP to set owner on the Smart Wallet
         # try:
         #     self._cdp_client.wallets.set_owner(
@@ -458,42 +485,42 @@ class WalletService:
         #     # Rollback the claim if CDP fails
         #     self.storage.unclaim_wallet(wallet_id)
         #     raise CDPIntegrationError(f"Failed to set owner: {e}") from e
-        
+
         # Return updated wallet
         wallet = self.get_wallet(wallet_id)
         logger.info(f"Wallet {wallet_id} claimed by owner {owner_eoa}")
         return wallet
-    
+
     def get_balance(self, wallet_id: str) -> WalletBalance:
         """Get the current balance of a wallet.
-        
+
         Args:
             wallet_id: Wallet ID
-            
+
         Returns:
             WalletBalance: Current balance information
-            
+
         Raises:
             WalletNotFoundError: If wallet doesn't exist
             CDPIntegrationError: If balance check fails
-            
+
         TODO: Implement actual balance checking via RPC/CDP
         """
         wallet = self.get_wallet(wallet_id)
-        
+
         # TODO: Query actual balances from chain
         # try:
         #     # Get USDC balance
         #     usdc_contract = self._get_usdc_contract()
         #     usdc_raw = usdc_contract.functions.balanceOf(wallet.wallet_address).call()
         #     usdc_balance = Decimal(usdc_raw) / Decimal(10**6)  # USDC has 6 decimals
-        #     
+        #
         #     # Get ETH balance for gas
         #     eth_raw = self._web3.eth.get_balance(wallet.wallet_address)
         #     eth_balance = Decimal(eth_raw) / Decimal(10**18)
         # except Exception as e:
         #     raise CDPIntegrationError(f"Failed to get balance: {e}") from e
-        
+
         # STUB: Return zero balances for development
         return WalletBalance(
             wallet_address=wallet.wallet_address,
@@ -502,19 +529,19 @@ class WalletService:
             chain=wallet.chain,
             as_of=datetime.now(timezone.utc),
         )
-    
+
     def get_balance_for_agent(self, agent_id: str) -> WalletBalance:
         """Get balance for an agent's wallet.
-        
+
         Args:
             agent_id: Kernle agent ID
-            
+
         Returns:
             WalletBalance: Current balance information
         """
         wallet = self.get_wallet_for_agent(agent_id)
         return self.get_balance(wallet.id)
-    
+
     def transfer(
         self,
         wallet_id: str,
@@ -523,35 +550,35 @@ class WalletService:
         actor_id: str,
     ) -> TransferResult:
         """Transfer USDC from wallet to another address.
-        
+
         Validates spending limits and wallet status before executing.
-        
+
         Args:
             wallet_id: Source wallet ID
             to_address: Destination Ethereum address
             amount: Amount of USDC to transfer
             actor_id: Agent/user initiating the transfer
-            
+
         Returns:
             TransferResult: Result of the transfer operation
-            
+
         Raises:
             WalletNotFoundError: If wallet doesn't exist
             WalletNotActiveError: If wallet cannot transact
             InsufficientBalanceError: If balance is too low
             SpendingLimitExceededError: If transfer exceeds limits
-            
+
         TODO: Implement actual transfer via CDP
         """
         wallet = self.get_wallet(wallet_id)
-        
+
         # SECURITY FIX: Verify actor is authorized to transfer from this wallet
         if not self._is_authorized_actor(wallet, actor_id):
             raise WalletAuthorizationError(
                 f"Actor {actor_id} is not authorized to transfer from wallet {wallet_id}. "
                 f"Must be wallet owner ({wallet.owner_eoa}) or agent ({wallet.agent_id})."
             )
-        
+
         # SECURITY FIX: Reject non-positive transfer amounts
         # Negative amounts could bypass daily spending limits by reducing _daily_spend
         if amount <= 0:
@@ -562,13 +589,13 @@ class WalletService:
                 amount=amount,
                 error="Transfer amount must be positive",
             )
-        
+
         # Validate wallet can transact
         if not wallet.can_transact:
             raise WalletNotActiveError(
                 f"Wallet {wallet_id} is not active (status: {wallet.status})"
             )
-        
+
         # Validate destination address
         if not to_address.startswith("0x") or len(to_address) != 42:
             return TransferResult(
@@ -578,19 +605,18 @@ class WalletService:
                 amount=amount,
                 error=f"Invalid destination address: {to_address}",
             )
-        
+
         # Check per-transaction limit
         if float(amount) > wallet.spending_limit_per_tx:
             raise SpendingLimitExceededError(
-                f"Transfer amount {amount} exceeds per-tx limit "
-                f"{wallet.spending_limit_per_tx}"
+                f"Transfer amount {amount} exceeds per-tx limit " f"{wallet.spending_limit_per_tx}"
             )
-        
+
         # SECURITY FIX: Atomic daily spending limit check and increment
         # Uses database atomic operation when available (thread-safe, persistent)
         # Falls back to in-memory with lock (thread-safe, but resets on restart)
         spend_result = self._try_atomic_spend(wallet_id, amount, wallet.spending_limit_daily)
-        
+
         if not spend_result.success:
             raise SpendingLimitExceededError(
                 f"Transfer would exceed daily limit. "
@@ -598,9 +624,9 @@ class WalletService:
                 f"Already spent today: {spend_result.daily_spent} USDC, "
                 f"Remaining: {spend_result.remaining} USDC"
             )
-        
+
         # TODO: Check actual balance
-        
+
         # TODO: Execute transfer via CDP
         # try:
         #     tx = self._cdp_client.wallets.transfer(
@@ -620,13 +646,13 @@ class WalletService:
         #         amount=amount,
         #         error=str(e),
         #     )
-        
+
         # STUB: Simulate successful transfer
         logger.info(
             f"STUB: Transfer {amount} USDC from {wallet.wallet_address} "
             f"to {to_address} (actor: {actor_id})"
         )
-        
+
         return TransferResult(
             success=True,
             from_address=wallet.wallet_address,
@@ -635,80 +661,78 @@ class WalletService:
             tx_hash=f"0x{'0' * 64}",  # Stub tx hash
             error=None,
         )
-    
+
     def pause_wallet(self, wallet_id: str, actor_id: str) -> WalletAccount:
         """Pause a wallet (disable transactions).
-        
+
         Only the owner EOA can pause a wallet. Agents cannot pause their
         own wallets to prevent malicious self-disabling.
-        
+
         Args:
             wallet_id: Wallet ID to pause
             actor_id: Agent/user requesting the pause (must be owner_eoa)
-            
+
         Returns:
             WalletAccount: Updated wallet
-            
+
         Raises:
             WalletAuthorizationError: If actor is not the owner
         """
         wallet = self.get_wallet(wallet_id)
-        
+
         # SECURITY FIX: Only owner can pause wallet
         if not self._is_authorized_actor(wallet, actor_id, require_owner=True):
             raise WalletAuthorizationError(
                 f"Actor {actor_id} is not authorized to pause wallet {wallet_id}. "
                 f"Only owner ({wallet.owner_eoa}) can pause wallets."
             )
-        
+
         if wallet.status == WalletStatus.PAUSED.value:
             logger.warning(f"Wallet {wallet_id} is already paused")
             return wallet
-        
+
         if wallet.status == WalletStatus.FROZEN.value:
             raise WalletServiceError("Cannot pause a frozen wallet")
-        
+
         self.storage.update_wallet_status(wallet_id, WalletStatus.PAUSED)
         wallet.status = WalletStatus.PAUSED.value
-        
+
         logger.info(f"Wallet {wallet_id} paused by {actor_id}")
         return wallet
-    
+
     def resume_wallet(self, wallet_id: str, actor_id: str) -> WalletAccount:
         """Resume a paused wallet.
-        
+
         Only the owner EOA can resume a wallet.
-        
+
         Args:
             wallet_id: Wallet ID to resume
             actor_id: Agent/user requesting the resume (must be owner_eoa)
-            
+
         Returns:
             WalletAccount: Updated wallet
-            
+
         Raises:
             WalletAuthorizationError: If actor is not the owner
         """
         wallet = self.get_wallet(wallet_id)
-        
+
         # SECURITY FIX: Only owner can resume wallet
         if not self._is_authorized_actor(wallet, actor_id, require_owner=True):
             raise WalletAuthorizationError(
                 f"Actor {actor_id} is not authorized to resume wallet {wallet_id}. "
                 f"Only owner ({wallet.owner_eoa}) can resume wallets."
             )
-        
+
         if wallet.status != WalletStatus.PAUSED.value:
-            raise WalletServiceError(
-                f"Cannot resume wallet in status: {wallet.status}"
-            )
-        
+            raise WalletServiceError(f"Cannot resume wallet in status: {wallet.status}")
+
         self.storage.update_wallet_status(wallet_id, WalletStatus.ACTIVE)
         wallet.status = WalletStatus.ACTIVE.value
-        
+
         logger.info(f"Wallet {wallet_id} resumed by {actor_id}")
         return wallet
-    
+
     def update_spending_limits(
         self,
         wallet_id: str,
@@ -717,23 +741,23 @@ class WalletService:
         actor_id: Optional[str] = None,
     ) -> WalletAccount:
         """Update wallet spending limits.
-        
+
         Only the owner EOA can modify spending limits.
-        
+
         Args:
             wallet_id: Wallet ID
             per_tx: New per-transaction limit (USDC)
             daily: New daily limit (USDC)
             actor_id: Agent/user making the change (must be owner_eoa)
-            
+
         Returns:
             WalletAccount: Updated wallet
-            
+
         Raises:
             WalletAuthorizationError: If actor is not the owner
         """
         wallet = self.get_wallet(wallet_id)
-        
+
         # SECURITY FIX: Only owner can modify spending limits
         if actor_id is None:
             raise WalletAuthorizationError(
@@ -744,19 +768,19 @@ class WalletService:
                 f"Actor {actor_id} is not authorized to update spending limits on wallet {wallet_id}. "
                 f"Only owner ({wallet.owner_eoa}) can modify spending limits."
             )
-        
+
         if per_tx is not None:
             if per_tx <= 0:
                 raise WalletServiceError("Per-transaction limit must be positive")
             wallet.spending_limit_per_tx = per_tx
-            
+
         if daily is not None:
             if daily <= 0:
                 raise WalletServiceError("Daily limit must be positive")
             wallet.spending_limit_daily = daily
-        
+
         self.storage.update_spending_limits(wallet_id, per_tx, daily)
-        
+
         logger.info(
             f"Wallet {wallet_id} spending limits updated: "
             f"per_tx={per_tx}, daily={daily} (by {actor_id})"

--- a/tests/commerce/test_wallet_service.py
+++ b/tests/commerce/test_wallet_service.py
@@ -1,49 +1,49 @@
 """Tests for wallet service."""
 
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timezone
 from decimal import Decimal
 from typing import List, Optional
+
 import pytest
 
 from kernle.commerce.config import CommerceConfig
 from kernle.commerce.wallet.models import WalletAccount, WalletStatus
-from kernle.commerce.wallet.storage import WalletStorage
 from kernle.commerce.wallet.service import (
+    SpendingLimitExceededError,
+    TransferResult,
+    WalletBalance,
+    WalletNotActiveError,
+    WalletNotFoundError,
     WalletService,
     WalletServiceError,
-    WalletNotFoundError,
-    WalletNotActiveError,
-    SpendingLimitExceededError,
-    WalletBalance,
-    TransferResult,
 )
 
 
 class InMemoryWalletStorage:
     """In-memory wallet storage for testing."""
-    
+
     def __init__(self):
         self.wallets: dict[str, WalletAccount] = {}
         self._by_agent: dict[str, str] = {}  # agent_id -> wallet_id
         self._by_address: dict[str, str] = {}  # address -> wallet_id
-    
+
     def save_wallet(self, wallet: WalletAccount) -> str:
         self.wallets[wallet.id] = wallet
         self._by_agent[wallet.agent_id] = wallet.id
         self._by_address[wallet.wallet_address] = wallet.id
         return wallet.id
-    
+
     def get_wallet(self, wallet_id: str) -> Optional[WalletAccount]:
         return self.wallets.get(wallet_id)
-    
+
     def get_wallet_by_agent(self, agent_id: str) -> Optional[WalletAccount]:
         wallet_id = self._by_agent.get(agent_id)
         return self.wallets.get(wallet_id) if wallet_id else None
-    
+
     def get_wallet_by_address(self, address: str) -> Optional[WalletAccount]:
         wallet_id = self._by_address.get(address)
         return self.wallets.get(wallet_id) if wallet_id else None
-    
+
     def update_wallet_status(
         self,
         wallet_id: str,
@@ -58,7 +58,7 @@ class InMemoryWalletStorage:
             wallet.owner_eoa = owner_eoa
             wallet.claimed_at = datetime.now(timezone.utc)
         return True
-    
+
     def update_spending_limits(
         self,
         wallet_id: str,
@@ -73,10 +73,10 @@ class InMemoryWalletStorage:
         if daily is not None:
             wallet.spending_limit_daily = daily
         return True
-    
+
     def list_wallets_by_user(self, user_id: str) -> List[WalletAccount]:
         return [w for w in self.wallets.values() if w.user_id == user_id]
-    
+
     def atomic_claim_wallet(
         self,
         wallet_id: str,
@@ -118,68 +118,68 @@ def service(storage, config):
 
 class TestWalletCreation:
     """Tests for wallet creation."""
-    
+
     def test_create_wallet_basic(self, service, storage):
         """Test creating a wallet with minimal parameters."""
         wallet = service.create_wallet(agent_id="agent-123")
-        
+
         assert wallet.agent_id == "agent-123"
         assert wallet.status == "pending_claim"
         assert wallet.wallet_address.startswith("0x")
         assert len(wallet.wallet_address) == 42
         assert wallet.cdp_wallet_id is not None
         assert wallet.created_at is not None
-        
+
         # Verify saved to storage
         saved = storage.get_wallet(wallet.id)
         assert saved is not None
         assert saved.id == wallet.id
-    
+
     def test_create_wallet_with_user(self, service, storage):
         """Test creating a wallet with user ID."""
         wallet = service.create_wallet(
             agent_id="agent-456",
             user_id="user-789",
         )
-        
+
         assert wallet.user_id == "user-789"
-        
+
         # Should be findable by user
         user_wallets = storage.list_wallets_by_user("user-789")
         assert len(user_wallets) == 1
         assert user_wallets[0].id == wallet.id
-    
+
     def test_create_wallet_uses_config_limits(self, service, config):
         """Test that wallet inherits config spending limits."""
         wallet = service.create_wallet(agent_id="agent-xyz")
-        
+
         assert wallet.spending_limit_per_tx == config.spending_limit_per_tx
         assert wallet.spending_limit_daily == config.spending_limit_daily
 
 
 class TestWalletRetrieval:
     """Tests for wallet retrieval."""
-    
+
     def test_get_wallet_by_id(self, service):
         """Test getting wallet by ID."""
         created = service.create_wallet(agent_id="agent-1")
         fetched = service.get_wallet(created.id)
-        
+
         assert fetched.id == created.id
         assert fetched.agent_id == "agent-1"
-    
+
     def test_get_wallet_not_found(self, service):
         """Test getting non-existent wallet raises error."""
         with pytest.raises(WalletNotFoundError, match="not found"):
             service.get_wallet("nonexistent-id")
-    
+
     def test_get_wallet_for_agent(self, service):
         """Test getting wallet by agent ID."""
         created = service.create_wallet(agent_id="agent-special")
         fetched = service.get_wallet_for_agent("agent-special")
-        
+
         assert fetched.id == created.id
-    
+
     def test_get_wallet_for_agent_not_found(self, service):
         """Test getting wallet for agent without wallet."""
         with pytest.raises(WalletNotFoundError, match="No wallet found"):
@@ -188,73 +188,80 @@ class TestWalletRetrieval:
 
 class TestWalletClaiming:
     """Tests for wallet claiming."""
-    
+
     def test_claim_wallet_success(self, service):
         """Test successfully claiming a wallet."""
         wallet = service.create_wallet(agent_id="agent-to-claim")
-        
+
         claimed = service.claim_wallet(
             wallet_id=wallet.id,
             owner_eoa="0x1234567890123456789012345678901234567890",
+            actor_id="agent-to-claim",
         )
-        
+
         assert claimed.status == "active"
         assert claimed.owner_eoa == "0x1234567890123456789012345678901234567890"
         assert claimed.claimed_at is not None
-    
+
     def test_claim_already_claimed_wallet(self, service):
         """Test claiming already claimed wallet raises error."""
         wallet = service.create_wallet(agent_id="agent-claimed")
         service.claim_wallet(
             wallet_id=wallet.id,
             owner_eoa="0x1234567890123456789012345678901234567890",
+            actor_id="agent-claimed",
         )
-        
+
         with pytest.raises(WalletServiceError, match="already claimed"):
             service.claim_wallet(
                 wallet_id=wallet.id,
                 owner_eoa="0x0987654321098765432109876543210987654321",
+                actor_id="agent-claimed",
             )
-    
+
     def test_claim_with_invalid_eoa(self, service):
         """Test claiming with invalid EOA format."""
         wallet = service.create_wallet(agent_id="agent-bad-eoa")
-        
+
         with pytest.raises(WalletServiceError, match="Invalid EOA"):
-            service.claim_wallet(wallet_id=wallet.id, owner_eoa="not-an-address")
+            service.claim_wallet(
+                wallet_id=wallet.id,
+                owner_eoa="not-an-address",
+                actor_id="agent-bad-eoa",
+            )
 
 
 class TestWalletBalance:
     """Tests for balance checking."""
-    
+
     def test_get_balance_returns_structure(self, service):
         """Test that get_balance returns proper structure."""
         wallet = service.create_wallet(agent_id="agent-balance")
-        
+
         balance = service.get_balance(wallet.id)
-        
+
         assert isinstance(balance, WalletBalance)
         assert balance.wallet_address == wallet.wallet_address
         assert balance.usdc_balance == Decimal("0.00")  # Stub returns 0
         assert balance.chain == "base-sepolia"
         assert balance.as_of is not None
-    
+
     def test_get_balance_for_agent(self, service):
         """Test getting balance by agent ID."""
         wallet = service.create_wallet(agent_id="agent-bal")
         balance = service.get_balance_for_agent("agent-bal")
-        
+
         assert balance.wallet_address == wallet.wallet_address
 
 
 class TestWalletTransfer:
     """Tests for transfer operations."""
-    
+
     def test_transfer_inactive_wallet_fails(self, service):
         """Test transfer from inactive wallet fails."""
         wallet = service.create_wallet(agent_id="agent-inactive")
         # Wallet is pending_claim, not active
-        
+
         with pytest.raises(WalletNotActiveError, match="not active"):
             service.transfer(
                 wallet_id=wallet.id,
@@ -262,7 +269,7 @@ class TestWalletTransfer:
                 amount=Decimal("10.00"),
                 actor_id="agent-inactive",
             )
-    
+
     def test_transfer_exceeds_limit_fails(self, service):
         """Test transfer exceeding per-tx limit fails."""
         wallet = service.create_wallet(agent_id="agent-limit")
@@ -270,8 +277,9 @@ class TestWalletTransfer:
         service.claim_wallet(
             wallet_id=wallet.id,
             owner_eoa="0x1234567890123456789012345678901234567890",
+            actor_id="agent-limit",
         )
-        
+
         with pytest.raises(SpendingLimitExceededError, match="exceeds per-tx"):
             service.transfer(
                 wallet_id=wallet.id,
@@ -279,40 +287,42 @@ class TestWalletTransfer:
                 amount=Decimal("200.00"),  # Over 100 limit
                 actor_id="agent-limit",
             )
-    
+
     def test_transfer_invalid_address_returns_error(self, service):
         """Test transfer to invalid address returns error result."""
         wallet = service.create_wallet(agent_id="agent-bad-dest")
         service.claim_wallet(
             wallet_id=wallet.id,
             owner_eoa="0x1234567890123456789012345678901234567890",
+            actor_id="agent-bad-dest",
         )
-        
+
         result = service.transfer(
             wallet_id=wallet.id,
             to_address="not-an-address",
             amount=Decimal("10.00"),
             actor_id="agent-bad-dest",
         )
-        
+
         assert result.success is False
         assert "Invalid destination" in result.error
-    
+
     def test_transfer_success_stub(self, service):
         """Test successful transfer (stub)."""
         wallet = service.create_wallet(agent_id="agent-transfer")
         service.claim_wallet(
             wallet_id=wallet.id,
             owner_eoa="0x1234567890123456789012345678901234567890",
+            actor_id="agent-transfer",
         )
-        
+
         result = service.transfer(
             wallet_id=wallet.id,
             to_address="0x0987654321098765432109876543210987654321",
             amount=Decimal("50.00"),
             actor_id="agent-transfer",
         )
-        
+
         assert isinstance(result, TransferResult)
         assert result.success is True
         assert result.tx_hash is not None  # Stub returns placeholder
@@ -320,7 +330,7 @@ class TestWalletTransfer:
 
 class TestWalletLifecycle:
     """Tests for wallet lifecycle operations."""
-    
+
     def test_pause_wallet(self, service):
         """Test pausing an active wallet."""
         owner_eoa = "0x1234567890123456789012345678901234567890"
@@ -328,14 +338,15 @@ class TestWalletLifecycle:
         service.claim_wallet(
             wallet_id=wallet.id,
             owner_eoa=owner_eoa,
+            actor_id="agent-pause",
         )
-        
+
         # Only owner can pause
         paused = service.pause_wallet(wallet.id, actor_id=owner_eoa)
-        
+
         assert paused.status == "paused"
         assert not paused.can_transact
-    
+
     def test_resume_wallet(self, service):
         """Test resuming a paused wallet."""
         owner_eoa = "0x1234567890123456789012345678901234567890"
@@ -343,15 +354,16 @@ class TestWalletLifecycle:
         service.claim_wallet(
             wallet_id=wallet.id,
             owner_eoa=owner_eoa,
+            actor_id="agent-resume",
         )
         service.pause_wallet(wallet.id, actor_id=owner_eoa)
-        
+
         # Only owner can resume
         resumed = service.resume_wallet(wallet.id, actor_id=owner_eoa)
-        
+
         assert resumed.status == "active"
         assert resumed.can_transact
-    
+
     def test_resume_non_paused_fails(self, service):
         """Test resuming non-paused wallet fails."""
         owner_eoa = "0x1234567890123456789012345678901234567890"
@@ -359,17 +371,18 @@ class TestWalletLifecycle:
         service.claim_wallet(
             wallet_id=wallet.id,
             owner_eoa=owner_eoa,
+            actor_id="agent-not-paused",
         )
-        
+
         with pytest.raises(WalletServiceError, match="Cannot resume"):
             service.resume_wallet(wallet.id, actor_id=owner_eoa)
-    
+
     def test_update_spending_limits(self, service, storage):
         """Test updating spending limits."""
         owner_eoa = "0x1234567890123456789012345678901234567890"
         wallet = service.create_wallet(agent_id="agent-limits")
-        service.claim_wallet(wallet_id=wallet.id, owner_eoa=owner_eoa)
-        
+        service.claim_wallet(wallet_id=wallet.id, owner_eoa=owner_eoa, actor_id="agent-limits")
+
         # Only owner can update spending limits
         updated = service.update_spending_limits(
             wallet_id=wallet.id,
@@ -377,16 +390,16 @@ class TestWalletLifecycle:
             daily=2000.0,
             actor_id=owner_eoa,
         )
-        
+
         assert updated.spending_limit_per_tx == 200.0
         assert updated.spending_limit_daily == 2000.0
-    
+
     def test_update_spending_limits_invalid(self, service):
         """Test updating with invalid limits fails."""
         owner_eoa = "0x1234567890123456789012345678901234567890"
         wallet = service.create_wallet(agent_id="agent-bad-limits")
-        service.claim_wallet(wallet_id=wallet.id, owner_eoa=owner_eoa)
-        
+        service.claim_wallet(wallet_id=wallet.id, owner_eoa=owner_eoa, actor_id="agent-bad-limits")
+
         with pytest.raises(WalletServiceError, match="must be positive"):
             service.update_spending_limits(
                 wallet_id=wallet.id,
@@ -397,22 +410,23 @@ class TestWalletLifecycle:
 
 class TestDailySpendingLimits:
     """Tests for daily spending limit enforcement."""
-    
+
     def test_daily_limit_enforced(self, service, config):
         """Test that daily spending limit is enforced."""
         wallet = service.create_wallet(agent_id="agent-daily")
         service.claim_wallet(
             wallet_id=wallet.id,
             owner_eoa="0x1234567890123456789012345678901234567890",
+            actor_id="agent-daily",
         )
-        
+
         # Set low daily limit for testing
         service.update_spending_limits(
             wallet_id=wallet.id,
             daily=100.0,  # $100 daily limit
             actor_id=wallet.owner_eoa,
         )
-        
+
         # First transfer should succeed
         result1 = service.transfer(
             wallet_id=wallet.id,
@@ -421,7 +435,7 @@ class TestDailySpendingLimits:
             actor_id="agent-daily",
         )
         assert result1.success is True
-        
+
         # Second transfer within limit should also succeed
         result2 = service.transfer(
             wallet_id=wallet.id,
@@ -430,7 +444,7 @@ class TestDailySpendingLimits:
             actor_id="agent-daily",
         )
         assert result2.success is True
-        
+
         # Third transfer exceeding daily limit should fail
         with pytest.raises(SpendingLimitExceededError, match="daily limit"):
             service.transfer(
@@ -439,22 +453,23 @@ class TestDailySpendingLimits:
                 amount=Decimal("20.00"),  # Would total $110, over $100 limit
                 actor_id="agent-daily",
             )
-    
+
     def test_daily_limit_exact_boundary(self, service):
         """Test transfer at exact daily limit boundary."""
         wallet = service.create_wallet(agent_id="agent-boundary")
         service.claim_wallet(
             wallet_id=wallet.id,
             owner_eoa="0x1234567890123456789012345678901234567890",
+            actor_id="agent-boundary",
         )
-        
+
         # Set daily limit to exactly match transfer
         service.update_spending_limits(
             wallet_id=wallet.id,
             daily=50.0,
             actor_id=wallet.owner_eoa,
         )
-        
+
         # Transfer exactly at limit should succeed
         result = service.transfer(
             wallet_id=wallet.id,
@@ -463,7 +478,7 @@ class TestDailySpendingLimits:
             actor_id="agent-boundary",
         )
         assert result.success is True
-        
+
         # Any additional transfer should fail
         with pytest.raises(SpendingLimitExceededError, match="daily limit"):
             service.transfer(
@@ -472,64 +487,66 @@ class TestDailySpendingLimits:
                 amount=Decimal("0.01"),
                 actor_id="agent-boundary",
             )
-    
+
     def test_negative_transfer_rejected(self, service):
         """Test that negative transfer amounts are rejected."""
         wallet = service.create_wallet(agent_id="agent-negative")
         service.claim_wallet(
             wallet_id=wallet.id,
             owner_eoa="0x1234567890123456789012345678901234567890",
+            actor_id="agent-negative",
         )
-        
+
         result = service.transfer(
             wallet_id=wallet.id,
             to_address="0x0987654321098765432109876543210987654321",
             amount=Decimal("-10.00"),
             actor_id="agent-negative",
         )
-        
+
         assert result.success is False
         assert "positive" in result.error.lower()
-    
+
     def test_zero_transfer_rejected(self, service):
         """Test that zero transfer amounts are rejected."""
         wallet = service.create_wallet(agent_id="agent-zero")
         service.claim_wallet(
             wallet_id=wallet.id,
             owner_eoa="0x1234567890123456789012345678901234567890",
+            actor_id="agent-zero",
         )
-        
+
         result = service.transfer(
             wallet_id=wallet.id,
             to_address="0x0987654321098765432109876543210987654321",
             amount=Decimal("0"),
             actor_id="agent-zero",
         )
-        
+
         assert result.success is False
         assert "positive" in result.error.lower()
-    
+
     def test_concurrent_transfers_thread_safety(self, service):
         """Test that concurrent transfers are handled safely."""
         import threading
-        import time
-        
+
         wallet = service.create_wallet(agent_id="agent-concurrent")
         service.claim_wallet(
             wallet_id=wallet.id,
             owner_eoa="0x1234567890123456789012345678901234567890",
+            actor_id="agent-concurrent",
         )
-        
+
         # Set a daily limit that should allow some but not all concurrent transfers
         service.update_spending_limits(
             wallet_id=wallet.id,
             daily=100.0,
             actor_id=wallet.owner_eoa,
         )
-        
+
         results = []
         errors = []
-        
+
         def make_transfer():
             try:
                 result = service.transfer(
@@ -541,18 +558,18 @@ class TestDailySpendingLimits:
                 results.append(result)
             except SpendingLimitExceededError as e:
                 errors.append(e)
-        
+
         # Launch 5 concurrent transfers of $30 each (total $150, limit is $100)
         threads = [threading.Thread(target=make_transfer) for _ in range(5)]
         for t in threads:
             t.start()
         for t in threads:
             t.join()
-        
+
         # Should have some successes and some failures
         successful = [r for r in results if r.success]
         total_successful_amount = len(successful) * 30
-        
+
         # At most 3 transfers should succeed ($90)
         # Some may fail due to limit
         assert total_successful_amount <= 100


### PR DESCRIPTION
## Summary
- fail closed on missing users, require user records for API key auth, and honor X-Forwarded-For in rate limiting
- enforce wallet claim ownership in service layer and update tests to pass actor/user context
- align docs with actual API/CLI/MCP behavior and fix broken links/examples

## Test plan
- [x] python -m pytest backend/tests
- [x] python -m pytest tests/commerce/test_wallet_service.py
- [x] python -m pytest tests/commerce/test_security.py (1 xfail)
- [x] python -m pytest tests/commerce/test_security_verification.py
- [ ] python -m pytest (fails: existing failures across suite)

Made with [Cursor](https://cursor.com)