### PR TITLE
chore: Bump version to 0.2.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kernle"
-version = "0.2.4"
+version = "0.2.5"
 description = "Stratified memory for synthetic intelligences"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump for v0.2.5 release.

## Changes in v0.2.5

### Bug Fixes
- **Bare exceptions logged** (#126) - All 32 bare exception handlers now log errors
- **Sync queue resilience** (#21) - Failed records retry with dead letter queue

### Test Improvements
- **Escrow tests** (#128) - +18 real unit tests, stub markers
- **MCP integration tests** (#129) - 15 tests with real Kernle instance
- **Sync resilience tests** - 4 new tests

### Documentation
- **Sync protocol docs** (#109) - Clarifies update vs insert operations

### Chores
- Removed orphaned supabase symlink (#155)
- Added `stub` pytest marker

## Test Summary
- Total: 1832 tests
- New: +77 tests