### PR TITLE
security: add PII detection and auto-redaction for job descriptions

### DIFF
--- a/kernle/commerce/pii.py
+++ b/kernle/commerce/pii.py
@@ -1,0 +1,225 @@
+"""PII (Personally Identifiable Information) detection and redaction.
+
+This module provides utilities for detecting and optionally redacting
+sensitive information from text content, such as:
+- Email addresses
+- Social Security Numbers (SSN)
+- Credit card numbers
+- Phone numbers
+
+Usage:
+    from kernle.commerce.pii import detect_pii, redact_pii, PIIType
+
+    # Check if text contains PII
+    findings = detect_pii("Contact me at john@example.com")
+    if findings:
+        print(f"Found PII: {findings}")
+
+    # Redact PII from text
+    safe_text = redact_pii("My SSN is 123-45-6789")
+    # Returns: "My SSN is [REDACTED-SSN]"
+"""
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import List, Optional
+
+
+class PIIType(Enum):
+    """Types of PII that can be detected."""
+
+    EMAIL = "email"
+    SSN = "ssn"
+    CREDIT_CARD = "credit_card"
+    PHONE = "phone"
+
+
+@dataclass
+class PIIFinding:
+    """A detected PII occurrence."""
+
+    pii_type: PIIType
+    value: str
+    start: int
+    end: int
+    redacted: str
+
+
+# Regex patterns for PII detection
+# Note: These are intentionally conservative to reduce false positives
+
+# Email: standard format, requires @ and domain
+EMAIL_PATTERN = re.compile(
+    r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b"
+)
+
+# SSN: xxx-xx-xxxx or xxx xx xxxx or xxxxxxxxx (9 digits)
+# Excludes obviously fake ones like 000-00-0000, 123-45-6789
+SSN_PATTERN = re.compile(
+    r"\b(?!000|666|9\d{2})([0-8]\d{2})"  # Area number (not 000, 666, 9xx)
+    r"[-\s]?"
+    r"(?!00)(\d{2})"  # Group number (not 00)
+    r"[-\s]?"
+    r"(?!0000)(\d{4})\b"  # Serial number (not 0000)
+)
+
+# Credit card: 13-19 digits, optionally separated by spaces or dashes
+# Validates using Luhn algorithm
+CREDIT_CARD_PATTERN = re.compile(
+    r"\b(?:\d{4}[-\s]?){3,4}\d{1,4}\b"
+)
+
+# Phone: various US formats
+# (xxx) xxx-xxxx, xxx-xxx-xxxx, xxx.xxx.xxxx, +1xxxxxxxxxx
+PHONE_PATTERN = re.compile(
+    r"\b(?:\+?1[-.\s]?)?"  # Optional country code
+    r"(?:\(?\d{3}\)?[-.\s]?)"  # Area code
+    r"\d{3}[-.\s]?"  # Exchange
+    r"\d{4}\b"  # Subscriber
+)
+
+
+def _luhn_check(card_number: str) -> bool:
+    """Validate credit card number using Luhn algorithm."""
+    digits = [int(d) for d in card_number if d.isdigit()]
+    if len(digits) < 13 or len(digits) > 19:
+        return False
+
+    # Luhn algorithm
+    checksum = 0
+    for i, digit in enumerate(reversed(digits)):
+        if i % 2 == 1:
+            digit *= 2
+            if digit > 9:
+                digit -= 9
+        checksum += digit
+
+    return checksum % 10 == 0
+
+
+def detect_pii(
+    text: str,
+    types: Optional[List[PIIType]] = None,
+) -> List[PIIFinding]:
+    """Detect PII in text.
+
+    Args:
+        text: Text to scan for PII
+        types: Specific PII types to detect (default: all)
+
+    Returns:
+        List of PIIFinding objects for each detected occurrence
+    """
+    if types is None:
+        types = list(PIIType)
+
+    findings: List[PIIFinding] = []
+
+    if PIIType.EMAIL in types:
+        for match in EMAIL_PATTERN.finditer(text):
+            findings.append(
+                PIIFinding(
+                    pii_type=PIIType.EMAIL,
+                    value=match.group(),
+                    start=match.start(),
+                    end=match.end(),
+                    redacted="[REDACTED-EMAIL]",
+                )
+            )
+
+    if PIIType.SSN in types:
+        for match in SSN_PATTERN.finditer(text):
+            # Additional validation: not obviously fake
+            full_match = match.group()
+            digits_only = re.sub(r"[-\s]", "", full_match)
+            # Skip test SSNs (123-45-6789, etc.)
+            if digits_only not in ("123456789", "111111111", "222222222"):
+                findings.append(
+                    PIIFinding(
+                        pii_type=PIIType.SSN,
+                        value=full_match,
+                        start=match.start(),
+                        end=match.end(),
+                        redacted="[REDACTED-SSN]",
+                    )
+                )
+
+    if PIIType.CREDIT_CARD in types:
+        for match in CREDIT_CARD_PATTERN.finditer(text):
+            card_number = match.group()
+            # Validate with Luhn algorithm to reduce false positives
+            if _luhn_check(card_number):
+                findings.append(
+                    PIIFinding(
+                        pii_type=PIIType.CREDIT_CARD,
+                        value=card_number,
+                        start=match.start(),
+                        end=match.end(),
+                        redacted="[REDACTED-CC]",
+                    )
+                )
+
+    if PIIType.PHONE in types:
+        for match in PHONE_PATTERN.finditer(text):
+            # Skip if it looks like a version number or other non-phone pattern
+            phone = match.group()
+            digits_only = re.sub(r"[^\d]", "", phone)
+            if len(digits_only) >= 10:  # At least 10 digits for a valid phone
+                findings.append(
+                    PIIFinding(
+                        pii_type=PIIType.PHONE,
+                        value=phone,
+                        start=match.start(),
+                        end=match.end(),
+                        redacted="[REDACTED-PHONE]",
+                    )
+                )
+
+    # Sort by position in text
+    findings.sort(key=lambda f: f.start)
+
+    return findings
+
+
+def redact_pii(
+    text: str,
+    types: Optional[List[PIIType]] = None,
+) -> str:
+    """Redact PII from text.
+
+    Args:
+        text: Text to redact PII from
+        types: Specific PII types to redact (default: all)
+
+    Returns:
+        Text with PII replaced by redaction markers
+    """
+    findings = detect_pii(text, types)
+
+    if not findings:
+        return text
+
+    # Build result by replacing matches from end to start
+    # (to preserve indices)
+    result = text
+    for finding in reversed(findings):
+        result = result[: finding.start] + finding.redacted + result[finding.end :]
+
+    return result
+
+
+def contains_pii(
+    text: str,
+    types: Optional[List[PIIType]] = None,
+) -> bool:
+    """Check if text contains any PII.
+
+    Args:
+        text: Text to check
+        types: Specific PII types to check (default: all)
+
+    Returns:
+        True if any PII is detected
+    """
+    return len(detect_pii(text, types)) > 0

--- a/tests/commerce/test_pii.py
+++ b/tests/commerce/test_pii.py
@@ -1,0 +1,248 @@
+"""Tests for PII detection and redaction."""
+
+
+from kernle.commerce.pii import (
+    PIIType,
+    contains_pii,
+    detect_pii,
+    redact_pii,
+)
+
+
+class TestPIIDetection:
+    """Tests for detect_pii function."""
+
+    def test_detect_email(self):
+        """Should detect email addresses."""
+        text = "Contact me at john.doe@example.com for details"
+        findings = detect_pii(text, types=[PIIType.EMAIL])
+
+        assert len(findings) == 1
+        assert findings[0].pii_type == PIIType.EMAIL
+        assert findings[0].value == "john.doe@example.com"
+
+    def test_detect_multiple_emails(self):
+        """Should detect multiple email addresses."""
+        text = "Email john@example.com or jane@test.org"
+        findings = detect_pii(text, types=[PIIType.EMAIL])
+
+        assert len(findings) == 2
+        assert findings[0].value == "john@example.com"
+        assert findings[1].value == "jane@test.org"
+
+    def test_detect_ssn_with_dashes(self):
+        """Should detect SSN with dashes."""
+        text = "My SSN is 456-78-9012"
+        findings = detect_pii(text, types=[PIIType.SSN])
+
+        assert len(findings) == 1
+        assert findings[0].pii_type == PIIType.SSN
+        assert "456" in findings[0].value
+
+    def test_detect_ssn_with_spaces(self):
+        """Should detect SSN with spaces."""
+        text = "SSN: 456 78 9012"
+        findings = detect_pii(text, types=[PIIType.SSN])
+
+        assert len(findings) == 1
+        assert findings[0].pii_type == PIIType.SSN
+
+    def test_skip_fake_ssn(self):
+        """Should skip obviously fake SSNs."""
+        text = "Test SSN 123-45-6789 and 000-00-0000"
+        findings = detect_pii(text, types=[PIIType.SSN])
+
+        # 123-45-6789 should be skipped (test pattern)
+        # 000-00-0000 should be skipped (invalid area)
+        assert len(findings) == 0
+
+    def test_detect_credit_card_visa(self):
+        """Should detect valid Visa card number."""
+        # Valid test Visa number (passes Luhn)
+        text = "Card: 4111 1111 1111 1111"
+        findings = detect_pii(text, types=[PIIType.CREDIT_CARD])
+
+        assert len(findings) == 1
+        assert findings[0].pii_type == PIIType.CREDIT_CARD
+
+    def test_detect_credit_card_mastercard(self):
+        """Should detect valid Mastercard number."""
+        # Valid test Mastercard (passes Luhn)
+        text = "Pay with 5500 0000 0000 0004"
+        findings = detect_pii(text, types=[PIIType.CREDIT_CARD])
+
+        assert len(findings) == 1
+        assert findings[0].pii_type == PIIType.CREDIT_CARD
+
+    def test_skip_invalid_credit_card(self):
+        """Should skip numbers that fail Luhn check."""
+        text = "Not a card: 1234 5678 9012 3456"
+        findings = detect_pii(text, types=[PIIType.CREDIT_CARD])
+
+        assert len(findings) == 0
+
+    def test_detect_phone_standard(self):
+        """Should detect standard US phone format."""
+        text = "Call me at (555) 123-4567"
+        findings = detect_pii(text, types=[PIIType.PHONE])
+
+        assert len(findings) == 1
+        assert findings[0].pii_type == PIIType.PHONE
+
+    def test_detect_phone_with_country_code(self):
+        """Should detect phone with country code."""
+        text = "International: +1-555-123-4567"
+        findings = detect_pii(text, types=[PIIType.PHONE])
+
+        assert len(findings) == 1
+        assert findings[0].pii_type == PIIType.PHONE
+
+    def test_detect_all_types(self):
+        """Should detect multiple PII types in one text."""
+        text = """
+        Contact: john@example.com
+        Phone: (555) 123-4567
+        SSN: 456-78-9012
+        Card: 4111 1111 1111 1111
+        """
+        findings = detect_pii(text)
+
+        types_found = {f.pii_type for f in findings}
+        assert PIIType.EMAIL in types_found
+        assert PIIType.PHONE in types_found
+        assert PIIType.SSN in types_found
+        assert PIIType.CREDIT_CARD in types_found
+
+    def test_no_false_positives_on_clean_text(self):
+        """Should not detect PII in clean text."""
+        text = """
+        Looking for a Python developer to build a REST API.
+        Budget is $500, deadline is next Friday.
+        Must have 3+ years experience with Django.
+        """
+        findings = detect_pii(text)
+
+        assert len(findings) == 0
+
+
+class TestPIIRedaction:
+    """Tests for redact_pii function."""
+
+    def test_redact_email(self):
+        """Should redact email addresses."""
+        text = "Contact john@example.com"
+        result = redact_pii(text, types=[PIIType.EMAIL])
+
+        assert "john@example.com" not in result
+        assert "[REDACTED-EMAIL]" in result
+
+    def test_redact_ssn(self):
+        """Should redact SSN."""
+        text = "SSN: 456-78-9012"
+        result = redact_pii(text, types=[PIIType.SSN])
+
+        assert "456-78-9012" not in result
+        assert "[REDACTED-SSN]" in result
+
+    def test_redact_credit_card(self):
+        """Should redact credit card numbers."""
+        text = "Card: 4111 1111 1111 1111"
+        result = redact_pii(text, types=[PIIType.CREDIT_CARD])
+
+        assert "4111" not in result
+        assert "[REDACTED-CC]" in result
+
+    def test_redact_phone(self):
+        """Should redact phone numbers."""
+        text = "Call (555) 123-4567"
+        result = redact_pii(text, types=[PIIType.PHONE])
+
+        assert "(555) 123-4567" not in result
+        assert "[REDACTED-PHONE]" in result
+
+    def test_redact_multiple(self):
+        """Should redact multiple PII instances."""
+        text = "Email john@test.com or jane@test.com"
+        result = redact_pii(text, types=[PIIType.EMAIL])
+
+        assert "john@test.com" not in result
+        assert "jane@test.com" not in result
+        assert result.count("[REDACTED-EMAIL]") == 2
+
+    def test_preserve_non_pii_text(self):
+        """Should preserve text around PII."""
+        text = "Contact john@example.com for more info"
+        result = redact_pii(text, types=[PIIType.EMAIL])
+
+        assert result == "Contact [REDACTED-EMAIL] for more info"
+
+
+class TestContainsPII:
+    """Tests for contains_pii function."""
+
+    def test_returns_true_for_pii(self):
+        """Should return True when PII is present."""
+        assert contains_pii("email: test@example.com")
+        assert contains_pii("SSN: 456-78-9012")
+        assert contains_pii("Card: 4111 1111 1111 1111")
+        assert contains_pii("Phone: (555) 123-4567")
+
+    def test_returns_false_for_clean_text(self):
+        """Should return False for clean text."""
+        assert not contains_pii("Hello, this is a normal message.")
+        assert not contains_pii("Budget: $500, deadline: Friday")
+
+    def test_type_filtering(self):
+        """Should only check specified types."""
+        text = "email: test@example.com"
+
+        assert contains_pii(text, types=[PIIType.EMAIL])
+        assert not contains_pii(text, types=[PIIType.SSN])
+        assert not contains_pii(text, types=[PIIType.CREDIT_CARD])
+
+
+class TestJobServicePIIIntegration:
+    """Tests for PII handling in JobService."""
+
+    def test_create_job_redacts_pii_by_default(self):
+        """Should redact PII from job description by default."""
+        from datetime import datetime, timedelta, timezone
+
+        from kernle.commerce.jobs.service import JobService
+        from kernle.commerce.jobs.storage import InMemoryJobStorage
+
+        service = JobService(storage=InMemoryJobStorage())
+        deadline = datetime.now(timezone.utc) + timedelta(days=7)
+
+        job = service.create_job(
+            client_id="agent_1",
+            title="Test Job",
+            description="Contact me at secret@email.com for details",
+            budget_usdc=100.0,
+            deadline=deadline,
+        )
+
+        assert "secret@email.com" not in job.description
+        assert "[REDACTED-EMAIL]" in job.description
+
+    def test_create_job_preserves_pii_when_disabled(self):
+        """Should preserve PII when redaction is disabled."""
+        from datetime import datetime, timedelta, timezone
+
+        from kernle.commerce.jobs.service import JobService
+        from kernle.commerce.jobs.storage import InMemoryJobStorage
+
+        service = JobService(storage=InMemoryJobStorage())
+        deadline = datetime.now(timezone.utc) + timedelta(days=7)
+
+        job = service.create_job(
+            client_id="agent_1",
+            title="Test Job",
+            description="Contact me at secret@email.com for details",
+            budget_usdc=100.0,
+            deadline=deadline,
+            redact_pii=False,
+        )
+
+        assert "secret@email.com" in job.description
+        assert "[REDACTED-EMAIL]" not in job.description


### PR DESCRIPTION
## Summary
Implements automatic detection and redaction of sensitive data in job descriptions.

## PII Types Detected
- **Email addresses** - standard format validation
- **SSNs** - with validation to skip fake patterns (000-00-0000, 123-45-6789)
- **Credit cards** - with Luhn algorithm validation to reduce false positives
- **Phone numbers** - various US formats

## Changes
- New `kernle.commerce.pii` module with:
  - `detect_pii(text)` - returns list of findings
  - `redact_pii(text)` - replaces PII with markers like `[REDACTED-EMAIL]`
  - `contains_pii(text)` - boolean check
- `JobService.create_job()` now auto-redacts PII by default
  - Can be disabled with `redact_pii=False` parameter
  - Logs warning when PII is detected

## Testing
- 23 new tests for PII detection/redaction
- 331 commerce tests pass
- Updated `test_no_pii_filtering` → `test_pii_filtering_enabled_by_default`

Fixes #122