### PR TITLE
feat: emotional salience in priority scoring + epoch staleness anxiety

### DIFF
--- a/kernle/cli/commands/anxiety.py
+++ b/kernle/cli/commands/anxiety.py
@@ -90,6 +90,7 @@ def cmd_anxiety(args, k: "Kernle"):
         "raw_aging": "Raw Entry Aging",
         "identity_coherence": "Identity Coherence",
         "memory_uncertainty": "Memory Uncertainty",
+        "epoch_staleness": "Epoch Staleness",
     }
 
     for dim_key, dim_label in dim_names.items():

--- a/tests/test_budget_loading.py
+++ b/tests/test_budget_loading.py
@@ -128,9 +128,9 @@ class TestComputePriorityScore:
         low_score = compute_priority_score("value", low_priority_value)
 
         assert high_score > low_score
-        # Both should include base priority
-        assert high_score >= MEMORY_TYPE_PRIORITIES["value"] * 0.6
-        assert low_score >= MEMORY_TYPE_PRIORITIES["value"] * 0.6 - 0.01
+        # Both should include base priority (55% weight on type priority)
+        assert high_score >= MEMORY_TYPE_PRIORITIES["value"] * 0.55
+        assert low_score >= MEMORY_TYPE_PRIORITIES["value"] * 0.55 - 0.01
 
     def test_belief_priority(self):
         """Belief priority should scale with confidence."""

--- a/tests/test_cli_anxiety.py
+++ b/tests/test_cli_anxiety.py
@@ -23,6 +23,7 @@ class TestCmdAnxiety:
                 "raw_aging": {"score": 10, "emoji": "🟢", "detail": "fresh"},
                 "identity_coherence": {"score": 50, "emoji": "🟡", "detail": "developing"},
                 "memory_uncertainty": {"score": 30, "emoji": "🟢", "detail": "2 beliefs"},
+                "epoch_staleness": {"score": 0, "emoji": "🟢", "detail": "No epochs (not in use)"},
             },
             "timestamp": "2026-01-28T12:00:00Z",
             "agent_id": "test",
@@ -117,6 +118,7 @@ class TestCmdAnxiety:
                 "raw_aging": {"score": 30, "emoji": "🟢", "detail": "fresh"},
                 "identity_coherence": {"score": 70, "emoji": "🟠", "detail": "weak"},
                 "memory_uncertainty": {"score": 50, "emoji": "🟡", "detail": "4 beliefs"},
+                "epoch_staleness": {"score": 0, "emoji": "🟢", "detail": "No epochs (not in use)"},
             },
             "timestamp": "2026-01-28T12:00:00Z",
             "agent_id": "test",
@@ -350,6 +352,7 @@ class TestDetailedAndActions:
                 "raw_aging": {"score": 10, "emoji": "🟢", "detail": "1 day"},
                 "identity_coherence": {"score": 60, "emoji": "🟠", "detail": "developing"},
                 "memory_uncertainty": {"score": 40, "emoji": "🟡", "detail": "3 beliefs"},
+                "epoch_staleness": {"score": 0, "emoji": "🟢", "detail": "No epochs (not in use)"},
             },
             "recommendations": [
                 {
@@ -396,6 +399,7 @@ class TestDetailedAndActions:
                 "raw_aging": {"score": 20, "emoji": "🟢", "detail": "recent"},
                 "identity_coherence": {"score": 60, "emoji": "🟠", "detail": "developing"},
                 "memory_uncertainty": {"score": 50, "emoji": "🟡", "detail": "5 beliefs"},
+                "epoch_staleness": {"score": 0, "emoji": "🟢", "detail": "No epochs (not in use)"},
             },
         }
         k.get_recommended_actions.return_value = [
@@ -442,6 +446,7 @@ class TestAutoMode:
                 "raw_aging": {"score": 5, "emoji": "🟢", "detail": "fresh"},
                 "identity_coherence": {"score": 30, "emoji": "🟢", "detail": "stable"},
                 "memory_uncertainty": {"score": 20, "emoji": "🟢", "detail": "1 belief"},
+                "epoch_staleness": {"score": 0, "emoji": "🟢", "detail": "No epochs (not in use)"},
             },
         }
         k.get_recommended_actions.return_value = []
@@ -478,6 +483,7 @@ class TestAutoMode:
                 "raw_aging": {"score": 30, "emoji": "🟢", "detail": "recent"},
                 "identity_coherence": {"score": 50, "emoji": "🟡", "detail": "developing"},
                 "memory_uncertainty": {"score": 40, "emoji": "🟡", "detail": "4 beliefs"},
+                "epoch_staleness": {"score": 0, "emoji": "🟢", "detail": "No epochs (not in use)"},
             },
         }
         k.get_recommended_actions.return_value = [
@@ -518,6 +524,7 @@ class TestAutoMode:
                 "raw_aging": {"score": 30, "emoji": "🟢", "detail": "recent"},
                 "identity_coherence": {"score": 70, "emoji": "🟠", "detail": "weak"},
                 "memory_uncertainty": {"score": 40, "emoji": "🟡", "detail": "4 beliefs"},
+                "epoch_staleness": {"score": 0, "emoji": "🟢", "detail": "No epochs (not in use)"},
             },
         }
         k.get_recommended_actions.return_value = [
@@ -563,6 +570,7 @@ class TestAutoMode:
                 "raw_aging": {"score": 30, "emoji": "🟢", "detail": "recent"},
                 "identity_coherence": {"score": 50, "emoji": "🟡", "detail": "developing"},
                 "memory_uncertainty": {"score": 40, "emoji": "🟡", "detail": "4 beliefs"},
+                "epoch_staleness": {"score": 0, "emoji": "🟢", "detail": "No epochs (not in use)"},
             },
         }
         k.get_recommended_actions.return_value = [
@@ -603,6 +611,7 @@ class TestAutoMode:
                 "raw_aging": {"score": 30, "emoji": "🟢", "detail": "recent"},
                 "identity_coherence": {"score": 50, "emoji": "🟡", "detail": "developing"},
                 "memory_uncertainty": {"score": 40, "emoji": "🟡", "detail": "4 beliefs"},
+                "epoch_staleness": {"score": 0, "emoji": "🟢", "detail": "No epochs (not in use)"},
             },
         }
         k.get_recommended_actions.return_value = [
@@ -642,6 +651,7 @@ class TestAutoMode:
                 "raw_aging": {"score": 70, "emoji": "🟠", "detail": "stale"},
                 "identity_coherence": {"score": 80, "emoji": "🔴", "detail": "fragmented"},
                 "memory_uncertainty": {"score": 90, "emoji": "🔴", "detail": "many beliefs"},
+                "epoch_staleness": {"score": 0, "emoji": "🟢", "detail": "No epochs (not in use)"},
             },
         }
         k.get_recommended_actions.return_value = [
@@ -682,6 +692,7 @@ class TestAutoMode:
                 "raw_aging": {"score": 70, "emoji": "🟠", "detail": "stale"},
                 "identity_coherence": {"score": 80, "emoji": "🔴", "detail": "fragmented"},
                 "memory_uncertainty": {"score": 90, "emoji": "🔴", "detail": "many beliefs"},
+                "epoch_staleness": {"score": 0, "emoji": "🟢", "detail": "No epochs (not in use)"},
             },
         }
         k.get_recommended_actions.return_value = [
@@ -721,6 +732,7 @@ class TestAutoMode:
                 "raw_aging": {"score": 30, "emoji": "🟢", "detail": "recent"},
                 "identity_coherence": {"score": 50, "emoji": "🟡", "detail": "developing"},
                 "memory_uncertainty": {"score": 70, "emoji": "🟠", "detail": "many beliefs"},
+                "epoch_staleness": {"score": 0, "emoji": "🟢", "detail": "No epochs (not in use)"},
             },
         }
         k.get_recommended_actions.return_value = [
@@ -765,6 +777,7 @@ class TestAutoMode:
                 "raw_aging": {"score": 30, "emoji": "🟢", "detail": "recent"},
                 "identity_coherence": {"score": 50, "emoji": "🟡", "detail": "developing"},
                 "memory_uncertainty": {"score": 40, "emoji": "🟡", "detail": "4 beliefs"},
+                "epoch_staleness": {"score": 0, "emoji": "🟢", "detail": "No epochs (not in use)"},
             },
         }
         k.get_recommended_actions.return_value = [
@@ -803,6 +816,7 @@ class TestAutoMode:
                 "raw_aging": {"score": 30, "emoji": "🟢", "detail": "recent"},
                 "identity_coherence": {"score": 50, "emoji": "🟡", "detail": "developing"},
                 "memory_uncertainty": {"score": 40, "emoji": "🟡", "detail": "4 beliefs"},
+                "epoch_staleness": {"score": 0, "emoji": "🟢", "detail": "No epochs (not in use)"},
             },
         }
         k.get_recommended_actions.return_value = [
@@ -841,6 +855,7 @@ class TestAutoMode:
                 "raw_aging": {"score": 30, "emoji": "🟢", "detail": "recent"},
                 "identity_coherence": {"score": 50, "emoji": "🟡", "detail": "developing"},
                 "memory_uncertainty": {"score": 40, "emoji": "🟡", "detail": "4 beliefs"},
+                "epoch_staleness": {"score": 0, "emoji": "🟢", "detail": "No epochs (not in use)"},
             },
         }
         k.get_recommended_actions.return_value = [
@@ -884,6 +899,7 @@ class TestHighAnxietySuggestion:
                 "raw_aging": {"score": 50, "emoji": "🟡", "detail": "aging"},
                 "identity_coherence": {"score": 70, "emoji": "🟠", "detail": "developing"},
                 "memory_uncertainty": {"score": 60, "emoji": "🟠", "detail": "5 beliefs"},
+                "epoch_staleness": {"score": 0, "emoji": "🟢", "detail": "No epochs (not in use)"},
             },
         }
 

--- a/tests/test_emotional_salience.py
+++ b/tests/test_emotional_salience.py
@@ -1,0 +1,210 @@
+"""Tests for emotional salience in priority scoring.
+
+Verifies that compute_priority_score() incorporates emotional valence and
+arousal with a 90-day half-life time decay, giving emotionally significant
+episodes higher cognitive availability.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from kernle.core import compute_priority_score
+
+
+class TestEmotionalSalienceInPriority:
+    """Test emotional salience factor in compute_priority_score."""
+
+    def test_no_emotion_baseline(self):
+        """Records without emotional data should use base scoring."""
+        record = {
+            "confidence": 0.8,
+            "emotional_valence": 0.0,
+            "emotional_arousal": 0.0,
+        }
+        score = compute_priority_score("belief", record)
+        # With zero emotion, emotional_salience = 0
+        # score = 0.55 * (0.70 * 0.8) + 0.35 * 0.8 + 0.10 * 0
+        # = 0.55 * 0.56 + 0.28 = 0.308 + 0.28 = 0.588
+        assert 0.0 <= score <= 1.0
+
+    def test_high_emotion_boosts_score(self):
+        """Records with high emotional intensity should score higher."""
+        base_record = {
+            "confidence": 0.8,
+            "emotional_valence": 0.0,
+            "emotional_arousal": 0.0,
+        }
+        emotional_record = {
+            "confidence": 0.8,
+            "emotional_valence": 0.9,
+            "emotional_arousal": 0.8,
+            "created_at": datetime.now(timezone.utc),
+        }
+
+        base_score = compute_priority_score("belief", base_record)
+        emotional_score = compute_priority_score("belief", emotional_record)
+
+        assert emotional_score > base_score
+
+    def test_negative_valence_also_boosts(self):
+        """Negative valence should also boost via abs(valence)."""
+        positive_record = {
+            "confidence": 0.8,
+            "emotional_valence": 0.8,
+            "emotional_arousal": 0.7,
+            "created_at": datetime.now(timezone.utc),
+        }
+        negative_record = {
+            "confidence": 0.8,
+            "emotional_valence": -0.8,
+            "emotional_arousal": 0.7,
+            "created_at": datetime.now(timezone.utc),
+        }
+
+        pos_score = compute_priority_score("belief", positive_record)
+        neg_score = compute_priority_score("belief", negative_record)
+
+        # abs(valence) should make them equal
+        assert abs(pos_score - neg_score) < 0.01
+
+    def test_time_decay_reduces_salience(self):
+        """Older records should have lower emotional salience."""
+        now = datetime.now(timezone.utc)
+        recent_record = {
+            "confidence": 0.8,
+            "emotional_valence": 0.9,
+            "emotional_arousal": 0.8,
+            "created_at": now,
+        }
+        old_record = {
+            "confidence": 0.8,
+            "emotional_valence": 0.9,
+            "emotional_arousal": 0.8,
+            "created_at": now - timedelta(days=180),
+        }
+
+        recent_score = compute_priority_score("belief", recent_record)
+        old_score = compute_priority_score("belief", old_record)
+
+        assert recent_score > old_score
+
+    def test_half_life_90_days(self):
+        """At 90 days, emotional salience should be halved."""
+        now = datetime.now(timezone.utc)
+        fresh_record = {
+            "confidence": 0.8,
+            "emotional_valence": 1.0,
+            "emotional_arousal": 1.0,
+            "created_at": now,
+        }
+        half_life_record = {
+            "confidence": 0.8,
+            "emotional_valence": 1.0,
+            "emotional_arousal": 1.0,
+            "created_at": now - timedelta(days=90),
+        }
+
+        fresh_score = compute_priority_score("belief", fresh_record)
+        half_life_score = compute_priority_score("belief", half_life_record)
+
+        # At 90 days, time_decay = 90/(90+90) = 0.5
+        # So emotional_salience at half_life should be half of fresh
+        # The difference in total score should reflect 10% * (1.0 - 0.5) = 0.05
+        # Allow some tolerance
+        no_emotion_score = compute_priority_score(
+            "belief", {"confidence": 0.8, "emotional_valence": 0.0, "emotional_arousal": 0.0}
+        )
+
+        fresh_boost = fresh_score - no_emotion_score
+        half_boost = half_life_score - no_emotion_score
+
+        # half_boost should be approximately half of fresh_boost
+        assert abs(half_boost - fresh_boost / 2) < 0.01
+
+    def test_episode_emotional_salience(self):
+        """Episodes with emotional data should get the boost too."""
+        base_episode = {
+            "emotional_valence": 0.0,
+            "emotional_arousal": 0.0,
+        }
+        emotional_episode = {
+            "emotional_valence": 0.8,
+            "emotional_arousal": 0.9,
+            "created_at": datetime.now(timezone.utc),
+        }
+
+        base_score = compute_priority_score("episode", base_episode)
+        emotional_score = compute_priority_score("episode", emotional_episode)
+
+        assert emotional_score > base_score
+
+    def test_zero_arousal_no_boost(self):
+        """High valence but zero arousal should produce no emotional boost."""
+        record = {
+            "confidence": 0.8,
+            "emotional_valence": 1.0,
+            "emotional_arousal": 0.0,
+        }
+        no_emotion_record = {
+            "confidence": 0.8,
+            "emotional_valence": 0.0,
+            "emotional_arousal": 0.0,
+        }
+
+        score = compute_priority_score("belief", record)
+        no_emotion_score = compute_priority_score("belief", no_emotion_record)
+
+        assert abs(score - no_emotion_score) < 0.001
+
+    def test_belief_scope_boost_still_works(self):
+        """Self-belief scope boost should still apply on top of emotional salience."""
+        world_belief = {
+            "confidence": 0.8,
+            "belief_scope": "world",
+            "emotional_valence": 0.5,
+            "emotional_arousal": 0.5,
+            "created_at": datetime.now(timezone.utc),
+        }
+        self_belief = {
+            "confidence": 0.8,
+            "belief_scope": "self",
+            "emotional_valence": 0.5,
+            "emotional_arousal": 0.5,
+            "created_at": datetime.now(timezone.utc),
+        }
+
+        world_score = compute_priority_score("belief", world_belief)
+        self_score = compute_priority_score("belief", self_belief)
+
+        assert self_score > world_score
+        assert abs(self_score - world_score - 0.05) < 0.001
+
+    def test_string_created_at(self):
+        """String ISO timestamps should be parsed correctly."""
+        record = {
+            "confidence": 0.8,
+            "emotional_valence": 0.9,
+            "emotional_arousal": 0.8,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        }
+        score = compute_priority_score("belief", record)
+        assert 0.0 <= score <= 1.0
+
+    def test_missing_created_at_uses_zero_days(self):
+        """Missing created_at should default to days_since=0 (max salience)."""
+        with_time = {
+            "confidence": 0.8,
+            "emotional_valence": 0.9,
+            "emotional_arousal": 0.8,
+            "created_at": datetime.now(timezone.utc),
+        }
+        without_time = {
+            "confidence": 0.8,
+            "emotional_valence": 0.9,
+            "emotional_arousal": 0.8,
+        }
+
+        score_with = compute_priority_score("belief", with_time)
+        score_without = compute_priority_score("belief", without_time)
+
+        # Should be nearly identical (both at ~0 days since)
+        assert abs(score_with - score_without) < 0.01


### PR DESCRIPTION
## Summary
- Add emotional salience factor (10% weight) to `compute_priority_score()` using `abs(valence) * arousal * time_decay` with a 90-day half-life, so emotionally significant episodes remain cognitively available longer
- Add epoch staleness as 7th anxiety dimension (10% weight) with thresholds: Calm (<6mo), Aware (6-12mo), Elevated (12-18mo), High (>18mo); gracefully degrades when epochs feature is not in use
- Reweight priority formula to 55% type weight + 35% record factors + 10% emotional salience (was 60/40)
- Update CLI to display epoch staleness dimension

## Test plan
- [x] 10 new tests for emotional salience in `test_emotional_salience.py`
- [x] 5 new tests for epoch staleness in `test_anxiety.py`
- [x] All 88 anxiety-related tests pass
- [x] Full test suite: 1749 passed (11 pre-existing failures unchanged)

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)