### PR TITLE
feat(comms): add agent registry schema and CRUD operations

### DIFF
--- a/kernle/cli/__main__.py
+++ b/kernle/cli/__main__.py
@@ -40,6 +40,7 @@ from kernle.cli.commands import (
     cmd_suggestions,
 )
 from kernle.cli.commands.agent import cmd_agent
+from kernle.cli.commands.comms import add_comms_parser, cmd_comms
 from kernle.cli.commands.import_cmd import cmd_import, cmd_migrate
 from kernle.cli.commands.setup import cmd_setup
 from kernle.commerce.cli import cmd_job, cmd_skills, cmd_wallet
@@ -3685,6 +3686,9 @@ Typical usage in a memoryFlush hook:
     agent_delete.add_argument("name", help="Agent ID to delete")
     agent_delete.add_argument("--force", "-f", action="store_true", help="Skip confirmation prompt")
 
+    # comms - agent-to-agent communication (v0.3.0)
+    add_comms_parser(subparsers)
+
     # import - import from external files (markdown, JSON, CSV)
     p_import = subparsers.add_parser(
         "import", help="Import memories from markdown, JSON, or CSV files"
@@ -4109,6 +4113,8 @@ Beliefs already present in the agent's memory will be skipped.
             cmd_mcp(args)
         elif args.command == "agent":
             cmd_agent(args, k)
+        elif args.command == "comms":
+            cmd_comms(args, k)
         elif args.command == "import":
             cmd_import(args, k)
         elif args.command == "migrate":

--- a/kernle/cli/commands/comms.py
+++ b/kernle/cli/commands/comms.py
@@ -1,0 +1,247 @@
+"""Comms CLI commands for Kernle.
+
+Commands for agent-to-agent communication:
+- kernle comms register - Register as discoverable agent
+- kernle comms profile - View agent profile
+- kernle comms discover - Find agents by capability
+- kernle comms update - Update your profile
+"""
+
+import json
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import argparse
+
+    from kernle import Kernle
+
+
+def cmd_comms(args: "argparse.Namespace", k: "Kernle") -> None:
+    """Handle comms subcommands."""
+    action = getattr(args, "comms_action", None)
+
+    if action == "register":
+        _register(args, k)
+    elif action == "profile":
+        _profile(args, k)
+    elif action == "discover":
+        _discover(args, k)
+    elif action == "update":
+        _update(args, k)
+    elif action == "delete":
+        _delete(args, k)
+    else:
+        print("Usage: kernle comms <register|profile|discover|update|delete>")
+        print()
+        print("Commands:")
+        print("  register   Register as a discoverable agent")
+        print("  profile    View an agent's profile")
+        print("  discover   Find agents by capability")
+        print("  update     Update your profile")
+        print("  delete     Delete your registration")
+
+
+def _register(args: "argparse.Namespace", k: "Kernle") -> None:
+    """Register as a discoverable agent."""
+    from kernle.comms.registry import AgentAlreadyExistsError, AgentRegistry
+
+    registry = AgentRegistry(k._storage)
+
+    capabilities = []
+    if hasattr(args, "capabilities") and args.capabilities:
+        capabilities = [c.strip() for c in args.capabilities.split(",")]
+
+    is_public = getattr(args, "public", False)
+    display_name = getattr(args, "name", None)
+
+    # Get user_id from storage config or generate
+    user_id = getattr(k._storage, "user_id", None) or f"local:{k.agent_id}"
+
+    try:
+        profile = registry.register(
+            agent_id=k.agent_id,
+            user_id=user_id,
+            display_name=display_name,
+            capabilities=capabilities,
+            is_public=is_public,
+        )
+
+        print(f"✓ Registered agent: {profile.agent_id}")
+        if profile.display_name:
+            print(f"  Name: {profile.display_name}")
+        if profile.capabilities:
+            print(f"  Capabilities: {', '.join(profile.capabilities)}")
+        print(f"  Public: {'Yes' if profile.is_public else 'No'}")
+        print(f"  Trust: {profile.trust_level}")
+
+    except AgentAlreadyExistsError:
+        print(f"✗ Agent '{k.agent_id}' is already registered")
+        print("  Use 'kernle comms update' to modify your profile")
+
+
+def _profile(args: "argparse.Namespace", k: "Kernle") -> None:
+    """View an agent's profile."""
+    from kernle.comms.registry import AgentRegistry
+
+    registry = AgentRegistry(k._storage)
+
+    agent_id = getattr(args, "agent_id", None) or k.agent_id
+    profile = registry.get_profile(agent_id)
+
+    if not profile:
+        print(f"✗ Agent '{agent_id}' not found")
+        return
+
+    if getattr(args, "json", False):
+        print(json.dumps(profile.to_dict(), indent=2, default=str))
+        return
+
+    print(f"Agent: {profile.agent_id}")
+    if profile.display_name:
+        print(f"Name: {profile.display_name}")
+    print(f"User: {profile.user_id}")
+    if profile.capabilities:
+        print(f"Capabilities: {', '.join(profile.capabilities)}")
+    print(f"Trust: {profile.trust_level}")
+    print(f"Reputation: {profile.reputation_score:.2f}")
+    print(f"Public: {'Yes' if profile.is_public else 'No'}")
+    if profile.endpoints:
+        print(f"Endpoints: {json.dumps(profile.endpoints)}")
+    if profile.registered_at:
+        print(f"Registered: {profile.registered_at.strftime('%Y-%m-%d %H:%M UTC')}")
+    if profile.last_seen_at:
+        print(f"Last seen: {profile.last_seen_at.strftime('%Y-%m-%d %H:%M UTC')}")
+
+
+def _discover(args: "argparse.Namespace", k: "Kernle") -> None:
+    """Find agents by capability."""
+    from kernle.comms.registry import AgentRegistry
+
+    registry = AgentRegistry(k._storage)
+
+    capabilities = None
+    if hasattr(args, "capability") and args.capability:
+        capabilities = [c.strip() for c in args.capability.split(",")]
+
+    limit = getattr(args, "limit", 20)
+    results = registry.discover(capabilities=capabilities, limit=limit)
+
+    if not results:
+        if capabilities:
+            print(f"No agents found with capabilities: {', '.join(capabilities)}")
+        else:
+            print("No public agents found")
+        return
+
+    if getattr(args, "json", False):
+        print(json.dumps([p.to_dict() for p in results], indent=2, default=str))
+        return
+
+    print(f"Found {len(results)} agent(s):")
+    print()
+    for profile in results:
+        name = profile.display_name or profile.agent_id
+        caps = ", ".join(profile.capabilities) if profile.capabilities else "none"
+        trust = profile.trust_level
+        rep = f"{profile.reputation_score:.2f}"
+        print(f"  {name}")
+        print(f"    ID: {profile.agent_id}")
+        print(f"    Capabilities: {caps}")
+        print(f"    Trust: {trust}, Reputation: {rep}")
+        print()
+
+
+def _update(args: "argparse.Namespace", k: "Kernle") -> None:
+    """Update your profile."""
+    from kernle.comms.registry import AgentNotFoundError, AgentRegistry
+
+    registry = AgentRegistry(k._storage)
+
+    # Build update kwargs
+    updates = {}
+
+    if hasattr(args, "name") and args.name is not None:
+        updates["display_name"] = args.name
+
+    if hasattr(args, "capabilities") and args.capabilities is not None:
+        updates["capabilities"] = [c.strip() for c in args.capabilities.split(",")]
+
+    if hasattr(args, "public") and args.public is not None:
+        updates["is_public"] = args.public
+
+    if not updates:
+        print("No updates specified")
+        print("Use: --name, --capabilities, --public/--private")
+        return
+
+    try:
+        profile = registry.update_profile(agent_id=k.agent_id, **updates)
+
+        print(f"✓ Updated profile: {profile.agent_id}")
+        if "display_name" in updates:
+            print(f"  Name: {profile.display_name}")
+        if "capabilities" in updates:
+            print(f"  Capabilities: {', '.join(profile.capabilities)}")
+        if "is_public" in updates:
+            print(f"  Public: {'Yes' if profile.is_public else 'No'}")
+
+    except AgentNotFoundError:
+        print(f"✗ Agent '{k.agent_id}' not registered")
+        print("  Use 'kernle comms register' first")
+
+
+def _delete(args: "argparse.Namespace", k: "Kernle") -> None:
+    """Delete your registration."""
+    from kernle.comms.registry import AgentRegistry
+
+    registry = AgentRegistry(k._storage)
+
+    if not getattr(args, "force", False):
+        confirm = input(f"Delete registration for '{k.agent_id}'? [y/N] ")
+        if confirm.lower() != "y":
+            print("Cancelled")
+            return
+
+    if registry.delete_profile(k.agent_id):
+        print(f"✓ Deleted registration: {k.agent_id}")
+    else:
+        print(f"✗ Agent '{k.agent_id}' not found")
+
+
+def add_comms_parser(subparsers) -> None:
+    """Add comms subcommand to argument parser."""
+    comms_parser = subparsers.add_parser(
+        "comms",
+        help="Agent-to-agent communication",
+        description="Commands for agent discovery and communication",
+    )
+
+    comms_sub = comms_parser.add_subparsers(dest="comms_action")
+
+    # Register
+    reg = comms_sub.add_parser("register", help="Register as a discoverable agent")
+    reg.add_argument("--name", "-n", help="Display name")
+    reg.add_argument("--capabilities", "-c", help="Capabilities (comma-separated)")
+    reg.add_argument("--public", action="store_true", help="Make agent discoverable")
+
+    # Profile
+    prof = comms_sub.add_parser("profile", help="View agent profile")
+    prof.add_argument("agent_id", nargs="?", help="Agent ID (default: current agent)")
+    prof.add_argument("--json", action="store_true", help="Output as JSON")
+
+    # Discover
+    disc = comms_sub.add_parser("discover", help="Find agents by capability")
+    disc.add_argument("--capability", "-c", help="Filter by capability (comma-separated)")
+    disc.add_argument("--limit", "-l", type=int, default=20, help="Max results")
+    disc.add_argument("--json", action="store_true", help="Output as JSON")
+
+    # Update
+    upd = comms_sub.add_parser("update", help="Update your profile")
+    upd.add_argument("--name", "-n", help="New display name")
+    upd.add_argument("--capabilities", "-c", help="New capabilities (comma-separated)")
+    upd.add_argument("--public", action="store_true", dest="public", default=None)
+    upd.add_argument("--private", action="store_false", dest="public")
+
+    # Delete
+    dele = comms_sub.add_parser("delete", help="Delete your registration")
+    dele.add_argument("--force", "-f", action="store_true", help="Skip confirmation")

--- a/kernle/comms/__init__.py
+++ b/kernle/comms/__init__.py
@@ -1,0 +1,21 @@
+"""
+Kernle Comms - Agent-to-Agent Communication.
+
+This package provides infrastructure for SI↔SI communication:
+- Agent registry and discovery
+- Messaging between agents
+- Memory sharing with consent
+- Collaboration protocols
+"""
+
+from kernle.comms.registry import (
+    AgentProfile,
+    AgentRegistry,
+    RegistryError,
+)
+
+__all__ = [
+    "AgentProfile",
+    "AgentRegistry",
+    "RegistryError",
+]

--- a/kernle/comms/registry.py
+++ b/kernle/comms/registry.py
@@ -1,0 +1,413 @@
+"""
+Agent Registry for Kernle Comms.
+
+Provides agent discovery and profile management:
+- Register agents with capabilities
+- Discover agents by capability
+- Manage trust levels and reputation
+"""
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class RegistryError(Exception):
+    """Base exception for registry errors."""
+
+    pass
+
+
+class AgentNotFoundError(RegistryError):
+    """Agent not found in registry."""
+
+    pass
+
+
+class AgentAlreadyExistsError(RegistryError):
+    """Agent already exists in registry."""
+
+    pass
+
+
+@dataclass
+class AgentProfile:
+    """Profile of a registered agent.
+
+    Attributes:
+        agent_id: Unique agent identifier
+        user_id: Owner's user ID
+        display_name: Human-readable name
+        capabilities: List of capabilities (e.g., ["code_review", "research"])
+        public_key: Ed25519 public key for message verification
+        endpoints: Communication endpoints (webhook URLs, etc.)
+        trust_level: Trust status (unverified, verified, trusted)
+        reputation_score: Reputation from 0.0 to 1.0
+        is_public: Whether agent is discoverable
+        registered_at: When agent was registered
+        last_seen_at: Last activity timestamp
+    """
+
+    agent_id: str
+    user_id: str
+    display_name: Optional[str] = None
+    capabilities: List[str] = field(default_factory=list)
+    public_key: Optional[str] = None
+    endpoints: Dict[str, str] = field(default_factory=dict)
+    trust_level: str = "unverified"
+    reputation_score: float = 0.0
+    is_public: bool = False
+    registered_at: Optional[datetime] = None
+    last_seen_at: Optional[datetime] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for serialization."""
+        return {
+            "agent_id": self.agent_id,
+            "user_id": self.user_id,
+            "display_name": self.display_name,
+            "capabilities": self.capabilities,
+            "public_key": self.public_key,
+            "endpoints": self.endpoints,
+            "trust_level": self.trust_level,
+            "reputation_score": self.reputation_score,
+            "is_public": self.is_public,
+            "registered_at": self.registered_at.isoformat() if self.registered_at else None,
+            "last_seen_at": self.last_seen_at.isoformat() if self.last_seen_at else None,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "AgentProfile":
+        """Create from dictionary."""
+        return cls(
+            agent_id=data["agent_id"],
+            user_id=data["user_id"],
+            display_name=data.get("display_name"),
+            capabilities=data.get("capabilities") or [],
+            public_key=data.get("public_key"),
+            endpoints=data.get("endpoints") or {},
+            trust_level=data.get("trust_level", "unverified"),
+            reputation_score=float(data.get("reputation_score", 0.0)),
+            is_public=bool(data.get("is_public", False)),
+            registered_at=cls._parse_datetime(data.get("registered_at")),
+            last_seen_at=cls._parse_datetime(data.get("last_seen_at")),
+        )
+
+    @staticmethod
+    def _parse_datetime(value: Optional[str]) -> Optional[datetime]:
+        """Parse ISO datetime string."""
+        if not value:
+            return None
+        try:
+            if value.endswith("Z"):
+                value = value[:-1] + "+00:00"
+            return datetime.fromisoformat(value)
+        except (ValueError, TypeError):
+            return None
+
+
+class AgentRegistry:
+    """Registry for agent discovery and profile management.
+
+    Provides local SQLite storage for agent profiles with optional
+    sync to Kernle Cloud for cross-agent discovery.
+    """
+
+    def __init__(self, storage: Any):
+        """Initialize registry with storage backend.
+
+        Args:
+            storage: SQLiteStorage or PostgresStorage instance
+        """
+        self._storage = storage
+        self._ensure_schema()
+
+    def _ensure_schema(self):
+        """Ensure registry table exists."""
+        # Schema is created by storage backend migration
+        pass
+
+    def register(
+        self,
+        agent_id: str,
+        user_id: str,
+        display_name: Optional[str] = None,
+        capabilities: Optional[List[str]] = None,
+        public_key: Optional[str] = None,
+        endpoints: Optional[Dict[str, str]] = None,
+        is_public: bool = False,
+    ) -> AgentProfile:
+        """Register a new agent in the registry.
+
+        Args:
+            agent_id: Unique agent identifier
+            user_id: Owner's user ID
+            display_name: Human-readable name
+            capabilities: List of capabilities
+            public_key: Ed25519 public key
+            endpoints: Communication endpoints
+            is_public: Whether agent is discoverable
+
+        Returns:
+            The created AgentProfile
+
+        Raises:
+            AgentAlreadyExistsError: If agent already registered
+        """
+        # Check if already exists
+        existing = self.get_profile(agent_id)
+        if existing:
+            raise AgentAlreadyExistsError(f"Agent '{agent_id}' already registered")
+
+        now = datetime.now(timezone.utc)
+        profile = AgentProfile(
+            agent_id=agent_id,
+            user_id=user_id,
+            display_name=display_name,
+            capabilities=capabilities or [],
+            public_key=public_key,
+            endpoints=endpoints or {},
+            trust_level="unverified",
+            reputation_score=0.0,
+            is_public=is_public,
+            registered_at=now,
+            last_seen_at=now,
+        )
+
+        self._save_profile(profile)
+        logger.info(f"Registered agent: {agent_id}")
+        return profile
+
+    def get_profile(self, agent_id: str) -> Optional[AgentProfile]:
+        """Get an agent's profile.
+
+        Args:
+            agent_id: Agent identifier
+
+        Returns:
+            AgentProfile if found, None otherwise
+        """
+        return self._load_profile(agent_id)
+
+    def update_profile(
+        self,
+        agent_id: str,
+        display_name: Optional[str] = None,
+        capabilities: Optional[List[str]] = None,
+        public_key: Optional[str] = None,
+        endpoints: Optional[Dict[str, str]] = None,
+        is_public: Optional[bool] = None,
+    ) -> AgentProfile:
+        """Update an agent's profile.
+
+        Args:
+            agent_id: Agent identifier
+            display_name: New display name (None = no change)
+            capabilities: New capabilities (None = no change)
+            public_key: New public key (None = no change)
+            endpoints: New endpoints (None = no change)
+            is_public: New visibility (None = no change)
+
+        Returns:
+            Updated AgentProfile
+
+        Raises:
+            AgentNotFoundError: If agent not found
+        """
+        profile = self.get_profile(agent_id)
+        if not profile:
+            raise AgentNotFoundError(f"Agent '{agent_id}' not found")
+
+        if display_name is not None:
+            profile.display_name = display_name
+        if capabilities is not None:
+            profile.capabilities = capabilities
+        if public_key is not None:
+            profile.public_key = public_key
+        if endpoints is not None:
+            profile.endpoints = endpoints
+        if is_public is not None:
+            profile.is_public = is_public
+
+        profile.last_seen_at = datetime.now(timezone.utc)
+        self._save_profile(profile)
+        logger.info(f"Updated agent profile: {agent_id}")
+        return profile
+
+    def update_last_seen(self, agent_id: str) -> None:
+        """Update agent's last_seen_at timestamp.
+
+        Args:
+            agent_id: Agent identifier
+        """
+        profile = self.get_profile(agent_id)
+        if profile:
+            profile.last_seen_at = datetime.now(timezone.utc)
+            self._save_profile(profile)
+
+    def delete_profile(self, agent_id: str) -> bool:
+        """Delete an agent's profile.
+
+        Args:
+            agent_id: Agent identifier
+
+        Returns:
+            True if deleted, False if not found
+        """
+        return self._delete_profile(agent_id)
+
+    def discover(
+        self,
+        capabilities: Optional[List[str]] = None,
+        trust_level: Optional[str] = None,
+        limit: int = 50,
+    ) -> List[AgentProfile]:
+        """Discover agents by criteria.
+
+        Args:
+            capabilities: Filter by capabilities (any match)
+            trust_level: Filter by minimum trust level
+            limit: Maximum results
+
+        Returns:
+            List of matching AgentProfiles (public only)
+        """
+        return self._search_profiles(
+            capabilities=capabilities,
+            trust_level=trust_level,
+            is_public=True,
+            limit=limit,
+        )
+
+    def list_all(self, limit: int = 100) -> List[AgentProfile]:
+        """List all registered agents (for admin/debugging).
+
+        Args:
+            limit: Maximum results
+
+        Returns:
+            List of all AgentProfiles
+        """
+        return self._search_profiles(limit=limit)
+
+    # === Storage Operations ===
+
+    def _save_profile(self, profile: AgentProfile) -> None:
+        """Save profile to storage."""
+        conn = self._storage._get_conn()
+        try:
+            conn.execute(
+                """INSERT OR REPLACE INTO agent_registry
+                   (agent_id, user_id, display_name, capabilities, public_key,
+                    endpoints, trust_level, reputation_score, is_public,
+                    registered_at, last_seen_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    profile.agent_id,
+                    profile.user_id,
+                    profile.display_name,
+                    json.dumps(profile.capabilities),
+                    profile.public_key,
+                    json.dumps(profile.endpoints),
+                    profile.trust_level,
+                    profile.reputation_score,
+                    1 if profile.is_public else 0,
+                    profile.registered_at.isoformat() if profile.registered_at else None,
+                    profile.last_seen_at.isoformat() if profile.last_seen_at else None,
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def _load_profile(self, agent_id: str) -> Optional[AgentProfile]:
+        """Load profile from storage."""
+        conn = self._storage._get_conn()
+        try:
+            row = conn.execute(
+                "SELECT * FROM agent_registry WHERE agent_id = ?",
+                (agent_id,),
+            ).fetchone()
+
+            if not row:
+                return None
+
+            return self._row_to_profile(row)
+        finally:
+            conn.close()
+
+    def _delete_profile(self, agent_id: str) -> bool:
+        """Delete profile from storage."""
+        conn = self._storage._get_conn()
+        try:
+            cursor = conn.execute(
+                "DELETE FROM agent_registry WHERE agent_id = ?",
+                (agent_id,),
+            )
+            conn.commit()
+            return cursor.rowcount > 0
+        finally:
+            conn.close()
+
+    def _search_profiles(
+        self,
+        capabilities: Optional[List[str]] = None,
+        trust_level: Optional[str] = None,
+        is_public: Optional[bool] = None,
+        limit: int = 50,
+    ) -> List[AgentProfile]:
+        """Search profiles with filters."""
+        conn = self._storage._get_conn()
+        try:
+            query = "SELECT * FROM agent_registry WHERE 1=1"
+            params: List[Any] = []
+
+            if is_public is not None:
+                query += " AND is_public = ?"
+                params.append(1 if is_public else 0)
+
+            if trust_level:
+                # Trust levels: unverified < verified < trusted
+                trust_order = {"unverified": 0, "verified": 1, "trusted": 2}
+                min_trust = trust_order.get(trust_level, 0)
+                query += " AND trust_level IN (?)"
+                # Get levels >= min_trust
+                valid_levels = [k for k, v in trust_order.items() if v >= min_trust]
+                query = query.replace("(?)", f"({','.join('?' * len(valid_levels))})")
+                params.extend(valid_levels)
+
+            query += " ORDER BY reputation_score DESC, last_seen_at DESC LIMIT ?"
+            params.append(limit)
+
+            rows = conn.execute(query, params).fetchall()
+            profiles = [self._row_to_profile(row) for row in rows]
+
+            # Filter by capabilities if specified (post-query for SQLite)
+            if capabilities:
+                profiles = [
+                    p for p in profiles if any(cap in p.capabilities for cap in capabilities)
+                ]
+
+            return profiles[:limit]
+        finally:
+            conn.close()
+
+    def _row_to_profile(self, row) -> AgentProfile:
+        """Convert database row to AgentProfile."""
+        return AgentProfile(
+            agent_id=row["agent_id"],
+            user_id=row["user_id"],
+            display_name=row["display_name"],
+            capabilities=json.loads(row["capabilities"] or "[]"),
+            public_key=row["public_key"],
+            endpoints=json.loads(row["endpoints"] or "{}"),
+            trust_level=row["trust_level"],
+            reputation_score=float(row["reputation_score"] or 0),
+            is_public=bool(row["is_public"]),
+            registered_at=AgentProfile._parse_datetime(row["registered_at"]),
+            last_seen_at=AgentProfile._parse_datetime(row["last_seen_at"]),
+        )

--- a/kernle/storage/sqlite.py
+++ b/kernle/storage/sqlite.py
@@ -124,6 +124,7 @@ ALLOWED_TABLES = frozenset(
         "embeddings",
         "health_check_events",
         "boot_config",
+        "agent_registry",  # Comms package (v0.3.0)
     }
 )
 
@@ -638,6 +639,24 @@ CREATE TABLE IF NOT EXISTS boot_config (
     UNIQUE(agent_id, key)
 );
 CREATE INDEX IF NOT EXISTS idx_boot_agent ON boot_config(agent_id);
+
+-- Agent registry for comms package (v0.3.0)
+CREATE TABLE IF NOT EXISTS agent_registry (
+    agent_id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    display_name TEXT,
+    capabilities TEXT,  -- JSON array
+    public_key TEXT,
+    endpoints TEXT,  -- JSON object
+    trust_level TEXT DEFAULT 'unverified',
+    reputation_score REAL DEFAULT 0.0,
+    is_public INTEGER DEFAULT 0,
+    registered_at TEXT,
+    last_seen_at TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_agent_registry_user ON agent_registry(user_id);
+CREATE INDEX IF NOT EXISTS idx_agent_registry_public ON agent_registry(is_public);
+CREATE INDEX IF NOT EXISTS idx_agent_registry_trust ON agent_registry(trust_level);
 
 -- Embedding metadata (tracks what's been embedded)
 CREATE TABLE IF NOT EXISTS embedding_meta (

--- a/tests/comms/__init__.py
+++ b/tests/comms/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for kernle.comms package."""

--- a/tests/comms/test_registry.py
+++ b/tests/comms/test_registry.py
@@ -1,0 +1,334 @@
+"""Tests for agent registry."""
+
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from kernle.comms.registry import (
+    AgentAlreadyExistsError,
+    AgentNotFoundError,
+    AgentProfile,
+    AgentRegistry,
+)
+from kernle.storage import SQLiteStorage
+
+
+@pytest.fixture
+def temp_db():
+    """Create a temporary database path."""
+    path = Path(tempfile.mktemp(suffix=".db"))
+    yield path
+    if path.exists():
+        path.unlink()
+
+
+@pytest.fixture
+def storage(temp_db):
+    """Create a SQLiteStorage instance for testing."""
+    storage = SQLiteStorage(agent_id="test-agent", db_path=temp_db)
+    yield storage
+    storage.close()
+
+
+@pytest.fixture
+def registry(storage):
+    """Create an AgentRegistry instance for testing."""
+    return AgentRegistry(storage)
+
+
+class TestAgentProfile:
+    """Tests for AgentProfile dataclass."""
+
+    def test_to_dict_includes_all_fields(self):
+        """Test that to_dict includes all fields."""
+        profile = AgentProfile(
+            agent_id="test-agent",
+            user_id="user-123",
+            display_name="Test Agent",
+            capabilities=["code", "research"],
+            public_key="pk_abc123",
+            endpoints={"webhook": "https://example.com/hook"},
+            trust_level="verified",
+            reputation_score=0.75,
+            is_public=True,
+            registered_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            last_seen_at=datetime(2026, 2, 1, tzinfo=timezone.utc),
+        )
+
+        data = profile.to_dict()
+
+        assert data["agent_id"] == "test-agent"
+        assert data["user_id"] == "user-123"
+        assert data["display_name"] == "Test Agent"
+        assert data["capabilities"] == ["code", "research"]
+        assert data["public_key"] == "pk_abc123"
+        assert data["endpoints"] == {"webhook": "https://example.com/hook"}
+        assert data["trust_level"] == "verified"
+        assert data["reputation_score"] == 0.75
+        assert data["is_public"] is True
+        assert "2026-01-01" in data["registered_at"]
+        assert "2026-02-01" in data["last_seen_at"]
+
+    def test_from_dict_creates_profile(self):
+        """Test that from_dict creates a valid profile."""
+        data = {
+            "agent_id": "test-agent",
+            "user_id": "user-123",
+            "display_name": "Test Agent",
+            "capabilities": ["code", "research"],
+            "trust_level": "verified",
+            "reputation_score": 0.75,
+            "is_public": True,
+        }
+
+        profile = AgentProfile.from_dict(data)
+
+        assert profile.agent_id == "test-agent"
+        assert profile.user_id == "user-123"
+        assert profile.display_name == "Test Agent"
+        assert profile.capabilities == ["code", "research"]
+        assert profile.trust_level == "verified"
+        assert profile.reputation_score == 0.75
+        assert profile.is_public is True
+
+    def test_from_dict_handles_missing_optional_fields(self):
+        """Test that from_dict handles missing optional fields."""
+        data = {
+            "agent_id": "test-agent",
+            "user_id": "user-123",
+        }
+
+        profile = AgentProfile.from_dict(data)
+
+        assert profile.agent_id == "test-agent"
+        assert profile.user_id == "user-123"
+        assert profile.display_name is None
+        assert profile.capabilities == []
+        assert profile.public_key is None
+        assert profile.endpoints == {}
+        assert profile.trust_level == "unverified"
+        assert profile.reputation_score == 0.0
+        assert profile.is_public is False
+
+
+class TestAgentRegistry:
+    """Tests for AgentRegistry CRUD operations."""
+
+    def test_register_creates_profile(self, registry):
+        """Test that register creates a new profile."""
+        profile = registry.register(
+            agent_id="new-agent",
+            user_id="user-123",
+            display_name="New Agent",
+            capabilities=["code", "research"],
+            is_public=True,
+        )
+
+        assert profile.agent_id == "new-agent"
+        assert profile.user_id == "user-123"
+        assert profile.display_name == "New Agent"
+        assert profile.capabilities == ["code", "research"]
+        assert profile.is_public is True
+        assert profile.trust_level == "unverified"
+        assert profile.registered_at is not None
+
+    def test_register_raises_for_duplicate(self, registry):
+        """Test that register raises for duplicate agent_id."""
+        registry.register(agent_id="dup-agent", user_id="user-123")
+
+        with pytest.raises(AgentAlreadyExistsError):
+            registry.register(agent_id="dup-agent", user_id="user-456")
+
+    def test_get_profile_returns_profile(self, registry):
+        """Test that get_profile returns existing profile."""
+        registry.register(
+            agent_id="get-agent",
+            user_id="user-123",
+            display_name="Get Agent",
+        )
+
+        profile = registry.get_profile("get-agent")
+
+        assert profile is not None
+        assert profile.agent_id == "get-agent"
+        assert profile.display_name == "Get Agent"
+
+    def test_get_profile_returns_none_for_missing(self, registry):
+        """Test that get_profile returns None for missing agent."""
+        profile = registry.get_profile("nonexistent")
+        assert profile is None
+
+    def test_update_profile_updates_fields(self, registry):
+        """Test that update_profile updates specified fields."""
+        registry.register(
+            agent_id="update-agent",
+            user_id="user-123",
+            display_name="Original Name",
+            capabilities=["code"],
+        )
+
+        updated = registry.update_profile(
+            agent_id="update-agent",
+            display_name="New Name",
+            capabilities=["code", "research"],
+            is_public=True,
+        )
+
+        assert updated.display_name == "New Name"
+        assert updated.capabilities == ["code", "research"]
+        assert updated.is_public is True
+
+    def test_update_profile_preserves_unchanged_fields(self, registry):
+        """Test that update_profile preserves fields not specified."""
+        registry.register(
+            agent_id="preserve-agent",
+            user_id="user-123",
+            display_name="Original Name",
+            capabilities=["code", "research"],
+        )
+
+        updated = registry.update_profile(
+            agent_id="preserve-agent",
+            display_name="New Name",
+        )
+
+        assert updated.display_name == "New Name"
+        assert updated.capabilities == ["code", "research"]  # Preserved
+
+    def test_update_profile_raises_for_missing(self, registry):
+        """Test that update_profile raises for missing agent."""
+        with pytest.raises(AgentNotFoundError):
+            registry.update_profile(agent_id="nonexistent", display_name="Name")
+
+    def test_delete_profile_removes_agent(self, registry):
+        """Test that delete_profile removes the agent."""
+        registry.register(agent_id="delete-agent", user_id="user-123")
+
+        result = registry.delete_profile("delete-agent")
+        assert result is True
+
+        profile = registry.get_profile("delete-agent")
+        assert profile is None
+
+    def test_delete_profile_returns_false_for_missing(self, registry):
+        """Test that delete_profile returns False for missing agent."""
+        result = registry.delete_profile("nonexistent")
+        assert result is False
+
+
+class TestAgentDiscovery:
+    """Tests for agent discovery functionality."""
+
+    def test_discover_returns_public_agents(self, registry):
+        """Test that discover returns only public agents."""
+        registry.register(
+            agent_id="public-agent",
+            user_id="user-123",
+            is_public=True,
+        )
+        registry.register(
+            agent_id="private-agent",
+            user_id="user-456",
+            is_public=False,
+        )
+
+        results = registry.discover()
+
+        agent_ids = [p.agent_id for p in results]
+        assert "public-agent" in agent_ids
+        assert "private-agent" not in agent_ids
+
+    def test_discover_filters_by_capability(self, registry):
+        """Test that discover filters by capability."""
+        registry.register(
+            agent_id="code-agent",
+            user_id="user-123",
+            capabilities=["code", "review"],
+            is_public=True,
+        )
+        registry.register(
+            agent_id="research-agent",
+            user_id="user-456",
+            capabilities=["research"],
+            is_public=True,
+        )
+
+        results = registry.discover(capabilities=["code"])
+
+        agent_ids = [p.agent_id for p in results]
+        assert "code-agent" in agent_ids
+        assert "research-agent" not in agent_ids
+
+    def test_discover_multiple_capabilities_match_any(self, registry):
+        """Test that discover with multiple capabilities matches any."""
+        registry.register(
+            agent_id="code-agent",
+            user_id="user-123",
+            capabilities=["code"],
+            is_public=True,
+        )
+        registry.register(
+            agent_id="research-agent",
+            user_id="user-456",
+            capabilities=["research"],
+            is_public=True,
+        )
+        registry.register(
+            agent_id="other-agent",
+            user_id="user-789",
+            capabilities=["writing"],
+            is_public=True,
+        )
+
+        results = registry.discover(capabilities=["code", "research"])
+
+        agent_ids = [p.agent_id for p in results]
+        assert "code-agent" in agent_ids
+        assert "research-agent" in agent_ids
+        assert "other-agent" not in agent_ids
+
+    def test_list_all_returns_all_agents(self, registry):
+        """Test that list_all returns all agents including private."""
+        registry.register(
+            agent_id="public-agent",
+            user_id="user-123",
+            is_public=True,
+        )
+        registry.register(
+            agent_id="private-agent",
+            user_id="user-456",
+            is_public=False,
+        )
+
+        results = registry.list_all()
+
+        agent_ids = [p.agent_id for p in results]
+        assert "public-agent" in agent_ids
+        assert "private-agent" in agent_ids
+
+
+class TestLastSeenTracking:
+    """Tests for last_seen_at tracking."""
+
+    def test_register_sets_last_seen(self, registry):
+        """Test that register sets last_seen_at."""
+        profile = registry.register(agent_id="new-agent", user_id="user-123")
+        assert profile.last_seen_at is not None
+
+    def test_update_last_seen_updates_timestamp(self, registry):
+        """Test that update_last_seen updates the timestamp."""
+        registry.register(agent_id="seen-agent", user_id="user-123")
+        profile1 = registry.get_profile("seen-agent")
+        original_seen = profile1.last_seen_at
+
+        # Small delay to ensure different timestamp
+        import time
+
+        time.sleep(0.01)
+
+        registry.update_last_seen("seen-agent")
+        profile2 = registry.get_profile("seen-agent")
+
+        assert profile2.last_seen_at >= original_seen


### PR DESCRIPTION
## Summary
Implements agent registry for the comms package (v0.3.0).

## Changes

### Core
- `kernle/comms/registry.py` - AgentProfile dataclass + AgentRegistry class
- `kernle/comms/__init__.py` - Package exports

### Storage
- SQLite schema for `agent_registry` table
- Added to ALLOWED_TABLES for SQL injection protection

### CLI
- `kernle comms register` - Register as discoverable agent
- `kernle comms profile [agent_id]` - View agent profile
- `kernle comms discover [--capability X]` - Find agents by capability
- `kernle comms update` - Update your profile
- `kernle comms delete` - Delete registration

### Tests
- 18 unit tests covering CRUD, discovery, and last_seen tracking

## Schema
```sql
CREATE TABLE agent_registry (
    agent_id TEXT PRIMARY KEY,
    user_id TEXT NOT NULL,
    display_name TEXT,
    capabilities TEXT,  -- JSON array
    public_key TEXT,
    endpoints TEXT,  -- JSON object
    trust_level TEXT DEFAULT 'unverified',
    reputation_score REAL DEFAULT 0.0,
    is_public INTEGER DEFAULT 0,
    registered_at TEXT,
    last_seen_at TEXT
);
```

Resolves #144
Part of v0.3.0 comms package