### PR TITLE
ci: add coverage threshold (70%) to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,9 +34,11 @@ jobs:
         run: |
           black --check .
 
-      - name: Run tests
+      - name: Run tests with coverage
         run: |
-          pytest tests/ -v --tb=short --ignore=tests/test_postgres_storage.py
+          pytest tests/ -v --tb=short --ignore=tests/test_postgres_storage.py \
+            --cov=kernle --cov-report=xml --cov-report=term-missing \
+            --cov-fail-under=70
 
       - name: Upload coverage (Python 3.11 only)
         if: matrix.python-version == '3.11'


### PR DESCRIPTION
## Summary

Adds minimum coverage enforcement to CI.

## Changes

- Adds `--cov=kernle --cov-fail-under=70` to pytest
- Generates XML coverage report for codecov
- Shows term-missing for local debugging

## Rationale

From testing audit: coverage can drop without failing builds. This ensures new code maintains test coverage.

Starting at 70% — can raise to 80% as gaps are filled.

Closes #97