### PR TITLE
fix: disable cloud search in storage tests for isolation

### DIFF
--- a/tests/test_sqlite_storage.py
+++ b/tests/test_sqlite_storage.py
@@ -36,9 +36,14 @@ def temp_db():
 
 
 @pytest.fixture
-def storage(temp_db):
-    """Create a SQLiteStorage instance for testing."""
+def storage(temp_db, monkeypatch):
+    """Create a SQLiteStorage instance for testing.
+    
+    Cloud credentials are disabled to ensure tests use local storage only.
+    """
     storage = SQLiteStorage(agent_id="test-agent", db_path=temp_db)
+    # Disable cloud search to ensure test isolation
+    monkeypatch.setattr(storage, "has_cloud_credentials", lambda: False)
     yield storage
     storage.close()
 


### PR DESCRIPTION
## Summary

Fixes 8 vector search test failures in `test_sqlite_storage.py`.

## Root Cause

Tests were hitting the cloud search endpoint when credentials were configured locally (e.g., `~/.kernle/credentials.json`). This caused tests to return real cloud data instead of test data.

## Fix

Patch `has_cloud_credentials()` to return `False` in the storage fixture, ensuring tests use local SQLite search only.

## Tests Fixed

- `test_search_mixed_types`
- `test_search_scores_ranked`
- `test_no_network_required`
- `test_batch_saves_embeddings`
- (and 4 others)

Closes #98