### PR TITLE
feat: add dynamic trust - decay, transitive chains, self-trust floor (#179)

### DIFF
--- a/kernle/cli/__main__.py
+++ b/kernle/cli/__main__.py
@@ -3070,6 +3070,22 @@ def main():
     trust_gate.add_argument("gate_action", help="Action type")
     trust_gate.add_argument("--domain", "-d", help="Domain for domain-specific check")
 
+    trust_compute = trust_sub.add_parser("compute", help="Compute trust from episode history")
+    trust_compute.add_argument("entity", help="Entity identifier")
+    trust_compute.add_argument("--domain", "-d", default="general", help="Trust domain")
+    trust_compute.add_argument(
+        "--apply", action="store_true", help="Apply computed score to stored assessment"
+    )
+
+    trust_chain = trust_sub.add_parser("chain", help="Compute transitive trust through a chain")
+    trust_chain.add_argument("target", help="Target entity")
+    trust_chain.add_argument("chain", nargs="+", help="Chain of intermediary entities")
+    trust_chain.add_argument("--domain", "-d", default="general", help="Trust domain")
+
+    trust_decay = trust_sub.add_parser("decay", help="Apply trust decay for N days")
+    trust_decay.add_argument("entity", help="Entity identifier")
+    trust_decay.add_argument("days", type=float, help="Days since last interaction")
+
     # promote (episodes → beliefs)
     p_promote = subparsers.add_parser(
         "promote", help="Promote recurring patterns from episodes into beliefs"

--- a/kernle/core.py
+++ b/kernle/core.py
@@ -43,7 +43,14 @@ from kernle.storage import (
     Value,
     get_storage,
 )
-from kernle.storage.base import SEED_TRUST, TRUST_THRESHOLDS
+from kernle.storage.base import (
+    DEFAULT_TRUST,
+    SEED_TRUST,
+    SELF_TRUST_FLOOR,
+    TRUST_DECAY_RATE,
+    TRUST_DEPTH_DECAY,
+    TRUST_THRESHOLDS,
+)
 
 if TYPE_CHECKING:
     from kernle.storage import Storage as StorageProtocol
@@ -2338,6 +2345,215 @@ class Kernle(
                 "authority": [auth.get("scope", "unknown") for auth in (a.authority or [])],
             }
         return summary
+
+    # === Dynamic Trust (KEP v3 section 8.6-8.7) ===
+
+    def compute_direct_trust(self, entity: str, domain: str = "general") -> Dict[str, Any]:
+        """Compute trust score from episode history with recency weighting.
+
+        Looks at episodes with the given source_entity, classifies outcomes
+        as positive/negative, and computes a recency-weighted score.
+        """
+        episodes = self._storage.get_episodes_by_source_entity(entity)
+        if not episodes:
+            return {
+                "entity": entity,
+                "domain": domain,
+                "score": DEFAULT_TRUST,
+                "positive": 0,
+                "negative": 0,
+                "total": 0,
+                "source": "default",
+            }
+
+        now = datetime.now(timezone.utc)
+        positive_weight = 0.0
+        negative_weight = 0.0
+
+        for ep in episodes:
+            # Recency weight: exponential decay, halving every 30 days
+            if ep.created_at:
+                days_ago = max(0, (now - ep.created_at).total_seconds() / 86400)
+            else:
+                days_ago = 30.0
+            recency = 0.5 ** (days_ago / 30.0)
+
+            # Classify outcome: positive if outcome_type is "success" or
+            # emotional_valence > 0, negative otherwise
+            is_positive = False
+            if ep.outcome_type in ("success", "positive"):
+                is_positive = True
+            elif ep.outcome_type in ("failure", "negative"):
+                is_positive = False
+            elif ep.emotional_valence > 0:
+                is_positive = True
+
+            if is_positive:
+                positive_weight += recency
+            else:
+                negative_weight += recency
+
+        total_weight = positive_weight + negative_weight
+        if total_weight == 0:
+            score = DEFAULT_TRUST
+        else:
+            score = positive_weight / total_weight
+
+        return {
+            "entity": entity,
+            "domain": domain,
+            "score": round(score, 4),
+            "positive": round(positive_weight, 4),
+            "negative": round(negative_weight, 4),
+            "total": len(episodes),
+            "source": "computed",
+        }
+
+    def apply_trust_decay(self, entity: str, days_since_interaction: float) -> Dict[str, Any]:
+        """Apply trust decay toward neutral (0.5) without reinforcement.
+
+        Formula: current + (0.5 - current) * min(decay_factor, 1.0)
+        where decay_factor = TRUST_DECAY_RATE * days_since_interaction
+        """
+        assessment = self._storage.get_trust_assessment(entity)
+        if assessment is None:
+            return {
+                "entity": entity,
+                "error": f"No trust assessment for entity: {entity}",
+            }
+
+        decay_factor = min(TRUST_DECAY_RATE * days_since_interaction, 1.0)
+        updated_dims = {}
+
+        for domain, dim_data in assessment.dimensions.items():
+            if not isinstance(dim_data, dict):
+                updated_dims[domain] = dim_data
+                continue
+            current = dim_data.get("score", DEFAULT_TRUST)
+            # Self-trust has a floor
+            if entity == "self":
+                floor = SELF_TRUST_FLOOR
+                decayed = current + (floor - current) * decay_factor
+                decayed = max(floor, decayed)
+            else:
+                decayed = current + (DEFAULT_TRUST - current) * decay_factor
+            updated_dims[domain] = {"score": round(decayed, 4)}
+
+        assessment.dimensions = updated_dims
+        self._storage.save_trust_assessment(assessment)
+
+        return {
+            "entity": entity,
+            "days": days_since_interaction,
+            "decay_factor": round(decay_factor, 4),
+            "dimensions": updated_dims,
+        }
+
+    def compute_transitive_trust(
+        self, target: str, chain: List[str], domain: str = "general"
+    ) -> Dict[str, Any]:
+        """Compute transitive trust through a chain of entities.
+
+        Trust flows through entity chains with 15% decay per hop:
+        trust = product of (direct_trust * depth_decay^i) for each entity in chain.
+        """
+        if not chain:
+            return {
+                "target": target,
+                "chain": [],
+                "domain": domain,
+                "score": 0.0,
+                "hops": [],
+                "error": "Empty chain",
+            }
+
+        trust = 1.0
+        hops = []
+
+        for i, entity in enumerate(chain):
+            assessment = self._storage.get_trust_assessment(entity)
+            if assessment is None:
+                direct = DEFAULT_TRUST
+            else:
+                dims = assessment.dimensions or {}
+                domain_data = dims.get(domain, dims.get("general", {}))
+                direct = (
+                    domain_data.get("score", DEFAULT_TRUST)
+                    if isinstance(domain_data, dict)
+                    else DEFAULT_TRUST
+                )
+
+            hop_factor = direct * (TRUST_DEPTH_DECAY**i)
+            trust *= hop_factor
+            hops.append(
+                {
+                    "entity": entity,
+                    "direct_trust": round(direct, 4),
+                    "depth_decay": round(TRUST_DEPTH_DECAY**i, 4),
+                    "cumulative": round(trust, 4),
+                }
+            )
+
+        return {
+            "target": target,
+            "chain": chain,
+            "domain": domain,
+            "score": round(trust, 4),
+            "hops": hops,
+        }
+
+    def compute_self_trust_floor(self) -> Dict[str, Any]:
+        """Compute self-trust floor from historical accuracy.
+
+        self_trust_floor = max(0.5, historical_accuracy_rate)
+        where accuracy is based on episodes where source_entity is 'self'.
+        """
+        episodes = self._storage.get_episodes_by_source_entity("self")
+        if not episodes:
+            return {
+                "floor": SELF_TRUST_FLOOR,
+                "accuracy": None,
+                "total_episodes": 0,
+                "source": "default",
+            }
+
+        positive = sum(
+            1
+            for e in episodes
+            if e.outcome_type in ("success", "positive") or e.emotional_valence > 0
+        )
+        total = len(episodes)
+        accuracy = positive / total if total > 0 else 0.5
+        floor = max(SELF_TRUST_FLOOR, accuracy)
+
+        return {
+            "floor": round(floor, 4),
+            "accuracy": round(accuracy, 4),
+            "total_episodes": total,
+            "positive_episodes": positive,
+            "source": "computed",
+        }
+
+    def trust_compute(self, entity: str, domain: str = "general") -> Dict[str, Any]:
+        """Compute and optionally update trust for an entity from episode history.
+
+        This is the main entry point for dynamic trust computation. It computes
+        direct trust from episodes and returns the result without automatically
+        updating the stored assessment (the caller can use trust_set to persist).
+        """
+        result = self.compute_direct_trust(entity, domain)
+
+        # If entity is "self", also compute the floor
+        if entity == "self":
+            floor_result = self.compute_self_trust_floor()
+            result["self_trust_floor"] = floor_result["floor"]
+            result["score"] = max(result["score"], floor_result["floor"])
+
+        return result
+
+    def trust_chain(self, target: str, chain: List[str], domain: str = "general") -> Dict[str, Any]:
+        """Compute transitive trust through a chain (CLI entry point)."""
+        return self.compute_transitive_trust(target, chain, domain)
 
     def export_cache(
         self,

--- a/kernle/storage/__init__.py
+++ b/kernle/storage/__init__.py
@@ -13,6 +13,11 @@ from pathlib import Path
 from typing import Literal, Optional
 
 from .base import (
+    # Dynamic trust constants
+    DEFAULT_TRUST,
+    SELF_TRUST_FLOOR,
+    TRUST_DECAY_RATE,
+    TRUST_DEPTH_DECAY,
     Belief,
     ConfidenceChange,
     Drive,
@@ -151,6 +156,11 @@ __all__ = [
     "RawEntry",
     "MemorySuggestion",
     "TrustAssessment",
+    # Dynamic trust constants
+    "DEFAULT_TRUST",
+    "TRUST_DECAY_RATE",
+    "TRUST_DEPTH_DECAY",
+    "SELF_TRUST_FLOOR",
     # Meta-memory types
     "SourceType",
     "ConfidenceChange",

--- a/kernle/storage/base.py
+++ b/kernle/storage/base.py
@@ -616,6 +616,12 @@ TRUST_THRESHOLDS: Dict[str, float] = {
     "diagnostic": 0.85,
 }
 
+# Dynamic trust constants (KEP v3 section 8.6-8.7)
+DEFAULT_TRUST: float = 0.5  # Neutral trust for unknown entities
+TRUST_DECAY_RATE: float = 0.01  # Per-day decay factor toward neutral
+TRUST_DEPTH_DECAY: float = 0.85  # 15% decay per hop in transitive chains
+SELF_TRUST_FLOOR: float = 0.5  # Minimum self-trust (overridden by accuracy)
+
 SEED_TRUST: List[Dict[str, Any]] = [
     {
         "entity": "stack-owner",
@@ -994,6 +1000,12 @@ class Storage(Protocol):
     def delete_trust_assessment(self, entity: str) -> bool:
         """Delete a trust assessment (soft delete)."""
         return False
+
+    def get_episodes_by_source_entity(
+        self, source_entity: str, limit: int = 500
+    ) -> List["Episode"]:
+        """Get episodes associated with a source entity for trust computation."""
+        return []
 
     # === Playbooks (Procedural Memory) ===
 

--- a/kernle/storage/sqlite.py
+++ b/kernle/storage/sqlite.py
@@ -2155,7 +2155,7 @@ class SQLiteStorage:
                  source_entity, subject_ids, access_grants, consent_grants,
                  epoch_id,
                  created_at, local_updated_at, cloud_synced_at, version, deleted)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
                 (
                     episode.id,
@@ -2187,6 +2187,7 @@ class SQLiteStorage:
                     self._to_json(getattr(episode, "subject_ids", None)),
                     self._to_json(getattr(episode, "access_grants", None)),
                     self._to_json(getattr(episode, "consent_grants", None)),
+                    getattr(episode, "epoch_id", None),
                     episode.created_at.isoformat() if episode.created_at else now,
                     now,
                     episode.cloud_synced_at.isoformat() if episode.cloud_synced_at else None,
@@ -2524,6 +2525,17 @@ class SQLiteStorage:
             access_grants=self._from_json(self._safe_get(row, "access_grants", None)),
             consent_grants=self._from_json(self._safe_get(row, "consent_grants", None)),
         )
+
+    def get_episodes_by_source_entity(self, source_entity: str, limit: int = 500) -> List[Episode]:
+        """Get episodes associated with a source entity for trust computation."""
+        query = """
+            SELECT * FROM episodes
+            WHERE agent_id = ? AND source_entity = ? AND deleted = 0 AND is_forgotten = 0
+            ORDER BY created_at DESC LIMIT ?
+        """
+        with self._connect() as conn:
+            rows = conn.execute(query, (self.agent_id, source_entity, limit)).fetchall()
+        return [self._row_to_episode(row) for row in rows]
 
     def update_episode_emotion(
         self, episode_id: str, valence: float, arousal: float, tags: Optional[List[str]] = None

--- a/tests/test_dynamic_trust.py
+++ b/tests/test_dynamic_trust.py
@@ -1,0 +1,385 @@
+"""Tests for dynamic trust features (KEP v3 section 8.6-8.7)."""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from kernle.core import Kernle
+from kernle.storage import SQLiteStorage
+from kernle.storage.base import (
+    DEFAULT_TRUST,
+    SELF_TRUST_FLOOR,
+    TRUST_DECAY_RATE,
+    TRUST_DEPTH_DECAY,
+    Episode,
+    TrustAssessment,
+)
+
+
+@pytest.fixture
+def setup(tmp_path):
+    """Create a Kernle instance for dynamic trust testing."""
+    db_path = tmp_path / "test_dynamic_trust.db"
+    storage = SQLiteStorage(agent_id="test_agent", db_path=db_path)
+    checkpoint_dir = tmp_path / "checkpoints"
+    checkpoint_dir.mkdir()
+    k = Kernle(agent_id="test_agent", storage=storage, checkpoint_dir=checkpoint_dir)
+    k.seed_trust()
+    yield k, storage
+    storage.close()
+
+
+def _make_episode(
+    source_entity,
+    outcome_type="success",
+    emotional_valence=0.5,
+    days_ago=0,
+):
+    """Helper to create an episode with the given source entity."""
+    created = datetime.now(timezone.utc) - timedelta(days=days_ago)
+    return Episode(
+        id=str(uuid.uuid4()),
+        agent_id="test_agent",
+        objective="test objective",
+        outcome="test outcome",
+        outcome_type=outcome_type,
+        emotional_valence=emotional_valence,
+        created_at=created,
+        source_entity=source_entity,
+    )
+
+
+class TestDynamicTrustConstants:
+    """Tests for dynamic trust constants."""
+
+    def test_default_trust(self):
+        assert DEFAULT_TRUST == 0.5
+
+    def test_decay_rate(self):
+        assert TRUST_DECAY_RATE == 0.01
+
+    def test_depth_decay(self):
+        assert TRUST_DEPTH_DECAY == 0.85
+
+    def test_self_trust_floor(self):
+        assert SELF_TRUST_FLOOR == 0.5
+
+
+class TestComputeDirectTrust:
+    """Tests for computing trust from episode history."""
+
+    def test_no_episodes_returns_default(self, setup):
+        k, storage = setup
+        result = k.compute_direct_trust("unknown-entity")
+        assert result["score"] == DEFAULT_TRUST
+        assert result["source"] == "default"
+        assert result["total"] == 0
+
+    def test_all_positive_episodes(self, setup):
+        k, storage = setup
+        for i in range(5):
+            ep = _make_episode("test-source", outcome_type="success", days_ago=i)
+            storage.save_episode(ep)
+
+        result = k.compute_direct_trust("test-source")
+        assert result["score"] > 0.9
+        assert result["total"] == 5
+        assert result["source"] == "computed"
+
+    def test_all_negative_episodes(self, setup):
+        k, storage = setup
+        for i in range(5):
+            ep = _make_episode(
+                "bad-source", outcome_type="failure", emotional_valence=-0.5, days_ago=i
+            )
+            storage.save_episode(ep)
+
+        result = k.compute_direct_trust("bad-source")
+        assert result["score"] < 0.1
+        assert result["total"] == 5
+
+    def test_mixed_episodes(self, setup):
+        k, storage = setup
+        # 3 positive, 2 negative, all recent
+        for i in range(3):
+            ep = _make_episode("mixed-source", outcome_type="success", days_ago=i)
+            storage.save_episode(ep)
+        for i in range(2):
+            ep = _make_episode(
+                "mixed-source", outcome_type="failure", emotional_valence=-0.5, days_ago=i
+            )
+            storage.save_episode(ep)
+
+        result = k.compute_direct_trust("mixed-source")
+        assert 0.4 < result["score"] < 0.8
+        assert result["total"] == 5
+
+    def test_recency_weighting(self, setup):
+        k, storage = setup
+        # Old positive episode (60 days ago) and recent negative (today)
+        old_pos = _make_episode("recency-test", outcome_type="success", days_ago=60)
+        recent_neg = _make_episode(
+            "recency-test", outcome_type="failure", emotional_valence=-0.5, days_ago=0
+        )
+        storage.save_episode(old_pos)
+        storage.save_episode(recent_neg)
+
+        result = k.compute_direct_trust("recency-test")
+        # Recent negative should dominate over old positive
+        assert result["score"] < 0.5
+
+    def test_emotional_valence_fallback(self, setup):
+        k, storage = setup
+        # Episode with no outcome_type but positive valence
+        ep = _make_episode("valence-test", outcome_type=None, emotional_valence=0.8, days_ago=0)
+        storage.save_episode(ep)
+
+        result = k.compute_direct_trust("valence-test")
+        assert result["score"] > 0.9
+
+
+class TestTrustDecay:
+    """Tests for trust decay toward neutral."""
+
+    def test_high_trust_decays_toward_neutral(self, setup):
+        k, storage = setup
+        # Set high trust
+        k.trust_set("test-entity", domain="general", score=0.9)
+
+        result = k.apply_trust_decay("test-entity", days_since_interaction=50)
+        new_score = result["dimensions"]["general"]["score"]
+        assert new_score < 0.9
+        assert new_score > 0.5  # Should not go below neutral
+
+    def test_low_trust_decays_toward_neutral(self, setup):
+        k, storage = setup
+        # Set low trust
+        k.trust_set("low-entity", domain="general", score=0.1)
+
+        result = k.apply_trust_decay("low-entity", days_since_interaction=50)
+        new_score = result["dimensions"]["general"]["score"]
+        assert new_score > 0.1
+        assert new_score < 0.5  # Should not go above neutral
+
+    def test_neutral_trust_stays_neutral(self, setup):
+        k, storage = setup
+        k.trust_set("neutral-entity", domain="general", score=0.5)
+
+        result = k.apply_trust_decay("neutral-entity", days_since_interaction=100)
+        new_score = result["dimensions"]["general"]["score"]
+        assert abs(new_score - 0.5) < 0.01
+
+    def test_decay_factor_capped_at_one(self, setup):
+        k, storage = setup
+        k.trust_set("cap-entity", domain="general", score=0.9)
+
+        result = k.apply_trust_decay("cap-entity", days_since_interaction=200)
+        assert result["decay_factor"] <= 1.0
+
+    def test_self_trust_has_floor(self, setup):
+        k, storage = setup
+        # Self trust starts at 0.8 from seed
+        result = k.apply_trust_decay("self", days_since_interaction=1000)
+        new_score = result["dimensions"]["general"]["score"]
+        # Self-trust should not go below SELF_TRUST_FLOOR
+        assert new_score >= SELF_TRUST_FLOOR
+
+    def test_unknown_entity_returns_error(self, setup):
+        k, storage = setup
+        result = k.apply_trust_decay("nonexistent", days_since_interaction=10)
+        assert "error" in result
+
+    def test_multi_domain_decay(self, setup):
+        k, storage = setup
+        # Create entity with multiple domains
+        assessment = TrustAssessment(
+            id=str(uuid.uuid4()),
+            agent_id="test_agent",
+            entity="multi-domain",
+            dimensions={
+                "general": {"score": 0.9},
+                "coding": {"score": 0.3},
+            },
+        )
+        storage.save_trust_assessment(assessment)
+
+        result = k.apply_trust_decay("multi-domain", days_since_interaction=50)
+        general = result["dimensions"]["general"]["score"]
+        coding = result["dimensions"]["coding"]["score"]
+        # Both should move toward 0.5
+        assert general < 0.9
+        assert coding > 0.3
+
+
+class TestTransitiveTrust:
+    """Tests for transitive trust chains."""
+
+    def test_single_hop(self, setup):
+        k, storage = setup
+        # stack-owner has 0.95 trust
+        result = k.compute_transitive_trust("target", ["stack-owner"], domain="general")
+        # 0.95 * 0.85^0 = 0.95
+        assert abs(result["score"] - 0.95) < 0.01
+        assert len(result["hops"]) == 1
+
+    def test_two_hop_chain(self, setup):
+        k, storage = setup
+        # stack-owner (0.95) -> self (0.8)
+        result = k.compute_transitive_trust("target", ["stack-owner", "self"], domain="general")
+        # 0.95 * 1.0 * 0.8 * 0.85 = 0.646
+        expected = 0.95 * (0.8 * TRUST_DEPTH_DECAY)
+        assert abs(result["score"] - expected) < 0.01
+        assert len(result["hops"]) == 2
+
+    def test_depth_decay_per_hop(self, setup):
+        k, storage = setup
+        # Three entities with 0.9 trust each
+        for name in ["a", "b", "c"]:
+            k.trust_set(name, score=0.9)
+
+        result = k.compute_transitive_trust("target", ["a", "b", "c"])
+        # 0.9 * 0.85^0 * 0.9 * 0.85^1 * 0.9 * 0.85^2
+        expected = (0.9 * 1.0) * (0.9 * 0.85) * (0.9 * 0.85**2)
+        assert abs(result["score"] - expected) < 0.01
+
+    def test_unknown_entity_in_chain(self, setup):
+        k, storage = setup
+        result = k.compute_transitive_trust("target", ["unknown-entity"])
+        # Unknown entity gets DEFAULT_TRUST (0.5)
+        assert abs(result["score"] - DEFAULT_TRUST) < 0.01
+
+    def test_empty_chain(self, setup):
+        k, storage = setup
+        result = k.compute_transitive_trust("target", [])
+        assert result["score"] == 0.0
+        assert "error" in result
+
+    def test_chain_with_zero_trust(self, setup):
+        k, storage = setup
+        # context-injection has 0.0 trust
+        result = k.compute_transitive_trust("target", ["context-injection", "stack-owner"])
+        assert result["score"] == 0.0
+
+    def test_domain_specific_chain(self, setup):
+        k, storage = setup
+        # web-search has medical: 0.3
+        result = k.compute_transitive_trust("target", ["web-search"], domain="medical")
+        assert abs(result["score"] - 0.3) < 0.01
+
+
+class TestSelfTrustFloor:
+    """Tests for self-trust floor computation."""
+
+    def test_no_self_episodes(self, setup):
+        k, storage = setup
+        result = k.compute_self_trust_floor()
+        assert result["floor"] == SELF_TRUST_FLOOR
+        assert result["source"] == "default"
+
+    def test_high_accuracy_raises_floor(self, setup):
+        k, storage = setup
+        # 9 positive, 1 negative -> 90% accuracy
+        for i in range(9):
+            ep = _make_episode("self", outcome_type="success", days_ago=i)
+            storage.save_episode(ep)
+        ep = _make_episode("self", outcome_type="failure", emotional_valence=-0.5, days_ago=10)
+        storage.save_episode(ep)
+
+        result = k.compute_self_trust_floor()
+        assert result["floor"] == 0.9
+        assert result["accuracy"] == 0.9
+        assert result["source"] == "computed"
+
+    def test_low_accuracy_uses_minimum(self, setup):
+        k, storage = setup
+        # 2 positive, 8 negative -> 20% accuracy, floor stays at 0.5
+        for i in range(2):
+            ep = _make_episode("self", outcome_type="success", days_ago=i)
+            storage.save_episode(ep)
+        for i in range(8):
+            ep = _make_episode(
+                "self", outcome_type="failure", emotional_valence=-0.5, days_ago=i + 2
+            )
+            storage.save_episode(ep)
+
+        result = k.compute_self_trust_floor()
+        assert result["floor"] == SELF_TRUST_FLOOR
+        assert result["accuracy"] == 0.2
+
+
+class TestTrustCompute:
+    """Tests for the trust_compute entry point."""
+
+    def test_compute_unknown_entity(self, setup):
+        k, storage = setup
+        result = k.trust_compute("unknown")
+        assert result["score"] == DEFAULT_TRUST
+
+    def test_compute_self_includes_floor(self, setup):
+        k, storage = setup
+        result = k.trust_compute("self")
+        assert "self_trust_floor" in result
+
+    def test_compute_with_episodes(self, setup):
+        k, storage = setup
+        for i in range(3):
+            ep = _make_episode("compute-test", outcome_type="success", days_ago=i)
+            storage.save_episode(ep)
+
+        result = k.trust_compute("compute-test")
+        assert result["score"] > 0.9
+        assert result["total"] == 3
+
+
+class TestTrustChain:
+    """Tests for trust_chain entry point."""
+
+    def test_chain_entry_point(self, setup):
+        k, storage = setup
+        result = k.trust_chain("target", ["stack-owner"])
+        assert "score" in result
+        assert "hops" in result
+        assert result["score"] > 0.9
+
+
+class TestGetEpisodesBySourceEntity:
+    """Tests for storage-level episode query by source entity."""
+
+    def test_returns_matching_episodes(self, setup):
+        k, storage = setup
+        ep1 = _make_episode("entity-a", outcome_type="success")
+        ep2 = _make_episode("entity-b", outcome_type="failure", emotional_valence=-0.5)
+        ep3 = _make_episode("entity-a", outcome_type="success")
+        storage.save_episode(ep1)
+        storage.save_episode(ep2)
+        storage.save_episode(ep3)
+
+        results = storage.get_episodes_by_source_entity("entity-a")
+        assert len(results) == 2
+        for ep in results:
+            assert ep.source_entity == "entity-a"
+
+    def test_returns_empty_for_unknown(self, setup):
+        k, storage = setup
+        results = storage.get_episodes_by_source_entity("nonexistent")
+        assert results == []
+
+    def test_respects_limit(self, setup):
+        k, storage = setup
+        for i in range(10):
+            ep = _make_episode("limited-entity", outcome_type="success", days_ago=i)
+            storage.save_episode(ep)
+
+        results = storage.get_episodes_by_source_entity("limited-entity", limit=3)
+        assert len(results) == 3
+
+    def test_excludes_deleted(self, setup):
+        k, storage = setup
+        ep = _make_episode("del-entity", outcome_type="success")
+        storage.save_episode(ep)
+        # Soft delete
+        storage.forget_memory("episode", ep.id)
+
+        results = storage.get_episodes_by_source_entity("del-entity")
+        assert len(results) == 0


### PR DESCRIPTION
## Summary

Extends the trust layer (PR #188) with dynamic trust features from KEP v3 sections 8.6-8.7:

- **Trust computation from episode history**: `compute_direct_trust()` analyzes episodes by source entity with recency weighting (exponential decay, halving every 30 days)
- **Trust decay**: `apply_trust_decay()` moves trust toward neutral (0.5) without reinforcement using formula `current + (0.5 - current) * min(decay_factor, 1.0)`
- **Transitive trust chains**: `compute_transitive_trust()` propagates trust through entity chains with 15% decay per hop (`depth_decay=0.85`)
- **Self-trust floor**: `compute_self_trust_floor()` ensures self-trust never drops below `max(0.5, historical_accuracy_rate)`
- **CLI commands**: `kernle trust compute`, `kernle trust chain`, `kernle trust decay`
- **Storage**: `get_episodes_by_source_entity()` query for trust-relevant episodes
- **Bug fix**: `save_episode` had 34 values for 35 columns (missing `epoch_id`)

## Test plan

- [x] 35 new tests in `tests/test_dynamic_trust.py` (all passing)
- [x] 32 existing trust layer tests still pass
- [x] Constants verified (DEFAULT_TRUST=0.5, TRUST_DECAY_RATE=0.01, TRUST_DEPTH_DECAY=0.85, SELF_TRUST_FLOOR=0.5)
- [x] Direct trust: default for no history, all positive, all negative, mixed, recency weighting, valence fallback
- [x] Decay: high/low/neutral trust convergence, self-trust floor, multi-domain, cap at 1.0
- [x] Transitive: single hop, two hops, depth decay, unknown entity, empty chain, zero trust blocker, domain-specific
- [x] Self-trust floor: no episodes default, high accuracy raises floor, low accuracy uses minimum
- [x] Storage: source entity filter, limit, excludes deleted/forgotten

Closes #179