### PR TITLE
feat(comms): add PKI module for agent identity

### DIFF
--- a/kernle/cli/__main__.py
+++ b/kernle/cli/__main__.py
@@ -42,6 +42,7 @@ from kernle.cli.commands import (
 from kernle.cli.commands.agent import cmd_agent
 from kernle.cli.commands.comms import add_comms_parser, cmd_comms
 from kernle.cli.commands.import_cmd import cmd_import, cmd_migrate
+from kernle.cli.commands.keys import add_keys_parser, cmd_keys
 from kernle.cli.commands.setup import cmd_setup
 from kernle.commerce.cli import cmd_job, cmd_skills, cmd_wallet
 from kernle.utils import resolve_agent_id
@@ -3689,6 +3690,9 @@ Typical usage in a memoryFlush hook:
     # comms - agent-to-agent communication (v0.3.0)
     add_comms_parser(subparsers)
 
+    # keys - cryptographic key management (v0.3.0 comms)
+    add_keys_parser(subparsers)
+
     # import - import from external files (markdown, JSON, CSV)
     p_import = subparsers.add_parser(
         "import", help="Import memories from markdown, JSON, or CSV files"
@@ -4115,6 +4119,8 @@ Beliefs already present in the agent's memory will be skipped.
             cmd_agent(args, k)
         elif args.command == "comms":
             cmd_comms(args, k)
+        elif args.command == "keys":
+            cmd_keys(args, k)
         elif args.command == "import":
             cmd_import(args, k)
         elif args.command == "migrate":

--- a/kernle/cli/commands/keys.py
+++ b/kernle/cli/commands/keys.py
@@ -1,0 +1,195 @@
+"""Key management CLI commands for Kernle Comms.
+
+Commands for managing agent cryptographic keys:
+- kernle keys generate - Generate a new key pair
+- kernle keys show - Show public key info
+- kernle keys rotate - Rotate to a new key pair
+- kernle keys export - Export public key
+"""
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import argparse
+
+    from kernle import Kernle
+
+
+def cmd_keys(args: "argparse.Namespace", k: "Kernle") -> None:
+    """Handle keys subcommands."""
+    action = getattr(args, "keys_action", None)
+
+    if action == "generate":
+        _generate(args, k)
+    elif action == "show":
+        _show(args, k)
+    elif action == "rotate":
+        _rotate(args, k)
+    elif action == "export":
+        _export(args, k)
+    elif action == "delete":
+        _delete(args, k)
+    else:
+        print("Usage: kernle keys <generate|show|rotate|export|delete>")
+        print()
+        print("Commands:")
+        print("  generate  Generate a new Ed25519 key pair")
+        print("  show      Show key info (public key, key ID)")
+        print("  rotate    Rotate to a new key pair (archives old)")
+        print("  export    Export public key for sharing")
+        print("  delete    Delete the key pair")
+
+
+def _generate(args: "argparse.Namespace", k: "Kernle") -> None:
+    """Generate a new key pair."""
+    from kernle.comms.crypto import KeyAlreadyExistsError, KeyManager
+
+    force = getattr(args, "force", False)
+    manager = KeyManager(agent_id=k.agent_id)
+
+    try:
+        key_pair = manager.generate(force=force)
+
+        print("✓ Generated Ed25519 key pair")
+        print(f"  Agent: {k.agent_id}")
+        print(f"  Key ID: {key_pair.key_id}")
+        print(f"  Public: {key_pair.public_key[:20]}...")
+        print()
+        print("Your public key can be shared with other agents.")
+        print("Your private key is stored locally and never leaves this machine.")
+
+    except KeyAlreadyExistsError:
+        print(f"✗ Key already exists for '{k.agent_id}'")
+        print("  Use --force to overwrite, or 'kernle keys rotate' to rotate")
+
+
+def _show(args: "argparse.Namespace", k: "Kernle") -> None:
+    """Show key info."""
+    import json
+
+    from kernle.comms.crypto import KeyManager, KeyNotFoundError
+
+    manager = KeyManager(agent_id=k.agent_id)
+
+    try:
+        key_pair = manager.get_key_pair()
+
+        if getattr(args, "json", False):
+            data = {
+                "agent_id": k.agent_id,
+                "key_id": key_pair.key_id,
+                "public_key": key_pair.public_key,
+                "created_at": key_pair.created_at.isoformat() if key_pair.created_at else None,
+            }
+            print(json.dumps(data, indent=2))
+            return
+
+        print(f"Agent: {k.agent_id}")
+        print(f"Key ID: {key_pair.key_id}")
+        print(f"Public Key: {key_pair.public_key}")
+        if key_pair.created_at:
+            print(f"Created: {key_pair.created_at.strftime('%Y-%m-%d %H:%M UTC')}")
+
+    except KeyNotFoundError:
+        print(f"✗ No key found for '{k.agent_id}'")
+        print("  Use 'kernle keys generate' to create one")
+
+
+def _rotate(args: "argparse.Namespace", k: "Kernle") -> None:
+    """Rotate to a new key pair."""
+    from kernle.comms.crypto import KeyManager
+
+    manager = KeyManager(agent_id=k.agent_id)
+
+    if not getattr(args, "force", False) and manager.has_key():
+        confirm = input("Rotate to a new key pair? This will archive the old key. [y/N] ")
+        if confirm.lower() != "y":
+            print("Cancelled")
+            return
+
+    new_key, old_key = manager.rotate()
+
+    print("✓ Rotated key pair")
+    print(f"  Agent: {k.agent_id}")
+    print(f"  New Key ID: {new_key.key_id}")
+    if old_key:
+        print(f"  Old Key ID: {old_key.key_id} (archived)")
+    print()
+    print("Remember to update your registry profile with the new public key:")
+    print("  kernle comms update --public-key")
+
+
+def _export(args: "argparse.Namespace", k: "Kernle") -> None:
+    """Export public key."""
+    from kernle.comms.crypto import KeyManager, KeyNotFoundError
+
+    manager = KeyManager(agent_id=k.agent_id)
+
+    try:
+        public_key = manager.get_public_key()
+
+        # Check if output file specified
+        output_path = getattr(args, "output", None)
+        if output_path:
+            from pathlib import Path
+
+            Path(output_path).write_text(public_key)
+            print(f"✓ Exported public key to: {output_path}")
+        else:
+            # Print to stdout for piping
+            print(public_key)
+
+    except KeyNotFoundError:
+        print(f"✗ No key found for '{k.agent_id}'")
+        print("  Use 'kernle keys generate' to create one")
+
+
+def _delete(args: "argparse.Namespace", k: "Kernle") -> None:
+    """Delete the key pair."""
+    from kernle.comms.crypto import KeyManager
+
+    manager = KeyManager(agent_id=k.agent_id)
+
+    if not manager.has_key():
+        print(f"✗ No key found for '{k.agent_id}'")
+        return
+
+    if not getattr(args, "force", False):
+        confirm = input(f"Delete key pair for '{k.agent_id}'? This cannot be undone. [y/N] ")
+        if confirm.lower() != "y":
+            print("Cancelled")
+            return
+
+    manager.delete()
+    print(f"✓ Deleted key pair for '{k.agent_id}'")
+
+
+def add_keys_parser(subparsers) -> None:
+    """Add keys subcommand to argument parser."""
+    keys_parser = subparsers.add_parser(
+        "keys",
+        help="Cryptographic key management",
+        description="Manage Ed25519 keys for agent identity and message signing",
+    )
+
+    keys_sub = keys_parser.add_subparsers(dest="keys_action")
+
+    # Generate
+    gen = keys_sub.add_parser("generate", help="Generate a new Ed25519 key pair")
+    gen.add_argument("--force", "-f", action="store_true", help="Overwrite existing key")
+
+    # Show
+    show = keys_sub.add_parser("show", help="Show key info")
+    show.add_argument("--json", "-j", action="store_true", help="Output as JSON")
+
+    # Rotate
+    rot = keys_sub.add_parser("rotate", help="Rotate to a new key pair")
+    rot.add_argument("--force", "-f", action="store_true", help="Skip confirmation")
+
+    # Export
+    exp = keys_sub.add_parser("export", help="Export public key")
+    exp.add_argument("--output", "-o", help="Output file path")
+
+    # Delete
+    dele = keys_sub.add_parser("delete", help="Delete the key pair")
+    dele.add_argument("--force", "-f", action="store_true", help="Skip confirmation")

--- a/kernle/comms/__init__.py
+++ b/kernle/comms/__init__.py
@@ -8,6 +8,17 @@ This package provides infrastructure for SI↔SI communication:
 - Collaboration protocols
 """
 
+from kernle.comms.crypto import (
+    CryptoError,
+    KeyAlreadyExistsError,
+    KeyManager,
+    KeyNotFoundError,
+    KeyPair,
+    SignatureError,
+    generate_key_pair,
+    sign_message,
+    verify_signature,
+)
 from kernle.comms.registry import (
     AgentProfile,
     AgentRegistry,
@@ -15,7 +26,18 @@ from kernle.comms.registry import (
 )
 
 __all__ = [
+    # Registry
     "AgentProfile",
     "AgentRegistry",
     "RegistryError",
+    # Crypto
+    "CryptoError",
+    "KeyAlreadyExistsError",
+    "KeyManager",
+    "KeyNotFoundError",
+    "KeyPair",
+    "SignatureError",
+    "generate_key_pair",
+    "sign_message",
+    "verify_signature",
 ]

--- a/kernle/comms/crypto.py
+++ b/kernle/comms/crypto.py
@@ -1,0 +1,374 @@
+"""
+Cryptographic utilities for Kernle Comms.
+
+Provides Ed25519 key management for agent identity:
+- Key pair generation
+- Message signing and verification
+- Key storage and rotation
+"""
+
+import base64
+import json
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Default key storage directory
+DEFAULT_KEY_DIR = Path.home() / ".kernle" / "keys"
+
+
+class CryptoError(Exception):
+    """Base exception for crypto errors."""
+
+    pass
+
+
+class KeyNotFoundError(CryptoError):
+    """Private key not found."""
+
+    pass
+
+
+class SignatureError(CryptoError):
+    """Signature verification failed."""
+
+    pass
+
+
+class KeyAlreadyExistsError(CryptoError):
+    """Key already exists (use rotate to replace)."""
+
+    pass
+
+
+@dataclass
+class KeyPair:
+    """Ed25519 key pair.
+
+    Attributes:
+        public_key: Base64-encoded public key
+        private_key: Base64-encoded private key (optional, for security)
+        created_at: When the key was generated
+        key_id: Short identifier derived from public key
+    """
+
+    public_key: str
+    private_key: Optional[str] = None
+    created_at: Optional[datetime] = None
+    key_id: Optional[str] = None
+
+    @property
+    def public_key_bytes(self) -> bytes:
+        """Get public key as bytes."""
+        return base64.b64decode(self.public_key)
+
+    @property
+    def private_key_bytes(self) -> Optional[bytes]:
+        """Get private key as bytes."""
+        if self.private_key is None:
+            return None
+        return base64.b64decode(self.private_key)
+
+
+def generate_key_pair() -> KeyPair:
+    """Generate a new Ed25519 key pair.
+
+    Returns:
+        KeyPair with public and private keys
+
+    Raises:
+        CryptoError: If key generation fails
+    """
+    try:
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+        private_key = Ed25519PrivateKey.generate()
+        public_key = private_key.public_key()
+
+        # Serialize to raw bytes then base64
+        private_bytes = private_key.private_bytes_raw()
+        public_bytes = public_key.public_bytes_raw()
+
+        public_b64 = base64.b64encode(public_bytes).decode("ascii")
+        private_b64 = base64.b64encode(private_bytes).decode("ascii")
+
+        # Generate key_id from first 8 chars of public key hash
+        import hashlib
+
+        key_id = hashlib.sha256(public_bytes).hexdigest()[:8]
+
+        return KeyPair(
+            public_key=public_b64,
+            private_key=private_b64,
+            created_at=datetime.now(timezone.utc),
+            key_id=key_id,
+        )
+    except ImportError:
+        raise CryptoError(
+            "cryptography package not installed. Install with: pip install cryptography"
+        )
+    except Exception as e:
+        logger.error(f"Key generation failed: {e}")
+        raise CryptoError(f"Failed to generate key pair: {e}") from e
+
+
+def sign_message(message: bytes, private_key_b64: str) -> str:
+    """Sign a message with Ed25519 private key.
+
+    Args:
+        message: Message bytes to sign
+        private_key_b64: Base64-encoded private key
+
+    Returns:
+        Base64-encoded signature
+
+    Raises:
+        CryptoError: If signing fails
+    """
+    try:
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+        private_bytes = base64.b64decode(private_key_b64)
+        private_key = Ed25519PrivateKey.from_private_bytes(private_bytes)
+
+        signature = private_key.sign(message)
+        return base64.b64encode(signature).decode("ascii")
+    except ImportError:
+        raise CryptoError("cryptography package not installed")
+    except Exception as e:
+        logger.error(f"Signing failed: {e}")
+        raise CryptoError(f"Failed to sign message: {e}") from e
+
+
+def verify_signature(message: bytes, signature_b64: str, public_key_b64: str) -> bool:
+    """Verify a message signature with Ed25519 public key.
+
+    Args:
+        message: Original message bytes
+        signature_b64: Base64-encoded signature
+        public_key_b64: Base64-encoded public key
+
+    Returns:
+        True if signature is valid, False otherwise
+
+    Raises:
+        SignatureError: If signature is invalid
+    """
+    try:
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+        public_bytes = base64.b64decode(public_key_b64)
+        signature = base64.b64decode(signature_b64)
+
+        public_key = Ed25519PublicKey.from_public_bytes(public_bytes)
+        public_key.verify(signature, message)
+        return True
+    except ImportError:
+        raise CryptoError("cryptography package not installed")
+    except Exception as e:
+        logger.debug(f"Signature verification failed: {e}")
+        raise SignatureError(f"Invalid signature: {e}") from e
+
+
+class KeyManager:
+    """Manages agent key pairs for signing and verification.
+
+    Keys are stored locally in the key directory with the following structure:
+    - {key_dir}/{agent_id}/private.key - Private key (base64)
+    - {key_dir}/{agent_id}/public.key - Public key (base64)
+    - {key_dir}/{agent_id}/meta.json - Key metadata
+    """
+
+    def __init__(self, agent_id: str, key_dir: Optional[Path] = None):
+        """Initialize key manager.
+
+        Args:
+            agent_id: Agent identifier
+            key_dir: Directory to store keys (default: ~/.kernle/keys)
+        """
+        self.agent_id = agent_id
+        self.key_dir = key_dir or DEFAULT_KEY_DIR
+        self._agent_key_dir = self.key_dir / agent_id
+
+    def has_key(self) -> bool:
+        """Check if agent has a key pair."""
+        return (self._agent_key_dir / "private.key").exists()
+
+    def generate(self, force: bool = False) -> KeyPair:
+        """Generate and store a new key pair.
+
+        Args:
+            force: If True, overwrite existing key
+
+        Returns:
+            The generated KeyPair
+
+        Raises:
+            KeyAlreadyExistsError: If key exists and force=False
+        """
+        if self.has_key() and not force:
+            raise KeyAlreadyExistsError(
+                f"Key already exists for '{self.agent_id}'. Use force=True or rotate() to replace."
+            )
+
+        key_pair = generate_key_pair()
+        self._save_key_pair(key_pair)
+        logger.info(f"Generated new key pair for agent: {self.agent_id}")
+        return key_pair
+
+    def rotate(self) -> Tuple[KeyPair, Optional[KeyPair]]:
+        """Rotate key pair, keeping old key for reference.
+
+        Returns:
+            Tuple of (new_key, old_key or None)
+        """
+        old_key = None
+        if self.has_key():
+            old_key = self.get_key_pair()
+            # Archive old key
+            self._archive_key()
+
+        new_key = generate_key_pair()
+        self._save_key_pair(new_key)
+        logger.info(f"Rotated key pair for agent: {self.agent_id}")
+        return new_key, old_key
+
+    def get_key_pair(self) -> KeyPair:
+        """Get the agent's key pair.
+
+        Returns:
+            KeyPair with both public and private keys
+
+        Raises:
+            KeyNotFoundError: If no key exists
+        """
+        if not self.has_key():
+            raise KeyNotFoundError(f"No key found for agent '{self.agent_id}'")
+
+        private_path = self._agent_key_dir / "private.key"
+        public_path = self._agent_key_dir / "public.key"
+        meta_path = self._agent_key_dir / "meta.json"
+
+        private_key = private_path.read_text().strip()
+        public_key = public_path.read_text().strip()
+
+        created_at = None
+        key_id = None
+        if meta_path.exists():
+            meta = json.loads(meta_path.read_text())
+            if "created_at" in meta:
+                created_at = datetime.fromisoformat(meta["created_at"])
+            key_id = meta.get("key_id")
+
+        return KeyPair(
+            public_key=public_key,
+            private_key=private_key,
+            created_at=created_at,
+            key_id=key_id,
+        )
+
+    def get_public_key(self) -> str:
+        """Get just the public key (safe to share).
+
+        Returns:
+            Base64-encoded public key
+
+        Raises:
+            KeyNotFoundError: If no key exists
+        """
+        if not self.has_key():
+            raise KeyNotFoundError(f"No key found for agent '{self.agent_id}'")
+
+        public_path = self._agent_key_dir / "public.key"
+        return public_path.read_text().strip()
+
+    def sign(self, message: bytes) -> str:
+        """Sign a message with the agent's private key.
+
+        Args:
+            message: Message bytes to sign
+
+        Returns:
+            Base64-encoded signature
+
+        Raises:
+            KeyNotFoundError: If no key exists
+        """
+        key_pair = self.get_key_pair()
+        if key_pair.private_key is None:
+            raise KeyNotFoundError("Private key not available")
+        return sign_message(message, key_pair.private_key)
+
+    def verify(self, message: bytes, signature: str, public_key: Optional[str] = None) -> bool:
+        """Verify a message signature.
+
+        Args:
+            message: Original message bytes
+            signature: Base64-encoded signature
+            public_key: Public key to verify with (default: this agent's key)
+
+        Returns:
+            True if valid
+
+        Raises:
+            SignatureError: If signature is invalid
+        """
+        if public_key is None:
+            public_key = self.get_public_key()
+        return verify_signature(message, signature, public_key)
+
+    def delete(self) -> bool:
+        """Delete the agent's key pair.
+
+        Returns:
+            True if deleted, False if not found
+        """
+        if not self.has_key():
+            return False
+
+        import shutil
+
+        shutil.rmtree(self._agent_key_dir)
+        logger.info(f"Deleted key pair for agent: {self.agent_id}")
+        return True
+
+    def _save_key_pair(self, key_pair: KeyPair) -> None:
+        """Save key pair to disk."""
+        self._agent_key_dir.mkdir(parents=True, exist_ok=True)
+
+        # Set restrictive permissions on private key
+        private_path = self._agent_key_dir / "private.key"
+        private_path.write_text(key_pair.private_key)
+        os.chmod(private_path, 0o600)
+
+        public_path = self._agent_key_dir / "public.key"
+        public_path.write_text(key_pair.public_key)
+
+        meta_path = self._agent_key_dir / "meta.json"
+        meta = {
+            "created_at": key_pair.created_at.isoformat() if key_pair.created_at else None,
+            "key_id": key_pair.key_id,
+            "agent_id": self.agent_id,
+        }
+        meta_path.write_text(json.dumps(meta, indent=2))
+
+    def _archive_key(self) -> None:
+        """Archive current key before rotation."""
+        if not self.has_key():
+            return
+
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+        archive_dir = self._agent_key_dir / "archive" / timestamp
+        archive_dir.mkdir(parents=True, exist_ok=True)
+
+        import shutil
+
+        for file in ["private.key", "public.key", "meta.json"]:
+            src = self._agent_key_dir / file
+            if src.exists():
+                shutil.copy2(src, archive_dir / file)

--- a/tests/comms/test_crypto.py
+++ b/tests/comms/test_crypto.py
@@ -1,0 +1,277 @@
+"""Tests for PKI/crypto module."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from kernle.comms.crypto import (
+    KeyAlreadyExistsError,
+    KeyManager,
+    KeyNotFoundError,
+    KeyPair,
+    SignatureError,
+    generate_key_pair,
+    sign_message,
+    verify_signature,
+)
+
+
+class TestKeyPairGeneration:
+    """Tests for key pair generation."""
+
+    def test_generate_key_pair_returns_valid_keypair(self):
+        """Test that generate_key_pair returns a valid KeyPair."""
+        key_pair = generate_key_pair()
+
+        assert key_pair.public_key is not None
+        assert key_pair.private_key is not None
+        assert key_pair.created_at is not None
+        assert key_pair.key_id is not None
+
+    def test_generate_key_pair_keys_are_base64(self):
+        """Test that keys are valid base64."""
+        import base64
+
+        key_pair = generate_key_pair()
+
+        # Should not raise on decode
+        public_bytes = base64.b64decode(key_pair.public_key)
+        private_bytes = base64.b64decode(key_pair.private_key)
+
+        # Ed25519 keys are 32 bytes
+        assert len(public_bytes) == 32
+        assert len(private_bytes) == 32
+
+    def test_generate_key_pair_unique_keys(self):
+        """Test that each generation produces unique keys."""
+        key1 = generate_key_pair()
+        key2 = generate_key_pair()
+
+        assert key1.public_key != key2.public_key
+        assert key1.private_key != key2.private_key
+        assert key1.key_id != key2.key_id
+
+    def test_key_id_is_hex_string(self):
+        """Test that key_id is a valid hex string."""
+        key_pair = generate_key_pair()
+
+        assert len(key_pair.key_id) == 8
+        # Should be valid hex
+        int(key_pair.key_id, 16)
+
+
+class TestSigningAndVerification:
+    """Tests for message signing and verification."""
+
+    def test_sign_and_verify_roundtrip(self):
+        """Test that a signed message can be verified."""
+        key_pair = generate_key_pair()
+        message = b"Hello, World!"
+
+        signature = sign_message(message, key_pair.private_key)
+        result = verify_signature(message, signature, key_pair.public_key)
+
+        assert result is True
+
+    def test_verify_fails_with_wrong_message(self):
+        """Test that verification fails if message is tampered."""
+        key_pair = generate_key_pair()
+        message = b"Original message"
+        tampered = b"Tampered message"
+
+        signature = sign_message(message, key_pair.private_key)
+
+        with pytest.raises(SignatureError):
+            verify_signature(tampered, signature, key_pair.public_key)
+
+    def test_verify_fails_with_wrong_key(self):
+        """Test that verification fails with wrong public key."""
+        key1 = generate_key_pair()
+        key2 = generate_key_pair()
+        message = b"Test message"
+
+        signature = sign_message(message, key1.private_key)
+
+        with pytest.raises(SignatureError):
+            verify_signature(message, signature, key2.public_key)
+
+    def test_sign_different_messages_different_signatures(self):
+        """Test that different messages produce different signatures."""
+        key_pair = generate_key_pair()
+
+        sig1 = sign_message(b"Message 1", key_pair.private_key)
+        sig2 = sign_message(b"Message 2", key_pair.private_key)
+
+        assert sig1 != sig2
+
+    def test_sign_same_message_same_signature(self):
+        """Test that signing same message produces same signature (deterministic)."""
+        key_pair = generate_key_pair()
+        message = b"Deterministic test"
+
+        sig1 = sign_message(message, key_pair.private_key)
+        sig2 = sign_message(message, key_pair.private_key)
+
+        # Ed25519 is deterministic
+        assert sig1 == sig2
+
+
+class TestKeyManager:
+    """Tests for KeyManager class."""
+
+    @pytest.fixture
+    def temp_key_dir(self):
+        """Create a temporary key directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir)
+
+    @pytest.fixture
+    def key_manager(self, temp_key_dir):
+        """Create a KeyManager with temp directory."""
+        return KeyManager(agent_id="test-agent", key_dir=temp_key_dir)
+
+    def test_has_key_returns_false_initially(self, key_manager):
+        """Test that has_key returns False before generation."""
+        assert key_manager.has_key() is False
+
+    def test_generate_creates_key(self, key_manager):
+        """Test that generate creates a new key pair."""
+        key_pair = key_manager.generate()
+
+        assert key_pair.public_key is not None
+        assert key_pair.private_key is not None
+        assert key_manager.has_key() is True
+
+    def test_generate_raises_if_exists(self, key_manager):
+        """Test that generate raises if key already exists."""
+        key_manager.generate()
+
+        with pytest.raises(KeyAlreadyExistsError):
+            key_manager.generate()
+
+    def test_generate_with_force_overwrites(self, key_manager):
+        """Test that generate with force=True overwrites existing key."""
+        original = key_manager.generate()
+        new_key = key_manager.generate(force=True)
+
+        assert new_key.public_key != original.public_key
+
+    def test_get_key_pair_returns_stored_key(self, key_manager):
+        """Test that get_key_pair returns the stored key."""
+        original = key_manager.generate()
+        retrieved = key_manager.get_key_pair()
+
+        assert retrieved.public_key == original.public_key
+        assert retrieved.private_key == original.private_key
+
+    def test_get_key_pair_raises_if_not_found(self, key_manager):
+        """Test that get_key_pair raises if no key exists."""
+        with pytest.raises(KeyNotFoundError):
+            key_manager.get_key_pair()
+
+    def test_get_public_key_returns_only_public(self, key_manager):
+        """Test that get_public_key returns just the public key."""
+        key_manager.generate()
+        public_key = key_manager.get_public_key()
+
+        assert public_key is not None
+        assert isinstance(public_key, str)
+
+    def test_rotate_creates_new_key(self, key_manager):
+        """Test that rotate creates a new key pair."""
+        original = key_manager.generate()
+        new_key, old_key = key_manager.rotate()
+
+        assert new_key.public_key != original.public_key
+        assert old_key.public_key == original.public_key
+
+    def test_rotate_archives_old_key(self, key_manager, temp_key_dir):
+        """Test that rotate archives the old key."""
+        key_manager.generate()
+        key_manager.rotate()
+
+        archive_dir = temp_key_dir / "test-agent" / "archive"
+        assert archive_dir.exists()
+        assert len(list(archive_dir.iterdir())) == 1
+
+    def test_sign_with_manager(self, key_manager):
+        """Test signing through KeyManager."""
+        key_manager.generate()
+        message = b"Test message"
+
+        signature = key_manager.sign(message)
+
+        assert signature is not None
+        assert len(signature) > 0
+
+    def test_verify_with_manager(self, key_manager):
+        """Test verification through KeyManager."""
+        key_manager.generate()
+        message = b"Test message"
+        signature = key_manager.sign(message)
+
+        result = key_manager.verify(message, signature)
+
+        assert result is True
+
+    def test_delete_removes_key(self, key_manager):
+        """Test that delete removes the key."""
+        key_manager.generate()
+        assert key_manager.has_key() is True
+
+        result = key_manager.delete()
+
+        assert result is True
+        assert key_manager.has_key() is False
+
+    def test_delete_returns_false_if_not_found(self, key_manager):
+        """Test that delete returns False if no key exists."""
+        result = key_manager.delete()
+        assert result is False
+
+
+class TestKeyPairDataclass:
+    """Tests for KeyPair dataclass."""
+
+    def test_public_key_bytes_property(self):
+        """Test public_key_bytes property."""
+        key_pair = generate_key_pair()
+        public_bytes = key_pair.public_key_bytes
+
+        assert isinstance(public_bytes, bytes)
+        assert len(public_bytes) == 32
+
+    def test_private_key_bytes_property(self):
+        """Test private_key_bytes property."""
+        key_pair = generate_key_pair()
+        private_bytes = key_pair.private_key_bytes
+
+        assert isinstance(private_bytes, bytes)
+        assert len(private_bytes) == 32
+
+    def test_private_key_bytes_returns_none_if_missing(self):
+        """Test that private_key_bytes returns None if private key not set."""
+        key_pair = KeyPair(public_key="dGVzdA==", private_key=None)
+        assert key_pair.private_key_bytes is None
+
+
+class TestFilePermissions:
+    """Tests for secure file permissions."""
+
+    def test_private_key_has_restricted_permissions(self):
+        """Test that private key file has 600 permissions."""
+        import stat
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            key_dir = Path(tmpdir)
+            manager = KeyManager(agent_id="perm-test", key_dir=key_dir)
+            manager.generate()
+
+            private_path = key_dir / "perm-test" / "private.key"
+            mode = private_path.stat().st_mode
+
+            # Check that only owner has read/write
+            assert mode & stat.S_IRWXU == stat.S_IRUSR | stat.S_IWUSR
+            assert mode & stat.S_IRWXG == 0
+            assert mode & stat.S_IRWXO == 0


### PR DESCRIPTION
## Summary
Implements Ed25519 public key infrastructure for agent identity and message signing.

## Changes

### Core
- `kernle/comms/crypto.py` - Key pair generation, signing, verification
- `KeyManager` class for secure key storage and rotation

### Security
- Private keys stored with 600 permissions
- Key rotation archives old keys
- Keys stored in `~/.kernle/keys/{agent_id}/`

### CLI
- `kernle keys generate` - Generate new key pair
- `kernle keys show` - Display key info (public key, key ID)
- `kernle keys rotate` - Rotate to new key pair (archives old)
- `kernle keys export` - Export public key for sharing
- `kernle keys delete` - Delete key pair

### Tests
- 26 unit tests covering:
  - Key generation
  - Signing and verification
  - KeyManager CRUD operations
  - Key rotation and archival
  - File permissions

## Key Format
- Ed25519 keys (32 bytes)
- Base64 encoded for storage/transport
- 8-character key ID (SHA256 prefix)

Resolves #145
Part of v0.3.0 comms package