### PR TITLE
feat: advanced consolidation scaffolds (#178)

### DIFF
--- a/kernle/cli/__main__.py
+++ b/kernle/cli/__main__.py
@@ -3121,6 +3121,11 @@ def main():
         default=20,
         help="Number of recent episodes to include (default: 20)",
     )
+    p_consolidate.add_argument(
+        "--advanced",
+        action="store_true",
+        help="Run advanced consolidation scaffolds (cross-domain, belief->value, entity model->belief)",
+    )
 
     # temporal
     p_temporal = subparsers.add_parser("when", help="Query by time")

--- a/kernle/cli/commands/identity.py
+++ b/kernle/cli/commands/identity.py
@@ -160,6 +160,13 @@ def cmd_consolidate(args, k: "Kernle"):
     reflection and pattern identification. The AGENT does the
     reasoning - Kernle just provides the data and structure.
     """
+    # Advanced consolidation mode
+    if getattr(args, "advanced", False):
+        limit = getattr(args, "limit", 100) or 100
+        result = k.scaffold_advanced_consolidation(episode_limit=limit)
+        print(result["scaffold"])
+        return
+
     # Get episode limit from args (default 20)
     limit = getattr(args, "limit", 20) or 20
 

--- a/kernle/core.py
+++ b/kernle/core.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 # Import feature mixins
 from kernle.features import (
     AnxietyMixin,
+    ConsolidationMixin,
     EmotionsMixin,
     ForgettingMixin,
     KnowledgeMixin,
@@ -320,6 +321,7 @@ def compute_priority_score(memory_type: str, record: Any) -> float:
 
 class Kernle(
     AnxietyMixin,
+    ConsolidationMixin,
     EmotionsMixin,
     ForgettingMixin,
     KnowledgeMixin,

--- a/kernle/features/__init__.py
+++ b/kernle/features/__init__.py
@@ -5,6 +5,7 @@ functionality to the main Kernle class.
 """
 
 from kernle.features.anxiety import AnxietyMixin
+from kernle.features.consolidation import ConsolidationMixin
 from kernle.features.emotions import EmotionsMixin
 from kernle.features.forgetting import ForgettingMixin
 from kernle.features.knowledge import KnowledgeMixin
@@ -20,6 +21,7 @@ from kernle.features.suggestions import SuggestionsMixin
 
 __all__ = [
     "AnxietyMixin",
+    "ConsolidationMixin",
     "DecayConfig",
     "DEFAULT_DECAY_CONFIGS",
     "DEFAULT_DECAY_FLOOR",

--- a/kernle/features/consolidation.py
+++ b/kernle/features/consolidation.py
@@ -1,0 +1,724 @@
+"""Advanced consolidation scaffolds for Kernle.
+
+This module provides three interconnected scaffold enhancements for deeper
+pattern recognition during memory consolidation:
+
+1. Cross-domain pattern scaffolding: Groups episodes by domain tags and
+   detects structural similarities in outcomes across domains.
+
+2. Belief-to-value promotion: Identifies beliefs that have reached
+   value-level stability (long-lived, reinforced, multi-domain) and
+   suggests promotion.
+
+3. Entity model-to-belief promotion: Detects when multiple entity models
+   point toward the same generalization and suggests belief formation.
+
+All scaffolds follow the SI autonomy principle: they surface patterns and
+suggestions, but the agent decides what to do with them.
+"""
+
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, Dict, List
+
+if TYPE_CHECKING:
+    from kernle.core import Kernle
+
+
+# Thresholds for belief-to-value promotion
+BELIEF_VALUE_MIN_AGE_DAYS = 180  # 6 months
+BELIEF_VALUE_MIN_REINFORCEMENTS = 3
+BELIEF_VALUE_MIN_DOMAINS = 3
+BELIEF_VALUE_MIN_CONFIDENCE = 0.8
+
+# Thresholds for cross-domain pattern detection
+CROSS_DOMAIN_MIN_EPISODES = 2
+CROSS_DOMAIN_MIN_DOMAINS = 2
+
+# Thresholds for entity model-to-belief promotion
+ENTITY_MODEL_MIN_ENTITIES = 2
+ENTITY_MODEL_MIN_EPISODES = 2
+
+
+class ConsolidationMixin:
+    """Mixin providing advanced consolidation scaffold capabilities."""
+
+    def scaffold_cross_domain_patterns(
+        self: "Kernle",
+        limit: int = 100,
+    ) -> Dict[str, Any]:
+        """Detect structural similarities in outcomes across different domains.
+
+        Groups episodes by their tags (used as domain proxies), then identifies
+        outcome patterns that repeat across multiple domains.
+
+        Args:
+            limit: Maximum episodes to analyze
+
+        Returns:
+            Dict with:
+            - episodes_scanned: number of episodes analyzed
+            - domains_found: number of distinct tag domains
+            - patterns: list of cross-domain pattern dicts
+            - scaffold: formatted text scaffold for reflection
+        """
+        episodes = self._storage.get_episodes(limit=limit)
+        episodes = [ep for ep in episodes if not ep.is_forgotten]
+
+        if not episodes:
+            return {
+                "episodes_scanned": 0,
+                "domains_found": 0,
+                "patterns": [],
+                "scaffold": "No episodes available for cross-domain analysis.",
+            }
+
+        # Group episodes by tag (each tag is treated as a domain)
+        domain_episodes: Dict[str, List] = defaultdict(list)
+        for ep in episodes:
+            tags = ep.tags or []
+            # Also include context_tags as domain indicators
+            ctx_tags = getattr(ep, "context_tags", None) or []
+            all_tags = set(tags + ctx_tags)
+            if not all_tags:
+                all_tags = {"untagged"}
+            for tag in all_tags:
+                domain_episodes[tag].append(ep)
+
+        # For each domain, build outcome-to-lesson mappings
+        # Structure: {domain: {outcome_type: [lessons]}}
+        domain_outcome_lessons: Dict[str, Dict[str, List[str]]] = {}
+        for domain, eps in domain_episodes.items():
+            outcome_map: Dict[str, List[str]] = defaultdict(list)
+            for ep in eps:
+                otype = ep.outcome_type or "unknown"
+                if ep.lessons:
+                    for lesson in ep.lessons:
+                        outcome_map[otype].append(lesson.strip().lower())
+                else:
+                    # Even without explicit lessons, track the pattern
+                    summary = ep.objective[:80].strip().lower()
+                    outcome_map[otype].append(f"[{summary}]")
+            domain_outcome_lessons[domain] = dict(outcome_map)
+
+        # Detect cross-domain patterns:
+        # A pattern is "something that leads to the same outcome in 2+ domains"
+        # We look for similar lessons/objectives across domains with same outcome
+        patterns = []
+
+        # Build a normalized lesson -> (domain, outcome, episode_ids) index
+        lesson_domain_map: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+        for domain, eps in domain_episodes.items():
+            for ep in eps:
+                otype = ep.outcome_type or "unknown"
+                if ep.lessons:
+                    for lesson in ep.lessons:
+                        normalized = lesson.strip().lower()
+                        lesson_domain_map[normalized].append(
+                            {
+                                "domain": domain,
+                                "outcome": otype,
+                                "episode_id": ep.id,
+                                "objective": ep.objective,
+                            }
+                        )
+
+        # Find lessons that appear in 2+ domains with the same outcome
+        for lesson, occurrences in lesson_domain_map.items():
+            domains_by_outcome: Dict[str, set] = defaultdict(set)
+            episodes_by_outcome: Dict[str, List[str]] = defaultdict(list)
+            for occ in occurrences:
+                domains_by_outcome[occ["outcome"]].add(occ["domain"])
+                episodes_by_outcome[occ["outcome"]].append(occ["episode_id"])
+
+            for outcome, domains in domains_by_outcome.items():
+                if len(domains) >= CROSS_DOMAIN_MIN_DOMAINS:
+                    patterns.append(
+                        {
+                            "lesson": lesson,
+                            "outcome": outcome,
+                            "domains": sorted(domains),
+                            "episode_count": len(episodes_by_outcome[outcome]),
+                            "episode_ids": episodes_by_outcome[outcome][:10],
+                        }
+                    )
+
+        # Also detect outcome-type patterns per domain (shortcutting -> failure)
+        # Look for domains where a particular outcome type dominates
+        outcome_patterns = []
+        for domain, eps in domain_episodes.items():
+            if len(eps) < CROSS_DOMAIN_MIN_EPISODES:
+                continue
+            outcome_counts: Dict[str, int] = defaultdict(int)
+            for ep in eps:
+                outcome_counts[ep.outcome_type or "unknown"] += 1
+
+            total = len(eps)
+            for otype, count in outcome_counts.items():
+                ratio = count / total
+                if ratio >= 0.6 and count >= CROSS_DOMAIN_MIN_EPISODES:
+                    outcome_patterns.append(
+                        {
+                            "domain": domain,
+                            "outcome": otype,
+                            "count": count,
+                            "total": total,
+                            "ratio": round(ratio, 2),
+                        }
+                    )
+
+        # Sort patterns by episode count (most evidence first)
+        patterns.sort(key=lambda p: -p["episode_count"])
+        patterns = patterns[:10]  # Cap output
+
+        # Build scaffold text
+        scaffold = self._format_cross_domain_scaffold(
+            episodes, domain_episodes, patterns, outcome_patterns
+        )
+
+        return {
+            "episodes_scanned": len(episodes),
+            "domains_found": len(domain_episodes),
+            "patterns": patterns,
+            "outcome_patterns": outcome_patterns[:10],
+            "scaffold": scaffold,
+        }
+
+    def _format_cross_domain_scaffold(
+        self: "Kernle",
+        episodes: list,
+        domain_episodes: Dict[str, list],
+        patterns: List[Dict],
+        outcome_patterns: List[Dict],
+    ) -> str:
+        """Format cross-domain analysis into a reflection scaffold."""
+        lines = []
+        lines.append("## Cross-Domain Pattern Analysis")
+        lines.append("")
+        lines.append(
+            f"Analyzed {len(episodes)} episodes across " f"{len(domain_episodes)} domains."
+        )
+        lines.append("")
+
+        # Show domain summaries
+        if domain_episodes:
+            lines.append("### Domains:")
+            for domain, eps in sorted(domain_episodes.items(), key=lambda x: -len(x[1]))[:10]:
+                outcomes = defaultdict(int)
+                for ep in eps:
+                    outcomes[ep.outcome_type or "unknown"] += 1
+                outcome_str = ", ".join(f"{k}: {v}" for k, v in sorted(outcomes.items()))
+                lines.append(f"- **{domain}** ({len(eps)} episodes): {outcome_str}")
+            lines.append("")
+
+        # Show cross-domain patterns
+        if patterns:
+            lines.append("### Cross-Domain Patterns:")
+            lines.append("")
+            for p in patterns:
+                domains_str = ", ".join(p["domains"])
+                lines.append(
+                    f'- "{p["lesson"]}" -> {p["outcome"]} '
+                    f"(in {domains_str}, {p['episode_count']} episodes)"
+                )
+            lines.append("")
+            lines.append(
+                "**Reflection prompt:** Are these general patterns? " "Could they become beliefs?"
+            )
+            lines.append("")
+
+        # Show outcome type patterns
+        if outcome_patterns:
+            lines.append("### Domain Outcome Tendencies:")
+            lines.append("")
+            for op in outcome_patterns:
+                lines.append(
+                    f"- **{op['domain']}**: {op['outcome']} in "
+                    f"{op['count']}/{op['total']} episodes "
+                    f"({op['ratio']:.0%})"
+                )
+            lines.append("")
+
+        if not patterns and not outcome_patterns:
+            lines.append(
+                "No cross-domain patterns detected yet. "
+                "More tagged episodes may reveal structural similarities."
+            )
+            lines.append("")
+
+        return "\n".join(lines)
+
+    def scaffold_belief_to_value(
+        self: "Kernle",
+        min_age_days: int = BELIEF_VALUE_MIN_AGE_DAYS,
+        min_reinforcements: int = BELIEF_VALUE_MIN_REINFORCEMENTS,
+        min_domains: int = BELIEF_VALUE_MIN_DOMAINS,
+        min_confidence: float = BELIEF_VALUE_MIN_CONFIDENCE,
+    ) -> Dict[str, Any]:
+        """Identify beliefs that may have reached value-level stability.
+
+        A belief is a candidate for value promotion when:
+        - Active for >min_age_days (default 180 / 6 months)
+        - Reinforced at least min_reinforcements times
+        - Never contradicted (not superseded)
+        - Appears across min_domains+ domains
+        - Confidence >= min_confidence
+
+        Args:
+            min_age_days: Minimum age in days
+            min_reinforcements: Minimum reinforcement count
+            min_domains: Minimum domain count
+            min_confidence: Minimum confidence threshold
+
+        Returns:
+            Dict with:
+            - beliefs_scanned: number of beliefs analyzed
+            - candidates: list of promotion candidate dicts
+            - scaffold: formatted text scaffold for reflection
+        """
+        beliefs = self._storage.get_beliefs(limit=500, include_inactive=False)
+        beliefs = [b for b in beliefs if b.is_active and not b.is_forgotten]
+
+        # Also get existing values for dedup checking
+        values = self._storage.get_values(limit=200)
+        value_statements = {v.statement.strip().lower() for v in values}
+
+        now = datetime.now(timezone.utc)
+        candidates = []
+
+        for belief in beliefs:
+            # Check age
+            created = belief.created_at
+            if not created:
+                continue
+            # Ensure timezone-aware comparison
+            if created.tzinfo is None:
+                created = created.replace(tzinfo=timezone.utc)
+            age_days = (now - created).days
+            if age_days < min_age_days:
+                continue
+
+            # Check reinforcements
+            if belief.times_reinforced < min_reinforcements:
+                continue
+
+            # Check not contradicted (superseded_by means it was replaced)
+            if belief.superseded_by:
+                continue
+
+            # Check confidence
+            if belief.confidence < min_confidence:
+                continue
+
+            # Check domain spread
+            domains = set()
+            if belief.source_domain:
+                domains.add(belief.source_domain)
+            if belief.cross_domain_applications:
+                domains.update(belief.cross_domain_applications)
+            if len(domains) < min_domains:
+                continue
+
+            # Check not already a value
+            if belief.statement.strip().lower() in value_statements:
+                continue
+
+            candidates.append(
+                {
+                    "belief_id": belief.id,
+                    "statement": belief.statement,
+                    "confidence": belief.confidence,
+                    "age_days": age_days,
+                    "times_reinforced": belief.times_reinforced,
+                    "domains": sorted(domains),
+                    "belief_type": belief.belief_type,
+                    "source_domain": belief.source_domain,
+                    "abstraction_level": getattr(belief, "abstraction_level", "specific"),
+                }
+            )
+
+        # Sort by reinforcement count (most stable first)
+        candidates.sort(key=lambda c: -c["times_reinforced"])
+        candidates = candidates[:10]  # Cap output
+
+        scaffold = self._format_belief_to_value_scaffold(len(beliefs), candidates)
+
+        return {
+            "beliefs_scanned": len(beliefs),
+            "candidates": candidates,
+            "scaffold": scaffold,
+        }
+
+    def _format_belief_to_value_scaffold(
+        self: "Kernle",
+        beliefs_scanned: int,
+        candidates: List[Dict],
+    ) -> str:
+        """Format belief-to-value analysis into a reflection scaffold."""
+        lines = []
+        lines.append("## Belief-to-Value Promotion Analysis")
+        lines.append("")
+        lines.append(f"Scanned {beliefs_scanned} active beliefs for value-level stability.")
+        lines.append("")
+
+        if candidates:
+            lines.append(f"### {len(candidates)} Promotion Candidate(s):")
+            lines.append("")
+            for i, c in enumerate(candidates, 1):
+                lines.append(f'**{i}. "{c["statement"]}"**')
+                lines.append(
+                    f"   - Active for {c['age_days']} days, "
+                    f"reinforced {c['times_reinforced']} times, "
+                    f"never contradicted"
+                )
+                lines.append(f"   - Appears across: {', '.join(c['domains'])}")
+                lines.append(
+                    f"   - Confidence: {c['confidence']:.0%}, "
+                    f"type: {c['belief_type']}, "
+                    f"abstraction: {c['abstraction_level']}"
+                )
+                lines.append("")
+                lines.append("   This belief may have reached value-level stability.")
+                lines.append(
+                    '   Consider: `kernle value "<name>" ' f'"{c["statement"]}" --priority 80`'
+                )
+                lines.append("")
+        else:
+            lines.append("No beliefs currently meet value-promotion criteria.")
+            lines.append("")
+            lines.append(
+                "Criteria: active >6 months, reinforced 3+ times, "
+                "never contradicted, 3+ domains, confidence >= 80%."
+            )
+            lines.append("")
+
+        return "\n".join(lines)
+
+    def scaffold_entity_model_to_belief(
+        self: "Kernle",
+        min_entities: int = ENTITY_MODEL_MIN_ENTITIES,
+        min_supporting_episodes: int = ENTITY_MODEL_MIN_EPISODES,
+    ) -> Dict[str, Any]:
+        """Detect when multiple entity models suggest a common generalization.
+
+        Groups entity models by observation theme and identifies cases where
+        similar observations about different entities could form a general belief.
+
+        Args:
+            min_entities: Minimum distinct entities with similar observations
+            min_supporting_episodes: Minimum total supporting episodes
+
+        Returns:
+            Dict with:
+            - models_scanned: number of entity models analyzed
+            - generalizations: list of potential generalization dicts
+            - scaffold: formatted text scaffold for reflection
+        """
+        models = self._storage.get_entity_models(limit=200)
+        if not models:
+            return {
+                "models_scanned": 0,
+                "generalizations": [],
+                "scaffold": "No entity models available for analysis.",
+            }
+
+        # Group models by model_type and look for similar observations
+        # We use a simple word-overlap approach for similarity
+        type_groups: Dict[str, list] = defaultdict(list)
+        for model in models:
+            type_groups[model.model_type].append(model)
+
+        generalizations = []
+
+        for model_type, group_models in type_groups.items():
+            if len(group_models) < min_entities:
+                continue
+
+            # Find clusters of similar observations using keyword overlap
+            clusters = self._cluster_observations(group_models)
+
+            for cluster in clusters:
+                entities = {m.entity_name for m in cluster}
+                if len(entities) < min_entities:
+                    continue
+
+                # Count total supporting episodes
+                total_episodes = 0
+                all_episode_ids = []
+                for m in cluster:
+                    eps = m.source_episodes or []
+                    total_episodes += len(eps)
+                    all_episode_ids.extend(eps)
+
+                if total_episodes < min_supporting_episodes:
+                    continue
+
+                # Compute average confidence
+                avg_conf = sum(m.confidence for m in cluster) / len(cluster)
+
+                # Generate a generalization suggestion
+                observations = [
+                    {
+                        "entity": m.entity_name,
+                        "observation": m.observation,
+                        "confidence": m.confidence,
+                        "model_id": m.id,
+                    }
+                    for m in cluster
+                ]
+
+                generalizations.append(
+                    {
+                        "model_type": model_type,
+                        "entities": sorted(entities),
+                        "entity_count": len(entities),
+                        "observations": observations[:10],
+                        "total_episodes": total_episodes,
+                        "episode_ids": all_episode_ids[:10],
+                        "average_confidence": round(avg_conf, 2),
+                        "model_ids": [m.id for m in cluster],
+                    }
+                )
+
+        # Sort by entity count (broadest patterns first)
+        generalizations.sort(key=lambda g: -g["entity_count"])
+        generalizations = generalizations[:10]
+
+        scaffold = self._format_entity_model_scaffold(len(models), generalizations)
+
+        return {
+            "models_scanned": len(models),
+            "generalizations": generalizations,
+            "scaffold": scaffold,
+        }
+
+    def _cluster_observations(
+        self: "Kernle",
+        models: list,
+    ) -> List[list]:
+        """Cluster entity models by observation similarity.
+
+        Uses keyword overlap to find groups of models with similar
+        observations. This is a simple heuristic approach that avoids
+        requiring LLM calls.
+
+        Args:
+            models: List of EntityModel objects
+
+        Returns:
+            List of clusters (each cluster is a list of EntityModel)
+        """
+        if not models:
+            return []
+
+        # Extract keywords from each observation
+        stop_words = {
+            "a",
+            "an",
+            "the",
+            "is",
+            "are",
+            "was",
+            "were",
+            "be",
+            "been",
+            "being",
+            "have",
+            "has",
+            "had",
+            "do",
+            "does",
+            "did",
+            "will",
+            "would",
+            "could",
+            "should",
+            "may",
+            "might",
+            "can",
+            "shall",
+            "to",
+            "of",
+            "in",
+            "for",
+            "on",
+            "with",
+            "at",
+            "by",
+            "from",
+            "as",
+            "into",
+            "through",
+            "during",
+            "before",
+            "after",
+            "about",
+            "between",
+            "under",
+            "above",
+            "up",
+            "down",
+            "out",
+            "off",
+            "over",
+            "and",
+            "but",
+            "or",
+            "nor",
+            "not",
+            "no",
+            "so",
+            "if",
+            "then",
+            "than",
+            "too",
+            "very",
+            "just",
+            "that",
+            "this",
+            "it",
+            "its",
+            "they",
+            "them",
+            "their",
+            "he",
+            "she",
+            "his",
+            "her",
+            "we",
+            "i",
+        }
+
+        def extract_keywords(text: str) -> set:
+            words = set(text.lower().split())
+            # Remove punctuation from words
+            cleaned = set()
+            for w in words:
+                clean = "".join(c for c in w if c.isalnum())
+                if clean and len(clean) > 2 and clean not in stop_words:
+                    cleaned.add(clean)
+            return cleaned
+
+        model_keywords = [(m, extract_keywords(m.observation)) for m in models]
+
+        # Simple greedy clustering: two models cluster if they share
+        # at least 2 meaningful keywords
+        min_shared = 2
+        clusters: List[list] = []
+        assigned = set()
+
+        for i, (model_i, kw_i) in enumerate(model_keywords):
+            if i in assigned:
+                continue
+
+            cluster = [model_i]
+            assigned.add(i)
+
+            for j, (model_j, kw_j) in enumerate(model_keywords):
+                if j in assigned or j <= i:
+                    continue
+                shared = kw_i & kw_j
+                if len(shared) >= min_shared:
+                    cluster.append(model_j)
+                    assigned.add(j)
+
+            if len(cluster) >= 2:
+                clusters.append(cluster)
+
+        return clusters
+
+    def _format_entity_model_scaffold(
+        self: "Kernle",
+        models_scanned: int,
+        generalizations: List[Dict],
+    ) -> str:
+        """Format entity model analysis into a reflection scaffold."""
+        lines = []
+        lines.append("## Entity Model-to-Belief Analysis")
+        lines.append("")
+        lines.append(f"Scanned {models_scanned} entity models for generalizable patterns.")
+        lines.append("")
+
+        if generalizations:
+            lines.append(f"### {len(generalizations)} Possible Generalization(s):")
+            lines.append("")
+            for i, g in enumerate(generalizations, 1):
+                lines.append(
+                    f"**{i}. Across {g['entity_count']} entities " f"({g['model_type']}):**"
+                )
+                lines.append("   Observations:")
+                for obs in g["observations"][:5]:
+                    lines.append(
+                        f'   - {obs["entity"]}: "{obs["observation"]}" '
+                        f'(confidence: {obs["confidence"]:.0%})'
+                    )
+                lines.append("")
+                lines.append(
+                    f"   Supported by {g['total_episodes']} episode(s), "
+                    f"average confidence: {g['average_confidence']:.0%}"
+                )
+                lines.append("")
+
+                # Build derived-from suggestion
+                model_refs = " ".join(f"entity_model:{mid}" for mid in g["model_ids"][:5])
+                lines.append(
+                    f'   Consider: `kernle belief "<generalization>" '
+                    f"--derived-from {model_refs}`"
+                )
+                lines.append("")
+        else:
+            lines.append("No generalizable patterns detected across entity models.")
+            lines.append("")
+            lines.append(
+                "More entity model observations about different entities "
+                "may reveal shared patterns."
+            )
+            lines.append("")
+
+        return "\n".join(lines)
+
+    def scaffold_advanced_consolidation(
+        self: "Kernle",
+        episode_limit: int = 100,
+    ) -> Dict[str, Any]:
+        """Run all three advanced consolidation scaffolds and combine results.
+
+        This is the main entry point that produces a comprehensive
+        consolidation scaffold covering cross-domain patterns,
+        belief-to-value promotion, and entity model-to-belief promotion.
+
+        Args:
+            episode_limit: Maximum episodes to analyze for cross-domain
+
+        Returns:
+            Dict with combined results from all three scaffolds
+        """
+        cross_domain = self.scaffold_cross_domain_patterns(limit=episode_limit)
+        belief_to_value = self.scaffold_belief_to_value()
+        entity_to_belief = self.scaffold_entity_model_to_belief()
+
+        # Combine scaffolds
+        combined_scaffold = []
+        combined_scaffold.append("# Advanced Consolidation Scaffold")
+        combined_scaffold.append("")
+        combined_scaffold.append(
+            "Kernle has analyzed your memories for deeper patterns. "
+            "Review the scaffolds below and decide what to act on."
+        )
+        combined_scaffold.append("")
+        combined_scaffold.append("---")
+        combined_scaffold.append("")
+        combined_scaffold.append(cross_domain["scaffold"])
+        combined_scaffold.append("---")
+        combined_scaffold.append("")
+        combined_scaffold.append(belief_to_value["scaffold"])
+        combined_scaffold.append("---")
+        combined_scaffold.append("")
+        combined_scaffold.append(entity_to_belief["scaffold"])
+
+        return {
+            "cross_domain": cross_domain,
+            "belief_to_value": belief_to_value,
+            "entity_to_belief": entity_to_belief,
+            "scaffold": "\n".join(combined_scaffold),
+        }

--- a/kernle/mcp/server.py
+++ b/kernle/mcp/server.py
@@ -262,6 +262,11 @@ def validate_tool_input(name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
                 validate_number(arguments.get("min_episodes"), "min_episodes", 1, 100, 3)
             )
 
+        elif name == "memory_consolidate_advanced":
+            sanitized["episode_limit"] = int(
+                validate_number(arguments.get("episode_limit"), "episode_limit", 1, 500, 100)
+            )
+
         elif name == "memory_status":
             # No parameters to validate
             pass
@@ -810,6 +815,20 @@ TOOLS = [
                     "type": "integer",
                     "description": "Minimum episodes required for full consolidation (default: 3)",
                     "default": 3,
+                },
+            },
+        },
+    ),
+    Tool(
+        name="memory_consolidate_advanced",
+        description="Get an advanced consolidation scaffold with cross-domain pattern analysis, belief-to-value promotion candidates, and entity model-to-belief generalizations. Surfaces deeper patterns across your memories for reflection. Kernle provides the analysis; you decide what to act on.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "episode_limit": {
+                    "type": "integer",
+                    "description": "Maximum episodes to analyze for cross-domain patterns (default: 100)",
+                    "default": 100,
                 },
             },
         },
@@ -1421,6 +1440,11 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
             lines.append(f"Episodes reviewed: {len(episodes)} | Beliefs on file: {len(beliefs)}")
 
             result = "\n".join(lines)
+
+        elif name == "memory_consolidate_advanced":
+            episode_limit = sanitized_args.get("episode_limit", 100)
+            advanced = k.scaffold_advanced_consolidation(episode_limit=episode_limit)
+            result = advanced["scaffold"]
 
         elif name == "memory_status":
             status = k.status()

--- a/kernle/storage/sqlite.py
+++ b/kernle/storage/sqlite.py
@@ -2155,7 +2155,7 @@ class SQLiteStorage:
                  source_entity, subject_ids, access_grants, consent_grants,
                  epoch_id,
                  created_at, local_updated_at, cloud_synced_at, version, deleted)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
                 (
                     episode.id,
@@ -2187,6 +2187,7 @@ class SQLiteStorage:
                     self._to_json(getattr(episode, "subject_ids", None)),
                     self._to_json(getattr(episode, "access_grants", None)),
                     self._to_json(getattr(episode, "consent_grants", None)),
+                    getattr(episode, "epoch_id", None),
                     episode.created_at.isoformat() if episode.created_at else now,
                     now,
                     episode.cloud_synced_at.isoformat() if episode.cloud_synced_at else None,

--- a/tests/test_consolidation_scaffolds.py
+++ b/tests/test_consolidation_scaffolds.py
@@ -1,0 +1,574 @@
+"""Tests for advanced consolidation scaffolds (KEP v3, Issue #178).
+
+Tests cover:
+- Cross-domain pattern detection
+- Belief-to-value promotion analysis
+- Entity model-to-belief generalization
+- Combined scaffold output
+"""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from kernle.core import Kernle
+from kernle.storage.base import Belief, EntityModel, Episode
+from kernle.storage.sqlite import SQLiteStorage
+
+
+@pytest.fixture
+def storage(tmp_path):
+    """SQLite storage for consolidation scaffold tests."""
+    db_path = tmp_path / "test_consolidation.db"
+    s = SQLiteStorage(agent_id="test_agent", db_path=db_path)
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def kernle_instance(storage):
+    """Kernle instance with test storage."""
+    k = Kernle(agent_id="test_agent", storage=storage)
+    return k
+
+
+def _make_episode(
+    tags=None, outcome_type="success", lessons=None, objective="Test task", **kwargs
+) -> Episode:
+    defaults = {
+        "id": str(uuid.uuid4()),
+        "agent_id": "test_agent",
+        "objective": objective,
+        "outcome": f"Outcome for {objective}",
+        "outcome_type": outcome_type,
+        "tags": tags,
+        "lessons": lessons,
+        "created_at": datetime.now(timezone.utc),
+    }
+    defaults.update(kwargs)
+    return Episode(**defaults)
+
+
+def _make_belief(
+    statement="Test belief",
+    confidence=0.85,
+    created_at=None,
+    times_reinforced=0,
+    source_domain=None,
+    cross_domain_applications=None,
+    **kwargs,
+) -> Belief:
+    defaults = {
+        "id": str(uuid.uuid4()),
+        "agent_id": "test_agent",
+        "statement": statement,
+        "belief_type": "pattern",
+        "confidence": confidence,
+        "created_at": created_at or datetime.now(timezone.utc),
+        "times_reinforced": times_reinforced,
+        "source_domain": source_domain,
+        "cross_domain_applications": cross_domain_applications,
+    }
+    defaults.update(kwargs)
+    return Belief(**defaults)
+
+
+def _make_entity_model(
+    entity_name="Alice",
+    model_type="behavioral",
+    observation="Test observation",
+    **kwargs,
+) -> EntityModel:
+    defaults = {
+        "id": str(uuid.uuid4()),
+        "agent_id": "test_agent",
+        "entity_name": entity_name,
+        "model_type": model_type,
+        "observation": observation,
+        "confidence": 0.8,
+        "source_episodes": [str(uuid.uuid4())],
+    }
+    defaults.update(kwargs)
+    return EntityModel(**defaults)
+
+
+# === Cross-domain pattern scaffolding ===
+
+
+class TestCrossDomainPatterns:
+    def test_no_episodes(self, kernle_instance):
+        result = kernle_instance.scaffold_cross_domain_patterns()
+        assert result["episodes_scanned"] == 0
+        assert result["patterns"] == []
+        assert "No episodes" in result["scaffold"]
+
+    def test_single_domain_no_cross_pattern(self, kernle_instance, storage):
+        """Episodes in one domain only should not produce cross-domain patterns."""
+        for i in range(3):
+            ep = _make_episode(
+                tags=["coding"],
+                outcome_type="success",
+                lessons=["tests help catch bugs"],
+            )
+            storage.save_episode(ep)
+
+        result = kernle_instance.scaffold_cross_domain_patterns()
+        assert result["episodes_scanned"] == 3
+        assert result["domains_found"] >= 1
+        # Single domain = no cross-domain patterns
+        assert len(result["patterns"]) == 0
+
+    def test_cross_domain_pattern_detected(self, kernle_instance, storage):
+        """Same lesson in 2+ domains should be detected."""
+        lesson = "shortcutting process leads to failure"
+
+        # Domain 1: deployment
+        for i in range(2):
+            ep = _make_episode(
+                tags=["deployment"],
+                outcome_type="failure",
+                lessons=[lesson],
+                objective=f"Deploy task {i}",
+            )
+            storage.save_episode(ep)
+
+        # Domain 2: relationships
+        for i in range(2):
+            ep = _make_episode(
+                tags=["relationships"],
+                outcome_type="failure",
+                lessons=[lesson],
+                objective=f"Relationship task {i}",
+            )
+            storage.save_episode(ep)
+
+        result = kernle_instance.scaffold_cross_domain_patterns()
+        assert result["episodes_scanned"] == 4
+        assert result["domains_found"] >= 2
+
+        # Should find the cross-domain pattern
+        assert len(result["patterns"]) >= 1
+        pattern = result["patterns"][0]
+        assert pattern["lesson"] == lesson
+        assert len(pattern["domains"]) >= 2
+        assert "deployment" in pattern["domains"]
+        assert "relationships" in pattern["domains"]
+
+    def test_scaffold_text_contains_domains(self, kernle_instance, storage):
+        """Scaffold text should list domains found."""
+        ep1 = _make_episode(tags=["coding"], outcome_type="success")
+        ep2 = _make_episode(tags=["writing"], outcome_type="failure")
+        storage.save_episode(ep1)
+        storage.save_episode(ep2)
+
+        result = kernle_instance.scaffold_cross_domain_patterns()
+        assert "coding" in result["scaffold"]
+        assert "writing" in result["scaffold"]
+
+    def test_outcome_patterns_detected(self, kernle_instance, storage):
+        """Domains with dominant outcome types should be flagged."""
+        for i in range(4):
+            ep = _make_episode(
+                tags=["testing"],
+                outcome_type="success",
+                objective=f"Test run {i}",
+            )
+            storage.save_episode(ep)
+        # Add one failure for variety
+        ep_fail = _make_episode(
+            tags=["testing"],
+            outcome_type="failure",
+            objective="Test run fail",
+        )
+        storage.save_episode(ep_fail)
+
+        result = kernle_instance.scaffold_cross_domain_patterns()
+        # 4/5 = 80% success rate should be detected
+        assert len(result.get("outcome_patterns", [])) >= 1
+        op = result["outcome_patterns"][0]
+        assert op["domain"] == "testing"
+        assert op["outcome"] == "success"
+        assert op["ratio"] >= 0.6
+
+    def test_untagged_episodes_grouped(self, kernle_instance, storage):
+        """Episodes without tags should be grouped under 'untagged'."""
+        ep = _make_episode(tags=None, outcome_type="success")
+        storage.save_episode(ep)
+
+        result = kernle_instance.scaffold_cross_domain_patterns()
+        assert result["episodes_scanned"] == 1
+        assert result["domains_found"] >= 1
+
+
+# === Belief-to-value promotion ===
+
+
+class TestBeliefToValuePromotion:
+    def test_no_beliefs(self, kernle_instance):
+        result = kernle_instance.scaffold_belief_to_value()
+        assert result["beliefs_scanned"] == 0
+        assert result["candidates"] == []
+
+    def test_young_belief_not_promoted(self, kernle_instance, storage):
+        """Beliefs younger than 6 months should not be candidates."""
+        belief = _make_belief(
+            statement="Young belief",
+            created_at=datetime.now(timezone.utc) - timedelta(days=30),
+            times_reinforced=5,
+            source_domain="coding",
+            cross_domain_applications=["testing", "deployment"],
+        )
+        storage.save_belief(belief)
+
+        result = kernle_instance.scaffold_belief_to_value()
+        assert result["beliefs_scanned"] == 1
+        assert len(result["candidates"]) == 0
+
+    def test_unreinforced_belief_not_promoted(self, kernle_instance, storage):
+        """Beliefs with few reinforcements should not be candidates."""
+        belief = _make_belief(
+            statement="Unreinforced belief",
+            created_at=datetime.now(timezone.utc) - timedelta(days=200),
+            times_reinforced=1,
+            source_domain="coding",
+            cross_domain_applications=["testing", "deployment"],
+        )
+        storage.save_belief(belief)
+
+        result = kernle_instance.scaffold_belief_to_value()
+        assert result["beliefs_scanned"] == 1
+        assert len(result["candidates"]) == 0
+
+    def test_single_domain_belief_not_promoted(self, kernle_instance, storage):
+        """Beliefs in fewer than 3 domains should not be candidates."""
+        belief = _make_belief(
+            statement="Single domain belief",
+            created_at=datetime.now(timezone.utc) - timedelta(days=200),
+            times_reinforced=5,
+            source_domain="coding",
+            cross_domain_applications=None,  # Only 1 domain
+        )
+        storage.save_belief(belief)
+
+        result = kernle_instance.scaffold_belief_to_value()
+        assert result["beliefs_scanned"] == 1
+        assert len(result["candidates"]) == 0
+
+    def test_contradicted_belief_not_promoted(self, kernle_instance, storage):
+        """Beliefs that have been superseded should not be candidates."""
+        belief = _make_belief(
+            statement="Contradicted belief",
+            created_at=datetime.now(timezone.utc) - timedelta(days=200),
+            times_reinforced=5,
+            source_domain="coding",
+            cross_domain_applications=["testing", "deployment"],
+            superseded_by="some-other-belief-id",
+        )
+        storage.save_belief(belief)
+
+        result = kernle_instance.scaffold_belief_to_value()
+        assert result["beliefs_scanned"] == 1
+        assert len(result["candidates"]) == 0
+
+    def test_stable_belief_is_candidate(self, kernle_instance, storage):
+        """A belief meeting all criteria should be a promotion candidate."""
+        belief = _make_belief(
+            statement="Iterative development leads to better outcomes",
+            created_at=datetime.now(timezone.utc) - timedelta(days=200),
+            times_reinforced=5,
+            confidence=0.9,
+            source_domain="coding",
+            cross_domain_applications=["writing", "relationships"],
+        )
+        storage.save_belief(belief)
+
+        result = kernle_instance.scaffold_belief_to_value()
+        assert result["beliefs_scanned"] == 1
+        assert len(result["candidates"]) == 1
+
+        candidate = result["candidates"][0]
+        assert candidate["statement"] == "Iterative development leads to better outcomes"
+        assert candidate["times_reinforced"] == 5
+        assert candidate["age_days"] >= 200
+        assert len(candidate["domains"]) >= 3
+        assert "coding" in candidate["domains"]
+
+    def test_scaffold_text_contains_candidate(self, kernle_instance, storage):
+        """Scaffold text should describe promotion candidates."""
+        belief = _make_belief(
+            statement="Quality matters more than speed",
+            created_at=datetime.now(timezone.utc) - timedelta(days=365),
+            times_reinforced=8,
+            confidence=0.95,
+            source_domain="coding",
+            cross_domain_applications=["writing", "design"],
+        )
+        storage.save_belief(belief)
+
+        result = kernle_instance.scaffold_belief_to_value()
+        assert "Quality matters more than speed" in result["scaffold"]
+        assert "value-level stability" in result["scaffold"]
+
+    def test_low_confidence_belief_not_promoted(self, kernle_instance, storage):
+        """Beliefs with confidence below threshold should not be candidates."""
+        belief = _make_belief(
+            statement="Low confidence belief",
+            created_at=datetime.now(timezone.utc) - timedelta(days=200),
+            times_reinforced=5,
+            confidence=0.5,
+            source_domain="coding",
+            cross_domain_applications=["testing", "deployment"],
+        )
+        storage.save_belief(belief)
+
+        result = kernle_instance.scaffold_belief_to_value()
+        assert len(result["candidates"]) == 0
+
+    def test_custom_thresholds(self, kernle_instance, storage):
+        """Custom thresholds should be respected."""
+        belief = _make_belief(
+            statement="Custom threshold belief",
+            created_at=datetime.now(timezone.utc) - timedelta(days=60),
+            times_reinforced=2,
+            confidence=0.7,
+            source_domain="coding",
+            cross_domain_applications=["testing"],
+        )
+        storage.save_belief(belief)
+
+        # With relaxed thresholds, should be a candidate
+        result = kernle_instance.scaffold_belief_to_value(
+            min_age_days=30,
+            min_reinforcements=1,
+            min_domains=2,
+            min_confidence=0.6,
+        )
+        assert len(result["candidates"]) == 1
+
+
+# === Entity model-to-belief promotion ===
+
+
+class TestEntityModelToBeliefPromotion:
+    def test_no_models(self, kernle_instance):
+        result = kernle_instance.scaffold_entity_model_to_belief()
+        assert result["models_scanned"] == 0
+        assert result["generalizations"] == []
+        assert "No entity models" in result["scaffold"]
+
+    def test_single_entity_no_generalization(self, kernle_instance, storage):
+        """Observations about a single entity should not generalize."""
+        model = _make_entity_model(
+            entity_name="Alice",
+            observation="careful with code reviews",
+        )
+        storage.save_entity_model(model)
+
+        result = kernle_instance.scaffold_entity_model_to_belief()
+        assert result["models_scanned"] == 1
+        assert len(result["generalizations"]) == 0
+
+    def test_similar_observations_across_entities(self, kernle_instance, storage):
+        """Similar observations about different entities should generalize."""
+        model1 = _make_entity_model(
+            entity_name="Alice",
+            model_type="behavioral",
+            observation="careful and thorough with code reviews and testing",
+            source_episodes=["ep1", "ep2"],
+        )
+        model2 = _make_entity_model(
+            entity_name="Bob",
+            model_type="behavioral",
+            observation="thorough and careful during code review process",
+            source_episodes=["ep3"],
+        )
+        storage.save_entity_model(model1)
+        storage.save_entity_model(model2)
+
+        result = kernle_instance.scaffold_entity_model_to_belief()
+        assert result["models_scanned"] == 2
+        # These share "careful", "thorough", "code", "reviews" - should cluster
+        assert len(result["generalizations"]) >= 1
+
+        gen = result["generalizations"][0]
+        assert gen["entity_count"] >= 2
+        assert "Alice" in gen["entities"]
+        assert "Bob" in gen["entities"]
+
+    def test_dissimilar_observations_no_cluster(self, kernle_instance, storage):
+        """Dissimilar observations should not cluster."""
+        model1 = _make_entity_model(
+            entity_name="Alice",
+            model_type="behavioral",
+            observation="prefers morning meetings for important decisions",
+        )
+        model2 = _make_entity_model(
+            entity_name="Bob",
+            model_type="behavioral",
+            observation="enjoys working on database optimization tasks",
+        )
+        storage.save_entity_model(model1)
+        storage.save_entity_model(model2)
+
+        result = kernle_instance.scaffold_entity_model_to_belief()
+        # These share no meaningful keywords - should not cluster
+        assert len(result["generalizations"]) == 0
+
+    def test_scaffold_text_contains_observations(self, kernle_instance, storage):
+        """Scaffold text should include entity observations."""
+        model1 = _make_entity_model(
+            entity_name="Alice",
+            model_type="capability",
+            observation="strong debugging and problem solving skills",
+            source_episodes=["ep1"],
+        )
+        model2 = _make_entity_model(
+            entity_name="Bob",
+            model_type="capability",
+            observation="excellent debugging skills and problem analysis",
+            source_episodes=["ep2"],
+        )
+        storage.save_entity_model(model1)
+        storage.save_entity_model(model2)
+
+        result = kernle_instance.scaffold_entity_model_to_belief()
+        if result["generalizations"]:
+            assert "Alice" in result["scaffold"]
+            assert "Bob" in result["scaffold"]
+
+    def test_min_supporting_episodes(self, kernle_instance, storage):
+        """Generalizations need minimum supporting episodes."""
+        model1 = _make_entity_model(
+            entity_name="Alice",
+            model_type="behavioral",
+            observation="careful with code reviews and testing",
+            source_episodes=[],  # No episodes
+        )
+        model2 = _make_entity_model(
+            entity_name="Bob",
+            model_type="behavioral",
+            observation="thorough with code reviews and testing",
+            source_episodes=[],  # No episodes
+        )
+        storage.save_entity_model(model1)
+        storage.save_entity_model(model2)
+
+        # With min_supporting_episodes=2, should not qualify (0 total)
+        result = kernle_instance.scaffold_entity_model_to_belief(min_supporting_episodes=2)
+        assert len(result["generalizations"]) == 0
+
+
+# === Combined scaffold ===
+
+
+class TestAdvancedConsolidation:
+    def test_combined_scaffold_empty(self, kernle_instance):
+        """Combined scaffold should work with no data."""
+        result = kernle_instance.scaffold_advanced_consolidation()
+        assert "cross_domain" in result
+        assert "belief_to_value" in result
+        assert "entity_to_belief" in result
+        assert "scaffold" in result
+        assert "Advanced Consolidation Scaffold" in result["scaffold"]
+
+    def test_combined_scaffold_with_data(self, kernle_instance, storage):
+        """Combined scaffold should integrate all three analyses."""
+        # Add some episodes
+        for i in range(3):
+            ep = _make_episode(
+                tags=["coding"],
+                outcome_type="success",
+                lessons=["testing helps"],
+                objective=f"Code task {i}",
+            )
+            storage.save_episode(ep)
+
+        # Add a stable belief
+        belief = _make_belief(
+            statement="Testing leads to quality",
+            created_at=datetime.now(timezone.utc) - timedelta(days=200),
+            times_reinforced=5,
+            source_domain="coding",
+            cross_domain_applications=["deployment", "writing"],
+        )
+        storage.save_belief(belief)
+
+        result = kernle_instance.scaffold_advanced_consolidation()
+        scaffold = result["scaffold"]
+
+        # Should contain sections from all three
+        assert "Cross-Domain Pattern Analysis" in scaffold
+        assert "Belief-to-Value Promotion Analysis" in scaffold
+        # Entity model section present (either header or "no models" message)
+        assert "entity model" in scaffold.lower()
+
+    def test_episode_limit_passed_through(self, kernle_instance, storage):
+        """Episode limit should be passed to cross-domain analysis."""
+        for i in range(10):
+            ep = _make_episode(
+                tags=[f"tag{i}"],
+                objective=f"Task {i}",
+            )
+            storage.save_episode(ep)
+
+        result = kernle_instance.scaffold_advanced_consolidation(episode_limit=5)
+        assert result["cross_domain"]["episodes_scanned"] <= 5
+
+
+# === Observation clustering ===
+
+
+class TestObservationClustering:
+    def test_cluster_similar_observations(self, kernle_instance):
+        """Models with overlapping keywords should cluster."""
+        models = [
+            _make_entity_model(
+                entity_name="A",
+                observation="careful thorough code review process",
+            ),
+            _make_entity_model(
+                entity_name="B",
+                observation="thorough careful review approach",
+            ),
+        ]
+        clusters = kernle_instance._cluster_observations(models)
+        assert len(clusters) >= 1
+        assert len(clusters[0]) >= 2
+
+    def test_no_cluster_dissimilar(self, kernle_instance):
+        """Models with no keyword overlap should not cluster."""
+        models = [
+            _make_entity_model(
+                entity_name="A",
+                observation="morning schedule breakfast routine",
+            ),
+            _make_entity_model(
+                entity_name="B",
+                observation="database optimization queries performance",
+            ),
+        ]
+        clusters = kernle_instance._cluster_observations(models)
+        # Should not form any cluster (no shared meaningful keywords)
+        assert len(clusters) == 0
+
+    def test_empty_models_list(self, kernle_instance):
+        """Empty model list should return no clusters."""
+        clusters = kernle_instance._cluster_observations([])
+        assert clusters == []
+
+    def test_stop_words_excluded(self, kernle_instance):
+        """Stop words should not count as shared keywords."""
+        models = [
+            _make_entity_model(
+                entity_name="A",
+                observation="the cat is on the mat",
+            ),
+            _make_entity_model(
+                entity_name="B",
+                observation="the dog is in the garden",
+            ),
+        ]
+        clusters = kernle_instance._cluster_observations(models)
+        # Only stop words in common - should not cluster
+        assert len(clusters) == 0


### PR DESCRIPTION
## Summary

Three interconnected scaffold enhancements for deeper pattern recognition during memory consolidation (KEP v3 Phase 3):

- **Cross-domain pattern scaffolding** (ss6.2): Groups episodes by domain tags and detects structural similarities in outcomes across domains. Surfaces patterns like "shortcutting process leads to failure in both deployment and relationships."
- **Belief-to-value promotion** (ss6.4): Identifies beliefs that have reached value-level stability -- active >6 months, reinforced 3+ times, never contradicted, appearing across 3+ domains, with confidence >= 80%.
- **Entity model-to-belief promotion** (ss9.4): Clusters similar observations about different entities using keyword overlap and suggests generalizable beliefs with proper provenance tracking.

All scaffolds follow the SI autonomy principle: they surface patterns and suggestions, but the agent decides what to act on.

### Changes

- `kernle/features/consolidation.py` -- New `ConsolidationMixin` with 4 public methods and 5 private helpers
- `kernle/core.py` -- Integrated `ConsolidationMixin` into Kernle class
- `kernle/mcp/server.py` -- Added `memory_consolidate_advanced` MCP tool
- `kernle/cli/__main__.py` -- Added `--advanced` flag to `consolidate` command
- `kernle/cli/commands/identity.py` -- Handler for `--advanced` flag
- `kernle/storage/sqlite.py` -- Fixed missing `epoch_id` value in `save_episode` after merge
- `tests/test_consolidation_scaffolds.py` -- 28 tests across 5 test classes

## Test plan

- [x] 28 new tests pass (cross-domain patterns, belief-to-value promotion, entity model clustering, combined scaffold, edge cases)
- [x] No regressions in existing test suite (all pre-existing failures confirmed unchanged)
- [ ] Manual verification: `kernle consolidate --advanced` produces expected scaffold output

Closes #178

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>