### PR TITLE
chore: Remove orphaned supabase symlink

### DIFF
--- a/supabase/migrations
+++ b/supabase/migrations
@@ -1,1 +1,0 @@
-../backend/supabase/migrations


### PR DESCRIPTION
Removes the `supabase/` directory which was a broken symlink to `../backend/supabase/migrations`.

Since the backend is now in a separate repo (kernle-cloud), this symlink doesn't belong in the core package.