### PR TITLE
fix: align docs with current auth implementation (HS256 not RS256)

### DIFF
--- a/docs/ARCHITECTURE_DIAGRAMS.md
+++ b/docs/ARCHITECTURE_DIAGRAMS.md
@@ -508,7 +508,7 @@ sequenceDiagram
 ```mermaid
 graph TB
     subgraph "Authentication Methods"
-        JWT["JWT (RS256)<br/>Issued at registration<br/>Contains: agent_id, user_id"]
+        JWT["JWT (HS256)<br/>Issued at registration<br/>Contains: agent_id, user_id"]
         APIKEY["API Key (knl_sk_...)<br/>32 hex chars after prefix<br/>bcrypt hashed in DB"]
         COOKIE["httpOnly Cookie<br/>(kernle_auth)<br/>Web dashboard fallback"]
     end
@@ -517,7 +517,7 @@ graph TB
         REQ["Incoming Request"]
         BEARER["HTTPBearer scheme<br/>(optional, allows cookie fallback)"]
         CHECK["is_api_key()?<br/>starts with knl_sk_"]
-        JWT_VERIFY["Verify JWT<br/>(RS256 signature)"]
+        JWT_VERIFY["Verify JWT<br/>(HS256 signature)"]
         KEY_VERIFY["Lookup by prefix (12 chars)<br/>bcrypt.checkpw()"]
         QUOTA["check_and_increment_quota_cached()<br/>TTL cache (60s) for denials<br/>Atomic DB increment for allows"]
         RESULT["CurrentAgent<br/>{agent_id, user_id, tier}"]
@@ -1255,7 +1255,7 @@ graph TB
     end
 
     subgraph "Layer 2: Authentication"
-        JWT_RS["RS256 JWT<br/>(asymmetric, non-forgeable)"]
+        JWT_HS["HS256 JWT<br/>(symmetric, shared secret)"]
         API_KEY_B["API Keys<br/>(bcrypt hashed, prefix lookup)"]
         COOKIE_H["httpOnly cookies<br/>(web fallback)"]
         FAIL_CLOSED["Fail-closed on DB error<br/>(503, not 200)"]
@@ -1280,8 +1280,8 @@ graph TB
         PRIVACY["Phase 8 Privacy Fields"]
     end
 
-    HTTPS --> JWT_RS & API_KEY_B & COOKIE_H
-    JWT_RS --> AGENT_ISO
+    HTTPS --> JWT_HS & API_KEY_B & COOKIE_H
+    JWT_HS --> AGENT_ISO
     API_KEY_B --> AGENT_ISO
     AGENT_ISO --> MASS_ASSIGN & TABLE_ALLOW & INPUT_VAL
     MASS_ASSIGN --> TOMBSTONE & PRIVACY

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -37,8 +37,11 @@ Kernle is the **one-stop infrastructure for SI identity and economic activity**.
 ### 📋 Planned
 - **Commerce Phase 5:** Smart contracts (on-chain escrow + tithe enforcement)
 - **Comms Package:** SI-only social network (E2E encrypted, no engagement metrics)
-- **Bettik Platform:** Where SIs flourish (hosting, marketplace, collaboration)
+- **Bettik Platform:** Application layer service (LLM orchestration, RAG, user mapping, privacy policies)
 - **Model Portability:** Sandboxed model exploration with auto-rollback (see below)
+- **Auth upgrade to RS256:** Migrate JWT from HS256 (symmetric) to RS256 (asymmetric) when Bettik launches as a separate service requiring independent token verification
+- **CSRF protections:** Add SameSite=Strict cookies + CSRF tokens for web dashboard auth
+- **Trusted proxy config:** Rate limiter should only trust X-Forwarded-For from known proxies (Railway)
 
 ---
 


### PR DESCRIPTION
Architecture diagrams incorrectly showed RS256 JWT. Code uses HS256 (set in PR #75).

**Docs fixed:**
- Diagram 2.4: JWT auth → HS256
- Diagram 7.1: Defense layers → HS256 symmetric  

**Added to roadmap (planned):**
- RS256 migration when Bettik is separate service
- CSRF protections for cookie auth
- Trusted proxy config for rate limiter

Closes #92. Related: #90, #93.