### PR TITLE
feat: add promote command — episodes → beliefs promotion

### DIFF
--- a/kernle/cli/__main__.py
+++ b/kernle/cli/__main__.py
@@ -32,6 +32,7 @@ from kernle.cli.commands import (
     cmd_init_md,
     cmd_meta,
     cmd_playbook,
+    cmd_promote,
     cmd_raw,
     cmd_stats,
     cmd_subscription,
@@ -2791,7 +2792,42 @@ def main():
     drive_satisfy.add_argument("type", help="Drive type")
     drive_satisfy.add_argument("--amount", "-a", type=float, default=0.2)
 
-    # consolidate
+    # promote (episodes → beliefs)
+    p_promote = subparsers.add_parser(
+        "promote", help="Promote recurring patterns from episodes into beliefs"
+    )
+    p_promote.add_argument(
+        "--auto",
+        action="store_true",
+        help="Create beliefs automatically (default: suggestions only)",
+    )
+    p_promote.add_argument(
+        "--min-occurrences",
+        type=int,
+        default=2,
+        help="Minimum times a lesson must appear to be promoted (default: 2)",
+    )
+    p_promote.add_argument(
+        "--min-episodes",
+        type=int,
+        default=3,
+        help="Minimum episodes required to run (default: 3)",
+    )
+    p_promote.add_argument(
+        "--confidence",
+        type=float,
+        default=0.7,
+        help="Initial confidence for auto-created beliefs (default: 0.7)",
+    )
+    p_promote.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help="Maximum episodes to scan (default: 50)",
+    )
+    p_promote.add_argument("--json", action="store_true", help="Output JSON")
+
+    # consolidate (kept as alias / legacy guided reflection)
     p_consolidate = subparsers.add_parser("consolidate", help="Output guided reflection prompt")
     p_consolidate.add_argument(
         "--min-episodes",
@@ -3957,6 +3993,8 @@ Beliefs already present in the agent's memory will be skipped.
             cmd_relation(args, k)
         elif args.command == "drive":
             cmd_drive(args, k)
+        elif args.command == "promote":
+            cmd_promote(args, k)
         elif args.command == "consolidate":
             cmd_consolidate(args, k)
         elif args.command == "when":

--- a/kernle/cli/commands/__init__.py
+++ b/kernle/cli/commands/__init__.py
@@ -8,7 +8,7 @@ from kernle.cli.commands.belief import cmd_belief
 from kernle.cli.commands.doctor import cmd_doctor
 from kernle.cli.commands.emotion import cmd_emotion
 from kernle.cli.commands.forget import cmd_forget
-from kernle.cli.commands.identity import cmd_consolidate, cmd_identity
+from kernle.cli.commands.identity import cmd_consolidate, cmd_identity, cmd_promote
 from kernle.cli.commands.init import cmd_init as cmd_init_md
 from kernle.cli.commands.meta import cmd_meta
 from kernle.cli.commands.playbook import cmd_playbook
@@ -21,6 +21,7 @@ __all__ = [
     "cmd_anxiety",
     "cmd_belief",
     "cmd_consolidate",
+    "cmd_promote",
     "cmd_doctor",
     "cmd_emotion",
     "cmd_forget",

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -1,0 +1,234 @@
+"""Tests for the promote (episodes → beliefs) feature."""
+
+import tempfile
+import os
+import json
+from pathlib import Path
+import pytest
+
+from kernle import Kernle
+from kernle.storage.sqlite import SQLiteStorage
+
+
+@pytest.fixture
+def kernle_instance():
+    """Create an isolated Kernle instance with temp storage."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.db"
+        storage = SQLiteStorage(agent_id="test-promote", db_path=db_path)
+        k = Kernle(
+            agent_id="test-promote",
+            storage=storage,
+            checkpoint_dir=Path(tmpdir),
+        )
+        yield k
+
+
+class TestPromoteBasic:
+    """Test basic promote functionality."""
+
+    def test_promote_no_episodes(self, kernle_instance):
+        """Promote with no episodes returns empty."""
+        result = kernle_instance.promote()
+        assert result["episodes_scanned"] == 0
+        assert result["patterns_found"] == 0
+        assert result["suggestions"] == []
+        assert result["beliefs_created"] == 0
+        assert "message" in result
+
+    def test_promote_few_episodes(self, kernle_instance):
+        """Promote with fewer than min_episodes returns message."""
+        kernle_instance.episode("task1", "done", lessons=["lesson A"])
+        result = kernle_instance.promote(min_episodes=3)
+        assert result["episodes_scanned"] == 1
+        assert "Need at least 3" in result["message"]
+
+    def test_promote_no_patterns(self, kernle_instance):
+        """Episodes with unique lessons produce no patterns."""
+        kernle_instance.episode("task1", "done", lessons=["unique lesson 1"])
+        kernle_instance.episode("task2", "done", lessons=["unique lesson 2"])
+        kernle_instance.episode("task3", "done", lessons=["unique lesson 3"])
+        result = kernle_instance.promote()
+        assert result["episodes_scanned"] == 3
+        assert result["patterns_found"] == 0
+        assert result["suggestions"] == []
+
+    def test_promote_finds_patterns(self, kernle_instance):
+        """Recurring lessons are detected as patterns."""
+        kernle_instance.episode("task1", "done", lessons=["recurring lesson"])
+        kernle_instance.episode("task2", "done", lessons=["recurring lesson"])
+        kernle_instance.episode("task3", "done", lessons=["unique lesson"])
+        result = kernle_instance.promote()
+        assert result["patterns_found"] == 1
+        assert len(result["suggestions"]) == 1
+        assert result["suggestions"][0]["lesson"] == "recurring lesson"
+        assert result["suggestions"][0]["count"] == 2
+
+    def test_promote_multiple_patterns(self, kernle_instance):
+        """Multiple recurring patterns are detected and sorted by frequency."""
+        kernle_instance.episode("t1", "done", lessons=["pattern A", "pattern B"])
+        kernle_instance.episode("t2", "done", lessons=["pattern A", "pattern B"])
+        kernle_instance.episode("t3", "done", lessons=["pattern A"])
+        result = kernle_instance.promote()
+        assert result["patterns_found"] == 2
+        # pattern A appears 3x, pattern B appears 2x — sorted by frequency
+        assert result["suggestions"][0]["lesson"] == "pattern A"
+        assert result["suggestions"][0]["count"] == 3
+        assert result["suggestions"][1]["lesson"] == "pattern B"
+        assert result["suggestions"][1]["count"] == 2
+
+
+class TestPromoteSuggestionMode:
+    """Test default (suggestion-only) mode."""
+
+    def test_suggestions_not_promoted(self, kernle_instance):
+        """Default mode returns suggestions without creating beliefs."""
+        kernle_instance.episode("t1", "done", lessons=["recurring"])
+        kernle_instance.episode("t2", "done", lessons=["recurring"])
+        kernle_instance.episode("t3", "done", lessons=["other"])
+        result = kernle_instance.promote(auto=False)
+        assert result["beliefs_created"] == 0
+        assert result["suggestions"][0]["promoted"] is False
+        assert result["suggestions"][0]["belief_id"] is None
+
+        # Verify no beliefs were created
+        beliefs = kernle_instance._storage.get_beliefs()
+        assert len(beliefs) == 0
+
+    def test_suggestions_include_source_episodes(self, kernle_instance):
+        """Suggestions include source episode IDs."""
+        ep1 = kernle_instance.episode("t1", "done", lessons=["pattern X"])
+        ep2 = kernle_instance.episode("t2", "done", lessons=["pattern X"])
+        kernle_instance.episode("t3", "done", lessons=["filler"])
+        result = kernle_instance.promote()
+        source_ids = result["suggestions"][0]["source_episodes"]
+        assert ep1 in source_ids
+        assert ep2 in source_ids
+
+
+class TestPromoteAutoMode:
+    """Test auto-promotion mode."""
+
+    def test_auto_creates_beliefs(self, kernle_instance):
+        """Auto mode creates beliefs from recurring patterns."""
+        kernle_instance.episode("t1", "done", lessons=["auto pattern"])
+        kernle_instance.episode("t2", "done", lessons=["auto pattern"])
+        kernle_instance.episode("t3", "done", lessons=["filler"])
+        result = kernle_instance.promote(auto=True)
+        assert result["beliefs_created"] == 1
+        assert result["suggestions"][0]["promoted"] is True
+        assert result["suggestions"][0]["belief_id"] is not None
+
+        # Verify belief was actually created
+        beliefs = kernle_instance._storage.get_beliefs()
+        created = [b for b in beliefs if b.statement == "auto pattern"]
+        assert len(created) == 1
+        assert created[0].confidence == 0.7
+        assert created[0].belief_type == "pattern"
+        assert created[0].source_type == "consolidation"  # "promotion" maps to consolidation
+
+    def test_auto_sets_provenance(self, kernle_instance):
+        """Auto-created beliefs have proper provenance."""
+        ep1 = kernle_instance.episode("t1", "done", lessons=["prov test"])
+        ep2 = kernle_instance.episode("t2", "done", lessons=["prov test"])
+        kernle_instance.episode("t3", "done", lessons=["filler"])
+        result = kernle_instance.promote(auto=True)
+        belief_id = result["suggestions"][0]["belief_id"]
+
+        beliefs = kernle_instance._storage.get_beliefs()
+        belief = [b for b in beliefs if b.id == belief_id][0]
+        # derived_from should include episode references
+        assert any(f"episode:{ep1}" in ref for ref in belief.derived_from)
+        assert any(f"episode:{ep2}" in ref for ref in belief.derived_from)
+
+    def test_auto_custom_confidence(self, kernle_instance):
+        """Auto mode respects custom confidence."""
+        kernle_instance.episode("t1", "done", lessons=["conf test"])
+        kernle_instance.episode("t2", "done", lessons=["conf test"])
+        kernle_instance.episode("t3", "done", lessons=["filler"])
+        result = kernle_instance.promote(auto=True, confidence=0.5)
+        belief_id = result["suggestions"][0]["belief_id"]
+
+        beliefs = kernle_instance._storage.get_beliefs()
+        belief = [b for b in beliefs if b.id == belief_id][0]
+        assert belief.confidence == 0.5
+
+    def test_auto_skips_existing_beliefs(self, kernle_instance):
+        """Auto mode skips patterns that match existing beliefs."""
+        # Create a belief first
+        kernle_instance.belief("already known")
+        # Create episodes with matching lesson
+        kernle_instance.episode("t1", "done", lessons=["already known"])
+        kernle_instance.episode("t2", "done", lessons=["already known"])
+        kernle_instance.episode("t3", "done", lessons=["filler"])
+        result = kernle_instance.promote(auto=True)
+        assert result["beliefs_created"] == 0
+        assert result["suggestions"][0]["skipped"] == "similar_belief_exists"
+
+    def test_auto_no_duplicates_within_run(self, kernle_instance):
+        """Auto mode doesn't create duplicate beliefs within a single run."""
+        # Same lesson appears in many episodes
+        kernle_instance.episode("t1", "done", lessons=["dup test"])
+        kernle_instance.episode("t2", "done", lessons=["dup test"])
+        kernle_instance.episode("t3", "done", lessons=["dup test"])
+        result = kernle_instance.promote(auto=True)
+        # Should only create 1 belief, not 3
+        assert result["beliefs_created"] == 1
+
+        beliefs = kernle_instance._storage.get_beliefs()
+        matching = [b for b in beliefs if b.statement == "dup test"]
+        assert len(matching) == 1
+
+
+class TestPromoteParameters:
+    """Test parameter validation and edge cases."""
+
+    def test_confidence_clamped(self, kernle_instance):
+        """Confidence is clamped to 0.1-0.95."""
+        kernle_instance.episode("t1", "done", lessons=["clamp test"])
+        kernle_instance.episode("t2", "done", lessons=["clamp test"])
+        kernle_instance.episode("t3", "done", lessons=["filler"])
+        # Over max
+        result = kernle_instance.promote(auto=True, confidence=1.5)
+        belief_id = result["suggestions"][0]["belief_id"]
+        beliefs = kernle_instance._storage.get_beliefs()
+        belief = [b for b in beliefs if b.id == belief_id][0]
+        assert belief.confidence == 0.95
+
+    def test_min_occurrences_respected(self, kernle_instance):
+        """Higher min_occurrences threshold filters out less common patterns."""
+        kernle_instance.episode("t1", "done", lessons=["twice"])
+        kernle_instance.episode("t2", "done", lessons=["twice"])
+        kernle_instance.episode("t3", "done", lessons=["filler"])
+        # Require 3 occurrences
+        result = kernle_instance.promote(min_occurrences=3)
+        assert result["patterns_found"] == 0
+
+    def test_empty_lessons_ignored(self, kernle_instance):
+        """Episodes with no lessons don't cause issues."""
+        kernle_instance.episode("t1", "done")  # no lessons
+        kernle_instance.episode("t2", "done", lessons=["something"])
+        kernle_instance.episode("t3", "done", lessons=["something"])
+        result = kernle_instance.promote()
+        assert result["episodes_scanned"] == 3
+        assert result["patterns_found"] == 1
+
+    def test_whitespace_lessons_ignored(self, kernle_instance):
+        """Whitespace-only lessons are skipped."""
+        kernle_instance.episode("t1", "done", lessons=["  ", "real lesson"])
+        kernle_instance.episode("t2", "done", lessons=["real lesson"])
+        kernle_instance.episode("t3", "done", lessons=["filler"])
+        result = kernle_instance.promote()
+        assert result["patterns_found"] == 1
+        assert result["suggestions"][0]["lesson"] == "real lesson"
+
+    def test_forgotten_episodes_excluded(self, kernle_instance):
+        """Forgotten episodes are not included in promotion."""
+        ep1 = kernle_instance.episode("t1", "done", lessons=["forgotten pattern"])
+        kernle_instance.episode("t2", "done", lessons=["forgotten pattern"])
+        kernle_instance.episode("t3", "done", lessons=["filler"])
+        # Forget one of the episodes
+        kernle_instance.forget("episode", ep1, reason="test")
+        result = kernle_instance.promote()
+        # Only 1 occurrence of "forgotten pattern" remains — below threshold
+        assert result["patterns_found"] == 0


### PR DESCRIPTION
Adds `Kernle.promote()` method and `kernle promote` CLI command for promoting recurring patterns from episodes into beliefs.

**Two modes:**
- Default (suggestion): shows recurring patterns, agent decides
- Auto (`--auto`): creates beliefs automatically with proper provenance

**Features:**
- Detects recurring lessons across episodes (configurable threshold)
- Skips patterns matching existing beliefs (dedup)
- Sets source_type='consolidation' and derived_from with episode refs  
- Configurable confidence, min-occurrences, episode limit
- Excludes forgotten episodes

**Tests:** 17/17 passing in `tests/test_promote.py`
**Existing tests:** 160 passed, 3 pre-existing search failures (unrelated)

Closes #88