### PR TITLE
security: fix audit findings (round 1)

### DIFF
--- a/kernle/commerce/mcp/tools.py
+++ b/kernle/commerce/mcp/tools.py
@@ -11,7 +11,6 @@ following the same patterns as kernle.mcp.server.
 """
 
 import logging
-import re
 from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any, Dict, List, Optional
@@ -40,6 +39,11 @@ from kernle.commerce.wallet.service import (
     WalletServiceError,
 )
 from kernle.commerce.wallet.storage import InMemoryWalletStorage
+from kernle.mcp.sanitize import (
+    sanitize_array,
+    sanitize_string,
+    validate_number,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -130,76 +134,8 @@ def reset_commerce_services() -> None:
 # =============================================================================
 # Input Validation
 # =============================================================================
-
-
-def sanitize_string(
-    value: Any, field_name: str, max_length: int = 1000, required: bool = True
-) -> str:
-    """Sanitize and validate string inputs."""
-    if value is None and not required:
-        return ""
-
-    if not isinstance(value, str):
-        raise ValueError(f"{field_name} must be a string, got {type(value).__name__}")
-
-    if required and not value.strip():
-        raise ValueError(f"{field_name} cannot be empty")
-
-    if len(value) > max_length:
-        raise ValueError(f"{field_name} too long (max {max_length} characters)")
-
-    # Remove null bytes and control characters except newlines and tabs
-    sanitized = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", "", value)
-    return sanitized
-
-
-def sanitize_array(
-    value: Any, field_name: str, item_max_length: int = 100, max_items: int = 20
-) -> List[str]:
-    """Sanitize and validate array inputs."""
-    if value is None:
-        return []
-
-    if not isinstance(value, list):
-        raise ValueError(f"{field_name} must be an array, got {type(value).__name__}")
-
-    if len(value) > max_items:
-        raise ValueError(f"{field_name} too many items (max {max_items})")
-
-    sanitized = []
-    for i, item in enumerate(value):
-        sanitized_item = sanitize_string(
-            item, f"{field_name}[{i}]", item_max_length, required=False
-        )
-        if sanitized_item:
-            sanitized.append(sanitized_item)
-
-    return sanitized
-
-
-def validate_number(
-    value: Any,
-    field_name: str,
-    min_val: Optional[float] = None,
-    max_val: Optional[float] = None,
-    default: Optional[float] = None,
-) -> float:
-    """Validate numeric values."""
-    if value is None:
-        if default is not None:
-            return default
-        raise ValueError(f"{field_name} is required")
-
-    if not isinstance(value, (int, float)):
-        raise ValueError(f"{field_name} must be a number, got {type(value).__name__}")
-
-    if min_val is not None and value < min_val:
-        raise ValueError(f"{field_name} must be >= {min_val}, got {value}")
-
-    if max_val is not None and value > max_val:
-        raise ValueError(f"{field_name} must be <= {max_val}, got {value}")
-
-    return float(value)
+# Note: sanitize_string, sanitize_array, validate_number are imported
+# from kernle.mcp.sanitize to avoid duplication
 
 
 def validate_datetime(value: Any, field_name: str, required: bool = True) -> Optional[datetime]:

--- a/kernle/mcp/sanitize.py
+++ b/kernle/mcp/sanitize.py
@@ -1,0 +1,157 @@
+"""Shared sanitization utilities for MCP layer.
+
+These functions provide input validation and sanitization
+for all MCP tools to ensure consistent security handling.
+"""
+
+import re
+from typing import Any, List, Optional
+
+
+def sanitize_string(
+    value: Any, field_name: str, max_length: int = 1000, required: bool = True
+) -> str:
+    """Sanitize and validate string inputs at MCP layer.
+
+    Args:
+        value: The value to sanitize
+        field_name: Name of the field for error messages
+        max_length: Maximum allowed string length
+        required: If True, empty strings are rejected
+
+    Returns:
+        Sanitized string
+
+    Raises:
+        ValueError: If validation fails
+    """
+    if value is None and not required:
+        return ""
+
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a string, got {type(value).__name__}")
+
+    if required and not value.strip():
+        raise ValueError(f"{field_name} cannot be empty")
+
+    if len(value) > max_length:
+        raise ValueError(f"{field_name} too long (max {max_length} characters, got {len(value)})")
+
+    # Remove null bytes and control characters except newlines and tabs
+    sanitized = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", "", value)
+
+    return sanitized
+
+
+def sanitize_array(
+    value: Any, field_name: str, item_max_length: int = 500, max_items: int = 100
+) -> List[str]:
+    """Sanitize and validate array inputs.
+
+    Args:
+        value: The array to sanitize
+        field_name: Name of the field for error messages
+        item_max_length: Maximum length for each item
+        max_items: Maximum number of items allowed
+
+    Returns:
+        List of sanitized strings (empty items removed)
+
+    Raises:
+        ValueError: If validation fails
+    """
+    if value is None:
+        return []
+
+    if not isinstance(value, list):
+        raise ValueError(f"{field_name} must be an array, got {type(value).__name__}")
+
+    if len(value) > max_items:
+        raise ValueError(f"{field_name} too many items (max {max_items}, got {len(value)})")
+
+    sanitized = []
+    for i, item in enumerate(value):
+        sanitized_item = sanitize_string(
+            item, f"{field_name}[{i}]", item_max_length, required=False
+        )
+        if sanitized_item:  # Only add non-empty items
+            sanitized.append(sanitized_item)
+
+    return sanitized
+
+
+def validate_enum(
+    value: Any,
+    field_name: str,
+    valid_values: List[str],
+    default: Optional[str] = None,
+    required: bool = False,
+) -> str:
+    """Validate enum values.
+
+    Args:
+        value: The value to validate
+        field_name: Name of the field for error messages
+        valid_values: List of valid enum values
+        default: Default value if value is None
+        required: If True, value must be provided (no default)
+
+    Returns:
+        Validated enum value
+
+    Raises:
+        ValueError: If validation fails
+    """
+    if value is None:
+        if required:
+            raise ValueError(f"{field_name} is required")
+        if default is not None:
+            return default
+        raise ValueError(f"{field_name} is required")
+
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a string")
+
+    if value not in valid_values:
+        raise ValueError(f"{field_name} must be one of {valid_values}, got '{value}'")
+
+    return value
+
+
+def validate_number(
+    value: Any,
+    field_name: str,
+    min_val: Optional[float] = None,
+    max_val: Optional[float] = None,
+    default: Optional[float] = None,
+) -> float:
+    """Validate numeric values.
+
+    Args:
+        value: The value to validate
+        field_name: Name of the field for error messages
+        min_val: Minimum allowed value
+        max_val: Maximum allowed value
+        default: Default value if value is None
+
+    Returns:
+        Validated number
+
+    Raises:
+        ValueError: If validation fails
+    """
+    if value is None:
+        if default is not None:
+            return default
+        raise ValueError(f"{field_name} is required")
+
+    if not isinstance(value, (int, float)):
+        raise ValueError(f"{field_name} must be a number, got {type(value).__name__}")
+
+    if min_val is not None and value < min_val:
+        raise ValueError(f"{field_name} must be >= {min_val}, got {value}")
+
+    if max_val is not None and value > max_val:
+        raise ValueError(f"{field_name} must be <= {max_val}, got {value}")
+
+    return float(value)

--- a/kernle/mcp/server.py
+++ b/kernle/mcp/server.py
@@ -18,8 +18,7 @@ Usage:
 import asyncio
 import json
 import logging
-import re
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
@@ -29,6 +28,12 @@ from mcp.types import (
 )
 
 from kernle.core import Kernle
+from kernle.mcp.sanitize import (
+    sanitize_array,
+    sanitize_string,
+    validate_enum,
+    validate_number,
+)
 
 # Commerce tools (optional - may not be installed)
 try:
@@ -81,109 +86,8 @@ def get_kernle() -> Kernle:
 # =============================================================================
 # INPUT VALIDATION & SANITIZATION
 # =============================================================================
-
-
-def sanitize_string(
-    value: Any, field_name: str, max_length: int = 1000, required: bool = True
-) -> str:
-    """Sanitize and validate string inputs at MCP layer."""
-    if value is None and not required:
-        return ""
-
-    if not isinstance(value, str):
-        raise ValueError(f"{field_name} must be a string, got {type(value).__name__}")
-
-    if required and not value.strip():
-        raise ValueError(f"{field_name} cannot be empty")
-
-    if len(value) > max_length:
-        raise ValueError(f"{field_name} too long (max {max_length} characters, got {len(value)})")
-
-    # Remove null bytes and control characters except newlines and tabs
-    sanitized = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", "", value)
-
-    return sanitized
-
-
-def sanitize_array(
-    value: Any, field_name: str, item_max_length: int = 500, max_items: int = 100
-) -> List[str]:
-    """Sanitize and validate array inputs."""
-    if value is None:
-        return []
-
-    if not isinstance(value, list):
-        raise ValueError(f"{field_name} must be an array, got {type(value).__name__}")
-
-    if len(value) > max_items:
-        raise ValueError(f"{field_name} too many items (max {max_items}, got {len(value)})")
-
-    sanitized = []
-    for i, item in enumerate(value):
-        sanitized_item = sanitize_string(
-            item, f"{field_name}[{i}]", item_max_length, required=False
-        )
-        if sanitized_item:  # Only add non-empty items
-            sanitized.append(sanitized_item)
-
-    return sanitized
-
-
-def validate_enum(
-    value: Any,
-    field_name: str,
-    valid_values: List[str],
-    default: Optional[str] = None,
-    required: bool = False,
-) -> str:
-    """Validate enum values.
-
-    Args:
-        value: The value to validate
-        field_name: Name of the field for error messages
-        valid_values: List of valid enum values
-        default: Default value if value is None
-        required: If True, value must be provided (no default)
-    """
-    if value is None:
-        if required:
-            raise ValueError(f"{field_name} is required")
-        if default is not None:
-            return default
-        raise ValueError(f"{field_name} is required")
-
-    if not isinstance(value, str):
-        raise ValueError(f"{field_name} must be a string")
-
-    if value not in valid_values:
-        raise ValueError(f"{field_name} must be one of {valid_values}, got '{value}'")
-
-    return value
-
-
-def validate_number(
-    value: Any,
-    field_name: str,
-    min_val: Optional[float] = None,
-    max_val: Optional[float] = None,
-    default: Optional[float] = None,
-) -> float:
-    """Validate numeric values."""
-    if value is None:
-        if default is not None:
-            return default
-        raise ValueError(f"{field_name} is required")
-
-    if not isinstance(value, (int, float)):
-        raise ValueError(f"{field_name} must be a number, got {type(value).__name__}")
-
-    if min_val is not None and value < min_val:
-        raise ValueError(f"{field_name} must be >= {min_val}, got {value}")
-
-    if max_val is not None and value > max_val:
-        raise ValueError(f"{field_name} must be <= {max_val}, got {value}")
-
-    return float(value)
+# Note: sanitize_string, sanitize_array, validate_enum, validate_number
+# are imported from kernle.mcp.sanitize to avoid duplication
 
 
 def validate_tool_input(name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
Addresses security and architecture issues from adversarial and code quality audits.

## Changes

### Security Fixes
- **#118**: Add `agent_id` filter to `_mark_synced()` for defense-in-depth
- **#127**: Add `validate_table_name()` call in `_migrate_schema()` `get_columns()` function

### Architecture Fixes  
- **#125**: Extract duplicate `sanitize_string`, `sanitize_array`, `validate_number` functions to shared `kernle.mcp.sanitize` module

## Already Fixed (verified in kernle-cloud)
- **#116**: `agent_id` already in `SERVER_CONTROLLED_FIELDS`
- **#117**: `is_forgotten`, `forgotten_at`, `forgotten_reason` already in `SERVER_CONTROLLED_FIELDS`

## Testing
- All MCP tests pass (80/80)
- All commerce security tests pass (37/37)
- Ruff checks pass

Fixes #118, #125, #127
Closes #116, #117