### PR TITLE
security: add actor_id auth to list_applications service methods

### DIFF
--- a/kernle/commerce/cli/job.py
+++ b/kernle/commerce/cli/job.py
@@ -347,6 +347,7 @@ def _job_applications(args: "argparse.Namespace", k: "Kernle") -> None:
     """List applications for a job."""
     job_id = args.job_id
     output_json = getattr(args, "json", False)
+    agent_id = k.agent_id
 
     try:
         service = _get_job_service()
@@ -354,7 +355,8 @@ def _job_applications(args: "argparse.Namespace", k: "Kernle") -> None:
         # Verify job exists and user is the client
         job = service.get_job(job_id)
 
-        applications = service.list_applications(job_id=job_id)
+        # Service layer handles authorization via actor_id
+        applications = service.list_applications(job_id=job_id, actor_id=agent_id)
 
         if output_json:
             result = [app.to_dict() for app in applications]

--- a/kernle/commerce/mcp/tools.py
+++ b/kernle/commerce/mcp/tools.py
@@ -658,14 +658,13 @@ async def handle_job_applications(arguments: Dict[str, Any]) -> List[TextContent
 
     job_id = validate_job_id(arguments.get("job_id"))
 
-    # Verify caller is the client
-    job = service.get_job(job_id)
-    if job.client_id != agent_id:
+    # Service layer handles authorization via actor_id
+    try:
+        applications = service.list_applications(job_id=job_id, actor_id=agent_id)
+    except UnauthorizedError:
         return [
             TextContent(type="text", text="You can only view applications for jobs you posted.")
         ]
-
-    applications = service.list_applications(job_id=job_id)
 
     if not applications:
         return [TextContent(type="text", text="No applications yet.")]


### PR DESCRIPTION
## Summary
Defense-in-depth: add authorization checks at service layer, not just MCP/CLI.

## Changes
- `list_applications()` now accepts `actor_id` parameter
- Verifies actor is job client (if `job_id`) or applicant (if `applicant_id`)  
- Requires at least one filter (`job_id` or `applicant_id`)
- `get_applications_for_applicant()` verifies actor matches applicant
- Updated MCP tool and CLI to pass `actor_id`

## Testing
- All commerce security tests pass (37/37)
- All job service tests pass (28/28)
- Ruff checks pass

Fixes #121