### PR TITLE
fix: Sync queue continues on failures with retry tracking

### DIFF
--- a/kernle/storage/base.py
+++ b/kernle/storage/base.py
@@ -118,6 +118,10 @@ class QueuedChange:
     operation: str  # 'insert', 'update', 'delete'
     payload: Optional[str] = None  # JSON payload for the change
     queued_at: Optional[datetime] = None
+    # Retry tracking for resilient sync
+    retry_count: int = 0
+    last_error: Optional[str] = None
+    last_attempt_at: Optional[datetime] = None
 
 
 @dataclass


### PR DESCRIPTION
## Summary

Fixes #21

Makes sync resilient to individual record failures by:
- Continuing to process other records when one fails
- Tracking retry counts and errors
- Moving persistently failing records to a 'dead letter' state

## Problem

When pushing sync changes, records that fail (e.g., test agents not on backend) blocked subsequent records from syncing. This caused 297 pending operations to pile up when only ~130 were for valid agents.

## Solution

### Retry Tracking
Added columns to sync_queue:
- `retry_count` - Number of sync attempts
- `last_error` - Most recent error message
- `last_attempt_at` - Timestamp of last attempt

### Dead Letter Behavior
- Records with >= 5 retries are skipped in normal sync
- Can be inspected via `get_failed_sync_records()`
- Can be cleared via `clear_failed_sync_records(older_than_days=7)`

### Resilient Processing
- Sync continues processing after individual failures
- Each failure increments retry count
- Errors are logged with retry count for visibility

## Tests

4 new tests in TestSyncQueueResilience:
- test_failed_record_increments_retry_count
- test_max_retries_excludes_from_queue
- test_sync_continues_after_individual_failure
- test_clear_failed_sync_records

**Total: 55 sync tests passing (+4 new)**