### PR TITLE
fix: align Supabase schema with local SQLite for sync compatibility

### DIFF
--- a/backend/supabase/migrations/026_add_missing_memory_columns.sql
+++ b/backend/supabase/migrations/026_add_missing_memory_columns.sql
@@ -1,0 +1,166 @@
+-- Migration 026: Align Supabase schema with local SQLite schema
+--
+-- The local SQLite schema evolved through Phases 1-8, adding provenance,
+-- forgetting, emotional, and context fields. The Supabase schema only had
+-- partial coverage, causing sync push failures ("Database error: operation
+-- failed") when clients send records containing these fields.
+--
+-- This migration adds ALL missing columns to bring Supabase in sync with
+-- the local SQLite dataclass definitions.
+
+-- ============================================================================
+-- Episodes: source_entity, context, context_tags
+-- (Most fields already added in migrations 001 + 003)
+-- ============================================================================
+ALTER TABLE episodes ADD COLUMN IF NOT EXISTS source_entity TEXT;
+ALTER TABLE episodes ADD COLUMN IF NOT EXISTS context TEXT;
+ALTER TABLE episodes ADD COLUMN IF NOT EXISTS context_tags JSONB DEFAULT '[]';
+
+-- ============================================================================
+-- Beliefs: source_entity, context, context_tags, supersedes/superseded_by,
+--          times_reinforced
+-- (Most provenance + forgetting fields already in migration 003)
+-- ============================================================================
+ALTER TABLE beliefs ADD COLUMN IF NOT EXISTS source_entity TEXT;
+ALTER TABLE beliefs ADD COLUMN IF NOT EXISTS context TEXT;
+ALTER TABLE beliefs ADD COLUMN IF NOT EXISTS context_tags JSONB DEFAULT '[]';
+ALTER TABLE beliefs ADD COLUMN IF NOT EXISTS supersedes TEXT;
+ALTER TABLE beliefs ADD COLUMN IF NOT EXISTS superseded_by TEXT;
+ALTER TABLE beliefs ADD COLUMN IF NOT EXISTS times_reinforced INTEGER DEFAULT 0;
+
+-- ============================================================================
+-- Values: many fields missing — provenance, forgetting, context, plus
+--         statement/priority which exist in dataclass but not Supabase
+-- ============================================================================
+ALTER TABLE values ADD COLUMN IF NOT EXISTS statement TEXT;
+ALTER TABLE values ADD COLUMN IF NOT EXISTS priority INTEGER DEFAULT 50;
+ALTER TABLE values ADD COLUMN IF NOT EXISTS confidence REAL DEFAULT 0.9;
+ALTER TABLE values ADD COLUMN IF NOT EXISTS source_type TEXT DEFAULT 'direct_experience';
+ALTER TABLE values ADD COLUMN IF NOT EXISTS source_episodes JSONB;
+ALTER TABLE values ADD COLUMN IF NOT EXISTS derived_from JSONB;
+ALTER TABLE values ADD COLUMN IF NOT EXISTS last_verified TIMESTAMPTZ;
+ALTER TABLE values ADD COLUMN IF NOT EXISTS verification_count INTEGER DEFAULT 0;
+ALTER TABLE values ADD COLUMN IF NOT EXISTS confidence_history JSONB;
+ALTER TABLE values ADD COLUMN IF NOT EXISTS times_accessed INTEGER DEFAULT 0;
+ALTER TABLE values ADD COLUMN IF NOT EXISTS last_accessed TIMESTAMPTZ;
+ALTER TABLE values ADD COLUMN IF NOT EXISTS is_protected BOOLEAN DEFAULT FALSE;
+ALTER TABLE values ADD COLUMN IF NOT EXISTS is_forgotten BOOLEAN DEFAULT FALSE;
+ALTER TABLE values ADD COLUMN IF NOT EXISTS forgotten_at TIMESTAMPTZ;
+ALTER TABLE values ADD COLUMN IF NOT EXISTS forgotten_reason TEXT;
+ALTER TABLE values ADD COLUMN IF NOT EXISTS context TEXT;
+ALTER TABLE values ADD COLUMN IF NOT EXISTS context_tags JSONB DEFAULT '[]';
+
+-- ============================================================================
+-- Goals: title, provenance, forgetting, context fields
+-- ============================================================================
+ALTER TABLE goals ADD COLUMN IF NOT EXISTS title TEXT;
+ALTER TABLE goals ADD COLUMN IF NOT EXISTS confidence REAL DEFAULT 0.8;
+ALTER TABLE goals ADD COLUMN IF NOT EXISTS source_type TEXT DEFAULT 'direct_experience';
+ALTER TABLE goals ADD COLUMN IF NOT EXISTS source_episodes JSONB;
+ALTER TABLE goals ADD COLUMN IF NOT EXISTS derived_from JSONB;
+ALTER TABLE goals ADD COLUMN IF NOT EXISTS last_verified TIMESTAMPTZ;
+ALTER TABLE goals ADD COLUMN IF NOT EXISTS verification_count INTEGER DEFAULT 0;
+ALTER TABLE goals ADD COLUMN IF NOT EXISTS confidence_history JSONB;
+ALTER TABLE goals ADD COLUMN IF NOT EXISTS times_accessed INTEGER DEFAULT 0;
+ALTER TABLE goals ADD COLUMN IF NOT EXISTS last_accessed TIMESTAMPTZ;
+ALTER TABLE goals ADD COLUMN IF NOT EXISTS is_protected BOOLEAN DEFAULT FALSE;
+ALTER TABLE goals ADD COLUMN IF NOT EXISTS is_forgotten BOOLEAN DEFAULT FALSE;
+ALTER TABLE goals ADD COLUMN IF NOT EXISTS forgotten_at TIMESTAMPTZ;
+ALTER TABLE goals ADD COLUMN IF NOT EXISTS forgotten_reason TEXT;
+ALTER TABLE goals ADD COLUMN IF NOT EXISTS context TEXT;
+ALTER TABLE goals ADD COLUMN IF NOT EXISTS context_tags JSONB DEFAULT '[]';
+
+-- ============================================================================
+-- Drives: intensity, focus_areas, provenance, forgetting, context
+-- Note: Supabase has 'strength' while SQLite uses 'intensity' — keep both
+-- ============================================================================
+ALTER TABLE drives ADD COLUMN IF NOT EXISTS intensity REAL DEFAULT 0.5;
+ALTER TABLE drives ADD COLUMN IF NOT EXISTS focus_areas JSONB DEFAULT '[]';
+ALTER TABLE drives ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ;
+ALTER TABLE drives ADD COLUMN IF NOT EXISTS confidence REAL DEFAULT 0.8;
+ALTER TABLE drives ADD COLUMN IF NOT EXISTS source_type TEXT DEFAULT 'direct_experience';
+ALTER TABLE drives ADD COLUMN IF NOT EXISTS source_episodes JSONB;
+ALTER TABLE drives ADD COLUMN IF NOT EXISTS derived_from JSONB;
+ALTER TABLE drives ADD COLUMN IF NOT EXISTS last_verified TIMESTAMPTZ;
+ALTER TABLE drives ADD COLUMN IF NOT EXISTS verification_count INTEGER DEFAULT 0;
+ALTER TABLE drives ADD COLUMN IF NOT EXISTS confidence_history JSONB;
+ALTER TABLE drives ADD COLUMN IF NOT EXISTS times_accessed INTEGER DEFAULT 0;
+ALTER TABLE drives ADD COLUMN IF NOT EXISTS last_accessed TIMESTAMPTZ;
+ALTER TABLE drives ADD COLUMN IF NOT EXISTS is_protected BOOLEAN DEFAULT FALSE;
+ALTER TABLE drives ADD COLUMN IF NOT EXISTS is_forgotten BOOLEAN DEFAULT FALSE;
+ALTER TABLE drives ADD COLUMN IF NOT EXISTS forgotten_at TIMESTAMPTZ;
+ALTER TABLE drives ADD COLUMN IF NOT EXISTS forgotten_reason TEXT;
+ALTER TABLE drives ADD COLUMN IF NOT EXISTS context TEXT;
+ALTER TABLE drives ADD COLUMN IF NOT EXISTS context_tags JSONB DEFAULT '[]';
+
+-- ============================================================================
+-- Relationships: entity_name, entity_type, notes, interaction_count,
+--                last_interaction, confidence, provenance, forgetting, context
+-- Note: Supabase has 'entity' + 'trust'; SQLite uses 'entity_name' +
+--       'sentiment'. Keep both column names for compatibility.
+-- ============================================================================
+ALTER TABLE relationships ADD COLUMN IF NOT EXISTS entity_name TEXT;
+ALTER TABLE relationships ADD COLUMN IF NOT EXISTS entity_type TEXT DEFAULT 'person';
+ALTER TABLE relationships ADD COLUMN IF NOT EXISTS notes TEXT;
+ALTER TABLE relationships ADD COLUMN IF NOT EXISTS interaction_count INTEGER DEFAULT 0;
+ALTER TABLE relationships ADD COLUMN IF NOT EXISTS last_interaction TIMESTAMPTZ;
+ALTER TABLE relationships ADD COLUMN IF NOT EXISTS confidence REAL DEFAULT 0.8;
+ALTER TABLE relationships ADD COLUMN IF NOT EXISTS source_type TEXT DEFAULT 'direct_experience';
+ALTER TABLE relationships ADD COLUMN IF NOT EXISTS source_episodes JSONB;
+ALTER TABLE relationships ADD COLUMN IF NOT EXISTS derived_from JSONB;
+ALTER TABLE relationships ADD COLUMN IF NOT EXISTS last_verified TIMESTAMPTZ;
+ALTER TABLE relationships ADD COLUMN IF NOT EXISTS verification_count INTEGER DEFAULT 0;
+ALTER TABLE relationships ADD COLUMN IF NOT EXISTS confidence_history JSONB;
+ALTER TABLE relationships ADD COLUMN IF NOT EXISTS times_accessed INTEGER DEFAULT 0;
+ALTER TABLE relationships ADD COLUMN IF NOT EXISTS last_accessed TIMESTAMPTZ;
+ALTER TABLE relationships ADD COLUMN IF NOT EXISTS is_protected BOOLEAN DEFAULT FALSE;
+ALTER TABLE relationships ADD COLUMN IF NOT EXISTS is_forgotten BOOLEAN DEFAULT FALSE;
+ALTER TABLE relationships ADD COLUMN IF NOT EXISTS forgotten_at TIMESTAMPTZ;
+ALTER TABLE relationships ADD COLUMN IF NOT EXISTS forgotten_reason TEXT;
+ALTER TABLE relationships ADD COLUMN IF NOT EXISTS context TEXT;
+ALTER TABLE relationships ADD COLUMN IF NOT EXISTS context_tags JSONB DEFAULT '[]';
+
+-- ============================================================================
+-- Notes: source_entity, tags, provenance, forgetting, context
+-- ============================================================================
+ALTER TABLE notes ADD COLUMN IF NOT EXISTS source_entity TEXT;
+ALTER TABLE notes ADD COLUMN IF NOT EXISTS tags JSONB DEFAULT '[]';
+ALTER TABLE notes ADD COLUMN IF NOT EXISTS confidence REAL DEFAULT 0.8;
+ALTER TABLE notes ADD COLUMN IF NOT EXISTS source_type TEXT DEFAULT 'direct_experience';
+ALTER TABLE notes ADD COLUMN IF NOT EXISTS source_episodes JSONB;
+ALTER TABLE notes ADD COLUMN IF NOT EXISTS derived_from JSONB;
+ALTER TABLE notes ADD COLUMN IF NOT EXISTS last_verified TIMESTAMPTZ;
+ALTER TABLE notes ADD COLUMN IF NOT EXISTS verification_count INTEGER DEFAULT 0;
+ALTER TABLE notes ADD COLUMN IF NOT EXISTS confidence_history JSONB;
+ALTER TABLE notes ADD COLUMN IF NOT EXISTS times_accessed INTEGER DEFAULT 0;
+ALTER TABLE notes ADD COLUMN IF NOT EXISTS last_accessed TIMESTAMPTZ;
+ALTER TABLE notes ADD COLUMN IF NOT EXISTS is_protected BOOLEAN DEFAULT FALSE;
+ALTER TABLE notes ADD COLUMN IF NOT EXISTS is_forgotten BOOLEAN DEFAULT FALSE;
+ALTER TABLE notes ADD COLUMN IF NOT EXISTS forgotten_at TIMESTAMPTZ;
+ALTER TABLE notes ADD COLUMN IF NOT EXISTS forgotten_reason TEXT;
+ALTER TABLE notes ADD COLUMN IF NOT EXISTS context TEXT;
+ALTER TABLE notes ADD COLUMN IF NOT EXISTS context_tags JSONB DEFAULT '[]';
+
+-- ============================================================================
+-- Playbooks: additional fields from local schema
+-- ============================================================================
+ALTER TABLE playbooks ADD COLUMN IF NOT EXISTS tags JSONB DEFAULT '[]';
+ALTER TABLE playbooks ADD COLUMN IF NOT EXISTS source_episodes JSONB;
+ALTER TABLE playbooks ADD COLUMN IF NOT EXISTS confidence REAL DEFAULT 0.8;
+ALTER TABLE playbooks ADD COLUMN IF NOT EXISTS mastery_level REAL DEFAULT 0.0;
+ALTER TABLE playbooks ADD COLUMN IF NOT EXISTS success_rate REAL DEFAULT 0.0;
+ALTER TABLE playbooks ADD COLUMN IF NOT EXISTS times_used INTEGER DEFAULT 0;
+ALTER TABLE playbooks ADD COLUMN IF NOT EXISTS last_used TIMESTAMPTZ;
+ALTER TABLE playbooks ADD COLUMN IF NOT EXISTS failure_modes JSONB DEFAULT '[]';
+ALTER TABLE playbooks ADD COLUMN IF NOT EXISTS recovery_steps JSONB DEFAULT '[]';
+ALTER TABLE playbooks ADD COLUMN IF NOT EXISTS context TEXT;
+ALTER TABLE playbooks ADD COLUMN IF NOT EXISTS context_tags JSONB DEFAULT '[]';
+
+-- ============================================================================
+-- Indexes for commonly queried new columns
+-- ============================================================================
+CREATE INDEX IF NOT EXISTS idx_values_is_forgotten ON values(is_forgotten);
+CREATE INDEX IF NOT EXISTS idx_goals_is_forgotten ON goals(is_forgotten);
+CREATE INDEX IF NOT EXISTS idx_drives_is_forgotten ON drives(is_forgotten);
+CREATE INDEX IF NOT EXISTS idx_relationships_is_forgotten ON relationships(is_forgotten);
+CREATE INDEX IF NOT EXISTS idx_notes_is_forgotten ON notes(is_forgotten);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -219,13 +219,13 @@ def mock_supabase_client():
 
     # In-memory storage for different tables
     storage = {
-        "agent_values": [],
-        "agent_beliefs": [],
-        "agent_goals": [],
-        "agent_episodes": [],
-        "agent_drives": [],
-        "agent_relationships": [],
-        "memories": [],
+        "values": [],
+        "beliefs": [],
+        "goals": [],
+        "episodes": [],
+        "drives": [],
+        "relationships": [],
+        "notes": [],
     }
 
     def create_table_mock(table_name: str):

--- a/tests/test_postgres_storage.py
+++ b/tests/test_postgres_storage.py
@@ -93,13 +93,13 @@ def mock_supabase_client():
 
     # Storage for simulating database
     storage = {
-        "agent_episodes": [],
-        "agent_beliefs": [],
-        "agent_values": [],
-        "agent_goals": [],
-        "memories": [],
-        "agent_drives": [],
-        "agent_relationships": [],
+        "episodes": [],
+        "beliefs": [],
+        "values": [],
+        "goals": [],
+        "notes": [],
+        "drives": [],
+        "relationships": [],
         "playbooks": [],
     }
 
@@ -270,25 +270,25 @@ class TestSupabaseEpisodes:
 
         episode_id = storage.save_episode(episode)
         assert episode_id is not None
-        assert len(db["agent_episodes"]) == 1
+        assert len(db["episodes"]) == 1
 
-        saved = db["agent_episodes"][0]
+        saved = db["episodes"][0]
         assert saved["objective"] == "Test objective"
-        assert saved["outcome_description"] == "Test outcome"
+        assert saved["outcome"] == "Test outcome"
 
     def test_get_episodes(self, supabase_storage):
         """Test retrieving episodes."""
         storage, db = supabase_storage
 
         # Add test data directly to mock storage
-        db["agent_episodes"].append(
+        db["episodes"].append(
             {
                 "id": str(uuid.uuid4()),
                 "agent_id": "test_agent",
                 "objective": "First task",
-                "outcome_description": "Completed",
+                "outcome": "Completed",
                 "outcome_type": "success",
-                "lessons_learned": [],
+                "lessons": [],
                 "tags": ["work"],
                 "created_at": datetime.now(timezone.utc).isoformat(),
                 "confidence": 0.9,
@@ -304,12 +304,12 @@ class TestSupabaseEpisodes:
         storage, db = supabase_storage
 
         ep_id = str(uuid.uuid4())
-        db["agent_episodes"].append(
+        db["episodes"].append(
             {
                 "id": ep_id,
                 "agent_id": "test_agent",
                 "objective": "Specific episode",
-                "outcome_description": "Done",
+                "outcome": "Done",
                 "outcome_type": "success",
                 "created_at": datetime.now(timezone.utc).isoformat(),
             }
@@ -324,12 +324,12 @@ class TestSupabaseEpisodes:
         storage, db = supabase_storage
 
         ep_id = str(uuid.uuid4())
-        db["agent_episodes"].append(
+        db["episodes"].append(
             {
                 "id": ep_id,
                 "agent_id": "test_agent",
                 "objective": "Emotional episode",
-                "outcome_description": "Felt good",
+                "outcome": "Felt good",
                 "emotional_valence": 0.0,
                 "emotional_arousal": 0.0,
                 "created_at": datetime.now(timezone.utc).isoformat(),
@@ -360,13 +360,13 @@ class TestSupabaseBeliefs:
 
         belief_id = storage.save_belief(belief)
         assert belief_id is not None
-        assert len(db["agent_beliefs"]) == 1
+        assert len(db["beliefs"]) == 1
 
     def test_get_beliefs(self, supabase_storage):
         """Test retrieving beliefs."""
         storage, db = supabase_storage
 
-        db["agent_beliefs"].append(
+        db["beliefs"].append(
             {
                 "id": str(uuid.uuid4()),
                 "agent_id": "test_agent",
@@ -386,7 +386,7 @@ class TestSupabaseBeliefs:
         """Test finding a belief by statement."""
         storage, db = supabase_storage
 
-        db["agent_beliefs"].append(
+        db["beliefs"].append(
             {
                 "id": str(uuid.uuid4()),
                 "agent_id": "test_agent",
@@ -422,13 +422,13 @@ class TestSupabaseValues:
 
         value_id = storage.save_value(value)
         assert value_id is not None
-        assert len(db["agent_values"]) == 1
+        assert len(db["values"]) == 1
 
     def test_get_values(self, supabase_storage):
         """Test retrieving values."""
         storage, db = supabase_storage
 
-        db["agent_values"].append(
+        db["values"].append(
             {
                 "id": str(uuid.uuid4()),
                 "agent_id": "test_agent",
@@ -466,13 +466,13 @@ class TestSupabaseGoals:
 
         goal_id = storage.save_goal(goal)
         assert goal_id is not None
-        assert len(db["agent_goals"]) == 1
+        assert len(db["goals"]) == 1
 
     def test_get_goals(self, supabase_storage):
         """Test retrieving goals."""
         storage, db = supabase_storage
 
-        db["agent_goals"].append(
+        db["goals"].append(
             {
                 "id": str(uuid.uuid4()),
                 "agent_id": "test_agent",
@@ -509,16 +509,16 @@ class TestSupabaseNotes:
 
         note_id = storage.save_note(note)
         assert note_id is not None
-        assert len(db["memories"]) == 1
+        assert len(db["notes"]) == 1
 
     def test_get_notes(self, supabase_storage):
         """Test retrieving notes."""
         storage, db = supabase_storage
 
-        db["memories"].append(
+        db["notes"].append(
             {
                 "id": str(uuid.uuid4()),
-                "owner_id": "test_agent",
+                "agent_id": "test_agent",
                 "content": "A curated memory",
                 "source": "curated",
                 "metadata": {"note_type": "note", "tags": []},
@@ -556,7 +556,7 @@ class TestSupabaseDrives:
         """Test retrieving drives."""
         storage, db = supabase_storage
 
-        db["agent_drives"].append(
+        db["drives"].append(
             {
                 "id": str(uuid.uuid4()),
                 "agent_id": "test_agent",
@@ -608,11 +608,11 @@ class TestSupabaseStats:
         storage, db = supabase_storage
 
         # Add some test data
-        db["agent_episodes"].append({"id": "1", "agent_id": "test_agent"})
-        db["agent_beliefs"].append({"id": "1", "agent_id": "test_agent", "is_active": True})
-        db["agent_values"].append({"id": "1", "agent_id": "test_agent", "is_active": True})
-        db["agent_goals"].append({"id": "1", "agent_id": "test_agent", "status": "active"})
-        db["memories"].append({"id": "1", "owner_id": "test_agent", "source": "curated"})
+        db["episodes"].append({"id": "1", "agent_id": "test_agent"})
+        db["beliefs"].append({"id": "1", "agent_id": "test_agent", "is_active": True})
+        db["values"].append({"id": "1", "agent_id": "test_agent", "is_active": True})
+        db["goals"].append({"id": "1", "agent_id": "test_agent", "status": "active"})
+        db["notes"].append({"id": "1", "agent_id": "test_agent", "source": "curated"})
 
         stats = storage.get_stats()
         assert "episodes" in stats
@@ -632,13 +632,13 @@ class TestSupabaseSearch:
         """Test searching episodes by text."""
         storage, db = supabase_storage
 
-        db["agent_episodes"].append(
+        db["episodes"].append(
             {
                 "id": str(uuid.uuid4()),
                 "agent_id": "test_agent",
                 "objective": "Implement feature X",
-                "outcome_description": "Successfully deployed",
-                "lessons_learned": ["Plan ahead"],
+                "outcome": "Successfully deployed",
+                "lessons": ["Plan ahead"],
                 "created_at": datetime.now(timezone.utc).isoformat(),
             }
         )
@@ -650,10 +650,10 @@ class TestSupabaseSearch:
         """Test searching notes by content."""
         storage, db = supabase_storage
 
-        db["memories"].append(
+        db["notes"].append(
             {
                 "id": str(uuid.uuid4()),
-                "owner_id": "test_agent",
+                "agent_id": "test_agent",
                 "content": "Important discovery about testing",
                 "source": "curated",
                 "metadata": {},
@@ -676,12 +676,12 @@ class TestSupabaseMetaMemory:
         storage, db = supabase_storage
 
         ep_id = str(uuid.uuid4())
-        db["agent_episodes"].append(
+        db["episodes"].append(
             {
                 "id": ep_id,
                 "agent_id": "test_agent",
                 "objective": "Test memory",
-                "outcome_description": "Found",
+                "outcome": "Found",
                 "created_at": datetime.now(timezone.utc).isoformat(),
             }
         )
@@ -939,12 +939,12 @@ class TestSupabaseForgetting:
         storage, db = supabase_storage
 
         ep_id = str(uuid.uuid4())
-        db["agent_episodes"].append(
+        db["episodes"].append(
             {
                 "id": ep_id,
                 "agent_id": "test_agent",
                 "objective": "Test episode",
-                "outcome_description": "Success",
+                "outcome": "Success",
                 "times_accessed": 0,
                 "last_accessed": None,
                 "created_at": datetime.now(timezone.utc).isoformat(),
@@ -955,7 +955,7 @@ class TestSupabaseForgetting:
         assert result is True
 
         # Verify access was recorded
-        updated = db["agent_episodes"][0]
+        updated = db["episodes"][0]
         assert updated["times_accessed"] == 1
         assert updated["last_accessed"] is not None
 
@@ -964,12 +964,12 @@ class TestSupabaseForgetting:
         storage, db = supabase_storage
 
         ep_id = str(uuid.uuid4())
-        db["agent_episodes"].append(
+        db["episodes"].append(
             {
                 "id": ep_id,
                 "agent_id": "test_agent",
                 "objective": "Test episode",
-                "outcome_description": "Success",
+                "outcome": "Success",
                 "times_accessed": 5,
                 "last_accessed": None,
                 "created_at": datetime.now(timezone.utc).isoformat(),
@@ -978,7 +978,7 @@ class TestSupabaseForgetting:
 
         storage.record_access("episode", ep_id)
 
-        updated = db["agent_episodes"][0]
+        updated = db["episodes"][0]
         assert updated["times_accessed"] == 6
 
     def test_record_access_not_found(self, supabase_storage):
@@ -999,13 +999,13 @@ class TestSupabaseForgetting:
 
         ep_id1 = str(uuid.uuid4())
         ep_id2 = str(uuid.uuid4())
-        db["agent_episodes"].extend(
+        db["episodes"].extend(
             [
                 {
                     "id": ep_id1,
                     "agent_id": "test_agent",
                     "objective": "Episode 1",
-                    "outcome_description": "Success",
+                    "outcome": "Success",
                     "times_accessed": 0,
                     "created_at": datetime.now(timezone.utc).isoformat(),
                 },
@@ -1013,7 +1013,7 @@ class TestSupabaseForgetting:
                     "id": ep_id2,
                     "agent_id": "test_agent",
                     "objective": "Episode 2",
-                    "outcome_description": "Success",
+                    "outcome": "Success",
                     "times_accessed": 0,
                     "created_at": datetime.now(timezone.utc).isoformat(),
                 },
@@ -1028,12 +1028,12 @@ class TestSupabaseForgetting:
         storage, db = supabase_storage
 
         ep_id = str(uuid.uuid4())
-        db["agent_episodes"].append(
+        db["episodes"].append(
             {
                 "id": ep_id,
                 "agent_id": "test_agent",
                 "objective": "Test episode",
-                "outcome_description": "Success",
+                "outcome": "Success",
                 "is_protected": False,
                 "is_forgotten": False,
                 "forgotten_at": None,
@@ -1045,7 +1045,7 @@ class TestSupabaseForgetting:
         result = storage.forget_memory("episode", ep_id, reason="Low salience")
         assert result is True
 
-        updated = db["agent_episodes"][0]
+        updated = db["episodes"][0]
         assert updated["is_forgotten"] is True
         assert updated["forgotten_reason"] == "Low salience"
         assert updated["forgotten_at"] is not None
@@ -1055,12 +1055,12 @@ class TestSupabaseForgetting:
         storage, db = supabase_storage
 
         ep_id = str(uuid.uuid4())
-        db["agent_episodes"].append(
+        db["episodes"].append(
             {
                 "id": ep_id,
                 "agent_id": "test_agent",
                 "objective": "Protected episode",
-                "outcome_description": "Success",
+                "outcome": "Success",
                 "is_protected": True,
                 "is_forgotten": False,
                 "created_at": datetime.now(timezone.utc).isoformat(),
@@ -1070,7 +1070,7 @@ class TestSupabaseForgetting:
         result = storage.forget_memory("episode", ep_id)
         assert result is False
 
-        updated = db["agent_episodes"][0]
+        updated = db["episodes"][0]
         assert updated["is_forgotten"] is False
 
     def test_forget_already_forgotten_fails(self, supabase_storage):
@@ -1078,12 +1078,12 @@ class TestSupabaseForgetting:
         storage, db = supabase_storage
 
         ep_id = str(uuid.uuid4())
-        db["agent_episodes"].append(
+        db["episodes"].append(
             {
                 "id": ep_id,
                 "agent_id": "test_agent",
                 "objective": "Already forgotten",
-                "outcome_description": "Success",
+                "outcome": "Success",
                 "is_protected": False,
                 "is_forgotten": True,
                 "forgotten_at": datetime.now(timezone.utc).isoformat(),
@@ -1099,12 +1099,12 @@ class TestSupabaseForgetting:
         storage, db = supabase_storage
 
         ep_id = str(uuid.uuid4())
-        db["agent_episodes"].append(
+        db["episodes"].append(
             {
                 "id": ep_id,
                 "agent_id": "test_agent",
                 "objective": "Forgotten episode",
-                "outcome_description": "Success",
+                "outcome": "Success",
                 "is_forgotten": True,
                 "forgotten_at": datetime.now(timezone.utc).isoformat(),
                 "forgotten_reason": "Test",
@@ -1115,7 +1115,7 @@ class TestSupabaseForgetting:
         result = storage.recover_memory("episode", ep_id)
         assert result is True
 
-        updated = db["agent_episodes"][0]
+        updated = db["episodes"][0]
         assert updated["is_forgotten"] is False
         assert updated["forgotten_at"] is None
         assert updated["forgotten_reason"] is None
@@ -1125,12 +1125,12 @@ class TestSupabaseForgetting:
         storage, db = supabase_storage
 
         ep_id = str(uuid.uuid4())
-        db["agent_episodes"].append(
+        db["episodes"].append(
             {
                 "id": ep_id,
                 "agent_id": "test_agent",
                 "objective": "Normal episode",
-                "outcome_description": "Success",
+                "outcome": "Success",
                 "is_forgotten": False,
                 "created_at": datetime.now(timezone.utc).isoformat(),
             }
@@ -1144,12 +1144,12 @@ class TestSupabaseForgetting:
         storage, db = supabase_storage
 
         ep_id = str(uuid.uuid4())
-        db["agent_episodes"].append(
+        db["episodes"].append(
             {
                 "id": ep_id,
                 "agent_id": "test_agent",
                 "objective": "Test episode",
-                "outcome_description": "Success",
+                "outcome": "Success",
                 "is_protected": False,
                 "created_at": datetime.now(timezone.utc).isoformat(),
             }
@@ -1158,7 +1158,7 @@ class TestSupabaseForgetting:
         result = storage.protect_memory("episode", ep_id, protected=True)
         assert result is True
 
-        updated = db["agent_episodes"][0]
+        updated = db["episodes"][0]
         assert updated["is_protected"] is True
 
     def test_unprotect_memory(self, supabase_storage):
@@ -1166,12 +1166,12 @@ class TestSupabaseForgetting:
         storage, db = supabase_storage
 
         ep_id = str(uuid.uuid4())
-        db["agent_episodes"].append(
+        db["episodes"].append(
             {
                 "id": ep_id,
                 "agent_id": "test_agent",
                 "objective": "Test episode",
-                "outcome_description": "Success",
+                "outcome": "Success",
                 "is_protected": True,
                 "created_at": datetime.now(timezone.utc).isoformat(),
             }
@@ -1180,7 +1180,7 @@ class TestSupabaseForgetting:
         result = storage.protect_memory("episode", ep_id, protected=False)
         assert result is True
 
-        updated = db["agent_episodes"][0]
+        updated = db["episodes"][0]
         assert updated["is_protected"] is False
 
     def test_get_forgetting_candidates(self, supabase_storage):
@@ -1189,12 +1189,12 @@ class TestSupabaseForgetting:
 
         # Add old episode (120 days ago) with low confidence
         old_date = datetime.now(timezone.utc).isoformat()
-        db["agent_episodes"].append(
+        db["episodes"].append(
             {
                 "id": "old-episode",
                 "agent_id": "test_agent",
                 "objective": "Old episode",
-                "outcome_description": "Meh",
+                "outcome": "Meh",
                 "confidence": 0.3,
                 "times_accessed": 0,
                 "last_accessed": None,
@@ -1205,12 +1205,12 @@ class TestSupabaseForgetting:
         )
 
         # Add protected episode (should not be a candidate)
-        db["agent_episodes"].append(
+        db["episodes"].append(
             {
                 "id": "protected-episode",
                 "agent_id": "test_agent",
                 "objective": "Protected episode",
-                "outcome_description": "Important",
+                "outcome": "Important",
                 "confidence": 0.3,
                 "times_accessed": 0,
                 "is_protected": True,
@@ -1220,12 +1220,12 @@ class TestSupabaseForgetting:
         )
 
         # Add already forgotten episode (should not be a candidate)
-        db["agent_episodes"].append(
+        db["episodes"].append(
             {
                 "id": "forgotten-episode",
                 "agent_id": "test_agent",
                 "objective": "Already forgotten",
-                "outcome_description": "Old",
+                "outcome": "Old",
                 "confidence": 0.3,
                 "times_accessed": 0,
                 "is_protected": False,
@@ -1248,12 +1248,12 @@ class TestSupabaseForgetting:
         now = datetime.now(timezone.utc).isoformat()
 
         # High salience (high confidence, recent access)
-        db["agent_episodes"].append(
+        db["episodes"].append(
             {
                 "id": "high-salience",
                 "agent_id": "test_agent",
                 "objective": "High salience",
-                "outcome_description": "Great",
+                "outcome": "Great",
                 "confidence": 0.9,
                 "times_accessed": 10,
                 "last_accessed": now,
@@ -1264,12 +1264,12 @@ class TestSupabaseForgetting:
         )
 
         # Low salience (low confidence, never accessed)
-        db["agent_episodes"].append(
+        db["episodes"].append(
             {
                 "id": "low-salience",
                 "agent_id": "test_agent",
                 "objective": "Low salience",
-                "outcome_description": "Meh",
+                "outcome": "Meh",
                 "confidence": 0.2,
                 "times_accessed": 0,
                 "last_accessed": None,
@@ -1294,12 +1294,12 @@ class TestSupabaseForgetting:
         now = datetime.now(timezone.utc).isoformat()
 
         # Add forgotten episodes
-        db["agent_episodes"].append(
+        db["episodes"].append(
             {
                 "id": "forgotten-1",
                 "agent_id": "test_agent",
                 "objective": "Forgotten 1",
-                "outcome_description": "Old",
+                "outcome": "Old",
                 "is_forgotten": True,
                 "forgotten_at": now,
                 "forgotten_reason": "Low salience",
@@ -1307,12 +1307,12 @@ class TestSupabaseForgetting:
             }
         )
 
-        db["agent_episodes"].append(
+        db["episodes"].append(
             {
                 "id": "forgotten-2",
                 "agent_id": "test_agent",
                 "objective": "Forgotten 2",
-                "outcome_description": "Old",
+                "outcome": "Old",
                 "is_forgotten": True,
                 "forgotten_at": now,
                 "forgotten_reason": "Manual",
@@ -1321,12 +1321,12 @@ class TestSupabaseForgetting:
         )
 
         # Add non-forgotten episode (should not be returned)
-        db["agent_episodes"].append(
+        db["episodes"].append(
             {
                 "id": "active",
                 "agent_id": "test_agent",
                 "objective": "Active",
-                "outcome_description": "Current",
+                "outcome": "Current",
                 "is_forgotten": False,
                 "created_at": now,
             }
@@ -1344,12 +1344,12 @@ class TestSupabaseForgetting:
         """Test getting forgotten memories when none exist."""
         storage, db = supabase_storage
 
-        db["agent_episodes"].append(
+        db["episodes"].append(
             {
                 "id": "active",
                 "agent_id": "test_agent",
                 "objective": "Active",
-                "outcome_description": "Current",
+                "outcome": "Current",
                 "is_forgotten": False,
                 "created_at": datetime.now(timezone.utc).isoformat(),
             }
@@ -1363,7 +1363,7 @@ class TestSupabaseForgetting:
         storage, db = supabase_storage
 
         belief_id = str(uuid.uuid4())
-        db["agent_beliefs"].append(
+        db["beliefs"].append(
             {
                 "id": belief_id,
                 "agent_id": "test_agent",
@@ -1380,18 +1380,18 @@ class TestSupabaseForgetting:
         result = storage.forget_memory("belief", belief_id, reason="Outdated")
         assert result is True
 
-        updated = db["agent_beliefs"][0]
+        updated = db["beliefs"][0]
         assert updated["is_forgotten"] is True
 
-    def test_forget_note_uses_owner_id(self, supabase_storage):
-        """Test that forgetting notes uses owner_id correctly."""
+    def test_forget_note_uses_agent_id(self, supabase_storage):
+        """Test that forgetting notes uses agent_id correctly."""
         storage, db = supabase_storage
 
         note_id = str(uuid.uuid4())
-        db["memories"].append(
+        db["notes"].append(
             {
                 "id": note_id,
-                "owner_id": "test_agent",  # Notes use owner_id, not agent_id
+                "agent_id": "test_agent",  # Notes use agent_id, not agent_id
                 "content": "Test note",
                 "source": "curated",
                 "is_protected": False,
@@ -1404,5 +1404,5 @@ class TestSupabaseForgetting:
         result = storage.forget_memory("note", note_id, reason="Cleanup")
         assert result is True
 
-        updated = db["memories"][0]
+        updated = db["notes"][0]
         assert updated["is_forgotten"] is True

--- a/uv.lock
+++ b/uv.lock
@@ -628,7 +628,7 @@ wheels = [
 
 [[package]]
 name = "kernle"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "python-dotenv" },


### PR DESCRIPTION
## Summary

Three-part fix for sync push failures ('Database error: operation failed'):

### 1. Supabase migration 026
Adds all missing columns across 8 memory tables to match local SQLite schema:
- `source_entity`, `context`, `context_tags` on episodes/beliefs/notes
- Full provenance + forgetting fields on values/goals/drives/relationships/notes  
- Playbook extended fields (mastery_level, success_rate, times_used, etc.)

### 2. postgres.py schema alignment
- Table names: `agent_episodes`→`episodes`, `agent_beliefs`→`beliefs`, etc.
- Column names: `outcome_description`→`outcome`, `lessons_learned`→`lessons`
- Notes: `memories` table→`notes` table, `owner_id`→`agent_id`
- Remove non-existent columns (`is_reflected`, `is_foundational`, `visibility`, etc.)
- Add provenance + context fields to all save methods

### 3. CLI sync push fix
- Re-fetch fallback now uses dataclass field introspection instead of hardcoded field list
- Pull path: Episode constructor uses `outcome` not `outcome_description`
- Both push paths handle all current + future dataclass fields automatically

## Root cause
`postgres.py` was written for a different schema than what the Supabase migrations actually created. The divergence grew as Phases 1-8 added fields to SQLite without corresponding Supabase migrations. This is the F27/F28 finding from the adversarial audit.

## Test plan
- [x] `python -m pytest tests/test_postgres_storage.py` — 55 passed
- [x] `python -m pytest tests/test_core.py tests/test_export_cache.py tests/test_boot_config.py tests/test_sqlite_storage.py` — 238 passed (10 failed = pre-existing search/embedding)
- [x] `python -m pytest backend/tests/` — 148 passed, 7 failed (pre-existing commerce)
- [ ] Run migration 026 on Supabase before testing sync end-to-end

## Deployment note
Migration 026 must be applied to Supabase **before** deploying this code change. Otherwise the stored payload path will still fail for records with the new fields (though the migration uses `IF NOT EXISTS` so it's safe to run idempotently).