### PR TITLE
Add fractal summarization: agent_summaries memory type (#176)

### DIFF
--- a/kernle/cli/__main__.py
+++ b/kernle/cli/__main__.py
@@ -43,6 +43,7 @@ from kernle.cli.commands import (
     cmd_stats,
     cmd_subscription,
     cmd_suggestions,
+    cmd_summary,
 )
 from kernle.cli.commands.agent import cmd_agent
 from kernle.cli.commands.import_cmd import cmd_import, cmd_migrate
@@ -3847,6 +3848,41 @@ Typical usage in a memoryFlush hook:
     epoch_current = epoch_sub.add_parser("current", help="Show current active epoch")
     epoch_current.add_argument("--json", "-j", action="store_true", help="Output as JSON")
 
+    # summary (fractal summarization)
+    p_summary = subparsers.add_parser("summary", help="Fractal summarization")
+    summary_sub = p_summary.add_subparsers(dest="summary_action", required=True)
+
+    # kernle summary write --scope SCOPE --content TEXT --period-start DATE --period-end DATE
+    summary_write = summary_sub.add_parser("write", help="Create a summary")
+    summary_write.add_argument(
+        "--scope",
+        "-s",
+        required=True,
+        choices=["month", "quarter", "year", "decade", "epoch"],
+        help="Temporal scope",
+    )
+    summary_write.add_argument("--content", "-c", required=True, help="Summary content")
+    summary_write.add_argument("--period-start", required=True, help="Period start (ISO date)")
+    summary_write.add_argument("--period-end", required=True, help="Period end (ISO date)")
+    summary_write.add_argument("--theme", "-t", action="append", help="Key theme (repeatable)")
+    summary_write.add_argument("--epoch-id", help="Associated epoch ID")
+    summary_write.add_argument("--json", "-j", action="store_true", help="Output as JSON")
+
+    # kernle summary list [--scope SCOPE]
+    summary_list = summary_sub.add_parser("list", help="List summaries")
+    summary_list.add_argument(
+        "--scope",
+        "-s",
+        choices=["month", "quarter", "year", "decade", "epoch"],
+        help="Filter by scope",
+    )
+    summary_list.add_argument("--json", "-j", action="store_true", help="Output as JSON")
+
+    # kernle summary show <id>
+    summary_show = summary_sub.add_parser("show", help="Show summary details")
+    summary_show.add_argument("id", help="Summary ID")
+    summary_show.add_argument("--json", "-j", action="store_true", help="Output as JSON")
+
     # sync (local-to-cloud synchronization)
     p_sync = subparsers.add_parser("sync", help="Sync with remote backend")
     sync_sub = p_sync.add_subparsers(dest="sync_action", required=True)
@@ -4433,6 +4469,8 @@ Beliefs already present in the agent's memory will be skipped.
             cmd_forget(args, k)
         elif args.command == "epoch":
             cmd_epoch(args, k)
+        elif args.command == "summary":
+            cmd_summary(args, k)
         elif args.command == "playbook":
             cmd_playbook(args, k)
         elif args.command == "raw":

--- a/kernle/cli/commands/__init__.py
+++ b/kernle/cli/commands/__init__.py
@@ -23,6 +23,7 @@ from kernle.cli.commands.raw import cmd_raw, resolve_raw_id
 from kernle.cli.commands.stats import cmd_stats
 from kernle.cli.commands.subscription import cmd_subscription
 from kernle.cli.commands.suggestions import cmd_suggestions, resolve_suggestion_id
+from kernle.cli.commands.summary import cmd_summary
 
 __all__ = [
     "cmd_anxiety",
@@ -45,6 +46,7 @@ __all__ = [
     "cmd_stats",
     "cmd_suggestions",
     "cmd_subscription",
+    "cmd_summary",
     "resolve_raw_id",
     "resolve_suggestion_id",
 ]

--- a/kernle/cli/commands/summary.py
+++ b/kernle/cli/commands/summary.py
@@ -1,0 +1,129 @@
+"""Summary (fractal summarization) commands for Kernle CLI."""
+
+import json
+from typing import TYPE_CHECKING
+
+from kernle.cli.commands.helpers import validate_input
+
+if TYPE_CHECKING:
+    from kernle import Kernle
+
+
+def cmd_summary(args, k: "Kernle"):
+    """Handle summary subcommands."""
+    if args.summary_action == "write":
+        scope = args.scope
+        content = validate_input(args.content, "content", 10000)
+        period_start = validate_input(args.period_start, "period_start", 30)
+        period_end = validate_input(args.period_end, "period_end", 30)
+        key_themes = args.theme if hasattr(args, "theme") and args.theme else None
+        epoch_id = getattr(args, "epoch_id", None)
+
+        try:
+            summary_id = k.summary_save(
+                content=content,
+                scope=scope,
+                period_start=period_start,
+                period_end=period_end,
+                key_themes=key_themes,
+                epoch_id=epoch_id,
+            )
+            if args.json:
+                print(json.dumps({"summary_id": summary_id, "scope": scope}))
+            else:
+                print(f"Summary created ({scope})")
+                print(f"  ID: {summary_id[:8]}...")
+                print(f"  Period: {period_start} to {period_end}")
+                if key_themes:
+                    print(f"  Themes: {', '.join(key_themes)}")
+        except ValueError as e:
+            print(f"Error: {e}")
+
+    elif args.summary_action == "list":
+        scope = getattr(args, "scope", None)
+        try:
+            summaries = k.summary_list(scope=scope)
+        except ValueError as e:
+            print(f"Error: {e}")
+            return
+
+        if args.json:
+            data = [
+                {
+                    "id": s.id,
+                    "scope": s.scope,
+                    "period_start": s.period_start,
+                    "period_end": s.period_end,
+                    "content": s.content[:200] + "..." if len(s.content) > 200 else s.content,
+                    "key_themes": s.key_themes,
+                    "supersedes": s.supersedes,
+                    "created_at": s.created_at.isoformat() if s.created_at else None,
+                }
+                for s in summaries
+            ]
+            print(json.dumps(data, indent=2, default=str))
+        else:
+            if not summaries:
+                print("No summaries found.")
+                return
+
+            print("Summaries")
+            print("=" * 60)
+
+            for s in summaries:
+                preview = s.content[:80] + "..." if len(s.content) > 80 else s.content
+                created = s.created_at.strftime("%Y-%m-%d") if s.created_at else "unknown"
+
+                print(f"\n  [{s.scope}] {s.period_start} to {s.period_end}")
+                print(f"      ID: {s.id[:8]}...")
+                print(f"      {preview}")
+                if s.key_themes:
+                    print(f"      Themes: {', '.join(s.key_themes)}")
+                if s.supersedes:
+                    print(f"      Supersedes: {len(s.supersedes)} summaries")
+                print(f"      Created: {created}")
+
+    elif args.summary_action == "show":
+        summary_id = validate_input(args.id, "summary_id", 100)
+        summary = k.summary_get(summary_id)
+
+        if not summary:
+            print(f"Summary {summary_id[:8]}... not found.")
+            return
+
+        if args.json:
+            data = {
+                "id": summary.id,
+                "scope": summary.scope,
+                "period_start": summary.period_start,
+                "period_end": summary.period_end,
+                "content": summary.content,
+                "key_themes": summary.key_themes,
+                "supersedes": summary.supersedes,
+                "epoch_id": summary.epoch_id,
+                "is_protected": summary.is_protected,
+                "created_at": summary.created_at.isoformat() if summary.created_at else None,
+                "updated_at": summary.updated_at.isoformat() if summary.updated_at else None,
+            }
+            print(json.dumps(data, indent=2, default=str))
+        else:
+            print(f"Summary [{summary.scope}]: {summary.period_start} to {summary.period_end}")
+            print("=" * 60)
+            print(f"  ID: {summary.id}")
+            print(f"  Protected: {'yes' if summary.is_protected else 'no'}")
+            if summary.epoch_id:
+                print(f"  Epoch: {summary.epoch_id[:8]}...")
+            if summary.key_themes:
+                print(f"  Themes: {', '.join(summary.key_themes)}")
+            if summary.supersedes:
+                print(f"  Supersedes: {len(summary.supersedes)} summaries")
+                for sid in summary.supersedes:
+                    print(f"    - {sid[:8]}...")
+            print()
+            print(summary.content)
+
+    else:
+        print("Usage: kernle summary {write|list|show}")
+        print("  write --scope SCOPE --content TEXT --period-start DATE --period-end DATE")
+        print("  list [--scope SCOPE]")
+        print("  show <id>")

--- a/kernle/core.py
+++ b/kernle/core.py
@@ -40,6 +40,7 @@ from kernle.storage import (
     Goal,
     Note,
     Relationship,
+    Summary,
     TrustAssessment,
     Value,
     get_storage,
@@ -78,10 +79,15 @@ TOKEN_ESTIMATION_SAFETY_MARGIN = 1.3
 MEMORY_TYPE_PRIORITIES = {
     "checkpoint": 1.00,  # Always loaded first
     "value": 0.90,
+    "summary_decade": 0.95,
+    "summary_epoch": 0.85,
+    "summary_year": 0.80,
     "belief": 0.70,
     "goal": 0.65,
     "drive": 0.60,
+    "summary_quarter": 0.50,
     "episode": 0.40,
+    "summary_month": 0.35,
     "note": 0.35,
     "relationship": 0.30,
 }
@@ -306,6 +312,9 @@ def compute_priority_score(memory_type: str, record: Any) -> float:
             else record.get("sentiment", 0.0)
         )
         type_factor = (sentiment + 1) / 2  # Normalize -1..1 to 0..1
+    elif memory_type.startswith("summary_"):
+        # Summaries use scope-based priority directly
+        type_factor = 0.8
     else:
         type_factor = 0.5
 
@@ -692,6 +701,19 @@ class Kernle(
             for r in batched.get("relationships", []):
                 candidates.append((compute_priority_score("relationship", r), "relationship", r))
 
+            # Summaries - with supersession logic
+            all_summaries = self._storage.list_summaries(self.agent_id)
+            # Collect IDs superseded by higher-scope summaries
+            superseded_ids = set()
+            for s in all_summaries:
+                if s.supersedes:
+                    superseded_ids.update(s.supersedes)
+            # Only include non-superseded summaries
+            for s in all_summaries:
+                if s.id not in superseded_ids:
+                    scope_key = f"summary_{s.scope}"
+                    candidates.append((compute_priority_score(scope_key, s), "summary", s))
+
             # Sort by priority descending
             candidates.sort(key=lambda x: x[0], reverse=True)
 
@@ -708,6 +730,7 @@ class Kernle(
                 "episodes": [],
                 "notes": [],
                 "relationships": [],
+                "summaries": [],
             }
 
             selected_indices = set()
@@ -727,6 +750,8 @@ class Kernle(
                     text = record.content
                 elif memory_type == "relationship":
                     text = f"{record.entity_name}: {record.notes or ''}"
+                elif memory_type == "summary":
+                    text = f"[{record.scope}] {record.content}"
                 else:
                     text = str(record)
 
@@ -753,6 +778,8 @@ class Kernle(
                         selected["notes"].append(record)
                     elif memory_type == "relationship":
                         selected["relationships"].append(record)
+                    elif memory_type == "summary":
+                        selected["summaries"].append(record)
 
                     remaining_budget -= tokens
                     selected_count += 1
@@ -878,6 +905,21 @@ class Kernle(
                         or datetime.min.replace(tzinfo=timezone.utc),
                         reverse=True,
                     )
+                ],
+                "summaries": [
+                    {
+                        "id": s.id,
+                        "scope": s.scope,
+                        "period_start": s.period_start,
+                        "period_end": s.period_end,
+                        "content": (
+                            truncate_at_word_boundary(s.content, max_item_chars)
+                            if truncate
+                            else s.content
+                        ),
+                        "key_themes": s.key_themes,
+                    }
+                    for s in selected["summaries"]
                 ],
                 "_meta": {
                     "budget_used": budget - remaining_budget,
@@ -2946,6 +2988,70 @@ class Kernle(
         """Get a specific epoch by ID."""
         epoch_id = self._validate_string_input(epoch_id, "epoch_id", 100)
         return self._storage.get_epoch(epoch_id)
+
+    # === Summaries (Fractal Summarization) ===
+
+    def summary_save(
+        self,
+        content: str,
+        scope: str,
+        period_start: str,
+        period_end: str,
+        key_themes: Optional[List[str]] = None,
+        supersedes: Optional[List[str]] = None,
+        epoch_id: Optional[str] = None,
+    ) -> str:
+        """Create or update a summary.
+
+        Args:
+            content: Agent-written narrative compression
+            scope: Temporal scope ('month', 'quarter', 'year', 'decade', 'epoch')
+            period_start: Start of the period (ISO date)
+            period_end: End of the period (ISO date)
+            key_themes: Key themes/topics covered
+            supersedes: IDs of lower-scope summaries this covers
+            epoch_id: Associated epoch ID
+
+        Returns:
+            The summary ID
+        """
+
+        valid_scopes = ("month", "quarter", "year", "decade", "epoch")
+        if scope not in valid_scopes:
+            raise ValueError(f"scope must be one of: {', '.join(valid_scopes)}")
+
+        content = self._validate_string_input(content, "content", 10000)
+        period_start = self._validate_string_input(period_start, "period_start", 30)
+        period_end = self._validate_string_input(period_end, "period_end", 30)
+
+        summary = Summary(
+            id=str(uuid.uuid4()),
+            agent_id=self.agent_id,
+            scope=scope,
+            period_start=period_start,
+            period_end=period_end,
+            epoch_id=epoch_id,
+            content=content,
+            key_themes=key_themes,
+            supersedes=supersedes,
+            is_protected=True,
+            created_at=datetime.now(timezone.utc),
+        )
+
+        return self._storage.save_summary(summary)
+
+    def summary_get(self, summary_id: str):
+        """Get a specific summary by ID."""
+        summary_id = self._validate_string_input(summary_id, "summary_id", 100)
+        return self._storage.get_summary(summary_id)
+
+    def summary_list(self, scope: Optional[str] = None):
+        """Get all summaries, optionally filtered by scope."""
+        if scope:
+            valid_scopes = ("month", "quarter", "year", "decade", "epoch")
+            if scope not in valid_scopes:
+                raise ValueError(f"scope must be one of: {', '.join(valid_scopes)}")
+        return self._storage.list_summaries(self.agent_id, scope=scope)
 
     def update_belief(
         self,

--- a/kernle/storage/__init__.py
+++ b/kernle/storage/__init__.py
@@ -38,6 +38,7 @@ from .base import (
     SearchResult,
     SourceType,
     Storage,
+    Summary,
     SyncConflict,
     SyncResult,
     SyncStatus,
@@ -160,6 +161,7 @@ __all__ = [
     "MemorySuggestion",
     "TrustAssessment",
     "Epoch",
+    "Summary",
     "DiagnosticSession",
     "DiagnosticReport",
     # Dynamic trust constants

--- a/kernle/storage/base.py
+++ b/kernle/storage/base.py
@@ -663,6 +663,34 @@ class DiagnosticReport:
     deleted: bool = False
 
 
+@dataclass
+class Summary:
+    """An agent summary - fractal narrative compression across time scales.
+
+    Summaries provide hierarchical compression of the agent's experience
+    at different temporal scopes: month, quarter, year, decade, epoch.
+    Higher-scope summaries supersede lower-scope ones, enabling efficient
+    memory loading by skipping covered lower-scope summaries.
+    """
+
+    id: str
+    agent_id: str
+    scope: str  # 'month' | 'quarter' | 'year' | 'decade' | 'epoch'
+    period_start: str  # ISO date string
+    period_end: str  # ISO date string
+    content: str  # Agent-written narrative compression
+    epoch_id: Optional[str] = None
+    key_themes: Optional[List[str]] = None  # JSON array
+    supersedes: Optional[List[str]] = None  # JSON array of lower-scope summary IDs
+    is_protected: bool = True  # Never forgotten
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+    # Sync metadata
+    cloud_synced_at: Optional[datetime] = None
+    version: int = 1
+    deleted: bool = False
+
+
 TRUST_THRESHOLDS: Dict[str, float] = {
     "suggest_belief": 0.3,
     "contradict_world_belief": 0.6,
@@ -1244,6 +1272,20 @@ class Storage(Protocol):
             True if deleted, False if not found
         """
         return False
+
+    # === Summaries (Fractal Summarization) ===
+
+    def save_summary(self, summary: "Summary") -> str:
+        """Save a summary. Returns the summary ID."""
+        return summary.id
+
+    def get_summary(self, summary_id: str) -> Optional["Summary"]:
+        """Get a specific summary by ID."""
+        return None
+
+    def list_summaries(self, agent_id: str, scope: Optional[str] = None) -> List["Summary"]:
+        """Get summaries, optionally filtered by scope."""
+        return []
 
     # === Epochs ===
 

--- a/kernle/storage/sqlite.py
+++ b/kernle/storage/sqlite.py
@@ -33,6 +33,7 @@ from .base import (
     Relationship,
     RelationshipHistoryEntry,
     SearchResult,
+    Summary,
     SyncConflict,
     SyncResult,
     TrustAssessment,
@@ -53,7 +54,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Schema version for migrations
-SCHEMA_VERSION = 20  # Add diagnostic sessions and reports tables
+SCHEMA_VERSION = 21  # Add agent_summaries table (fractal summarization)
 
 # Maximum size for merged arrays during sync to prevent resource exhaustion
 MAX_SYNC_ARRAY_SIZE = 500
@@ -135,6 +136,7 @@ ALLOWED_TABLES = frozenset(
         "agent_epochs",  # KEP v3 temporal epochs
         "agent_diagnostic_sessions",  # KEP v3 diagnostic sessions
         "agent_diagnostic_reports",  # KEP v3 diagnostic reports
+        "agent_summaries",  # KEP v3 fractal summarization
     }
 )
 
@@ -826,6 +828,28 @@ CREATE TABLE IF NOT EXISTS agent_diagnostic_reports (
 );
 CREATE INDEX IF NOT EXISTS idx_diag_reports_agent ON agent_diagnostic_reports(agent_id);
 CREATE INDEX IF NOT EXISTS idx_diag_reports_session ON agent_diagnostic_reports(session_id);
+
+-- Agent summaries (fractal summarization)
+CREATE TABLE IF NOT EXISTS agent_summaries (
+    id TEXT PRIMARY KEY,
+    agent_id TEXT NOT NULL,
+    scope TEXT NOT NULL,                         -- 'month' | 'quarter' | 'year' | 'decade' | 'epoch'
+    period_start TEXT NOT NULL,
+    period_end TEXT NOT NULL,
+    epoch_id TEXT,
+    content TEXT NOT NULL,                        -- Agent-written narrative compression
+    key_themes TEXT,                              -- JSON array
+    supersedes TEXT,                              -- JSON array of lower-scope summary IDs this covers
+    is_protected INTEGER DEFAULT 1,              -- Never forgotten
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    cloud_synced_at TEXT,
+    version INTEGER DEFAULT 1,
+    deleted INTEGER DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_summaries_agent ON agent_summaries(agent_id);
+CREATE INDEX IF NOT EXISTS idx_summaries_scope ON agent_summaries(agent_id, scope);
+CREATE INDEX IF NOT EXISTS idx_summaries_period ON agent_summaries(agent_id, period_start, period_end);
 
 -- Embedding metadata (tracks what's been embedded)
 CREATE TABLE IF NOT EXISTS embedding_meta (
@@ -2034,6 +2058,41 @@ class SQLiteStorage:
                     except Exception as e:
                         if "duplicate column" not in str(e).lower():
                             logger.warning(f"Failed to add epoch_id to {tbl}: {e}")
+
+        # v21: Add agent_summaries table (fractal summarization)
+        if "agent_summaries" not in table_names:
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS agent_summaries (
+                    id TEXT PRIMARY KEY,
+                    agent_id TEXT NOT NULL,
+                    scope TEXT NOT NULL,
+                    period_start TEXT NOT NULL,
+                    period_end TEXT NOT NULL,
+                    epoch_id TEXT,
+                    content TEXT NOT NULL,
+                    key_themes TEXT,
+                    supersedes TEXT,
+                    is_protected INTEGER DEFAULT 1,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    cloud_synced_at TEXT,
+                    version INTEGER DEFAULT 1,
+                    deleted INTEGER DEFAULT 0
+                )
+            """)
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_summaries_agent " "ON agent_summaries(agent_id)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_summaries_scope "
+                "ON agent_summaries(agent_id, scope)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_summaries_period "
+                "ON agent_summaries(agent_id, period_start, period_end)"
+            )
+            logger.info("Created agent_summaries table")
+            conn.commit()
 
         if "agent_epochs" not in table_names:
             conn.execute("""
@@ -4154,6 +4213,94 @@ class SQLiteStorage:
             key_goal_ids=self._from_json(self._safe_get(row, "key_goal_ids", None)),
             dominant_drive_ids=self._from_json(self._safe_get(row, "dominant_drive_ids", None)),
             local_updated_at=self._parse_datetime(row["local_updated_at"]),
+            cloud_synced_at=self._parse_datetime(self._safe_get(row, "cloud_synced_at", None)),
+            version=row["version"],
+            deleted=bool(row["deleted"]),
+        )
+
+    # === Summaries (Fractal Summarization) ===
+
+    def save_summary(self, summary: Summary) -> str:
+        """Save a summary. Returns the summary ID."""
+        if not summary.id:
+            summary.id = str(uuid.uuid4())
+
+        now = self._now()
+
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO agent_summaries
+                (id, agent_id, scope, period_start, period_end, epoch_id,
+                 content, key_themes, supersedes, is_protected,
+                 created_at, updated_at, cloud_synced_at, version, deleted)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+                (
+                    summary.id,
+                    self.agent_id,
+                    summary.scope,
+                    summary.period_start,
+                    summary.period_end,
+                    summary.epoch_id,
+                    summary.content,
+                    self._to_json(summary.key_themes),
+                    self._to_json(summary.supersedes),
+                    1 if summary.is_protected else 0,
+                    summary.created_at.isoformat() if summary.created_at else now,
+                    now,
+                    summary.cloud_synced_at.isoformat() if summary.cloud_synced_at else None,
+                    summary.version,
+                    1 if summary.deleted else 0,
+                ),
+            )
+            conn.commit()
+
+        return summary.id
+
+    def get_summary(self, summary_id: str) -> Optional[Summary]:
+        """Get a specific summary by ID."""
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM agent_summaries WHERE id = ? AND agent_id = ? AND deleted = 0",
+                (summary_id, self.agent_id),
+            ).fetchone()
+
+        return self._row_to_summary(row) if row else None
+
+    def list_summaries(self, agent_id: str, scope: Optional[str] = None) -> List[Summary]:
+        """Get summaries, optionally filtered by scope."""
+        with self._connect() as conn:
+            if scope:
+                rows = conn.execute(
+                    "SELECT * FROM agent_summaries WHERE agent_id = ? AND scope = ? AND deleted = 0 "
+                    "ORDER BY period_start DESC",
+                    (self.agent_id, scope),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    "SELECT * FROM agent_summaries WHERE agent_id = ? AND deleted = 0 "
+                    "ORDER BY period_start DESC",
+                    (self.agent_id,),
+                ).fetchall()
+
+        return [self._row_to_summary(row) for row in rows]
+
+    def _row_to_summary(self, row: sqlite3.Row) -> Summary:
+        """Convert a row to a Summary."""
+        return Summary(
+            id=row["id"],
+            agent_id=row["agent_id"],
+            scope=row["scope"],
+            period_start=row["period_start"],
+            period_end=row["period_end"],
+            epoch_id=self._safe_get(row, "epoch_id", None),
+            content=row["content"],
+            key_themes=self._from_json(self._safe_get(row, "key_themes", None)),
+            supersedes=self._from_json(self._safe_get(row, "supersedes", None)),
+            is_protected=bool(self._safe_get(row, "is_protected", 1)),
+            created_at=self._parse_datetime(row["created_at"]),
+            updated_at=self._parse_datetime(row["updated_at"]),
             cloud_synced_at=self._parse_datetime(self._safe_get(row, "cloud_synced_at", None)),
             version=row["version"],
             deleted=bool(row["deleted"]),

--- a/tests/test_diagnostic_sessions.py
+++ b/tests/test_diagnostic_sessions.py
@@ -803,10 +803,10 @@ class TestCLISessionCommands:
 class TestSchemaVersion:
     """Tests that schema version is correctly updated."""
 
-    def test_schema_version_is_20(self):
+    def test_schema_version_is_21(self):
         from kernle.storage.sqlite import SCHEMA_VERSION
 
-        assert SCHEMA_VERSION == 20
+        assert SCHEMA_VERSION == 21
 
     def test_tables_in_allowed_list(self):
         from kernle.storage.sqlite import ALLOWED_TABLES

--- a/tests/test_fractal_summarization.py
+++ b/tests/test_fractal_summarization.py
@@ -1,0 +1,389 @@
+"""Tests for fractal summarization (agent_summaries memory type).
+
+Covers:
+- Storage: save, get, list
+- Core: create, list, get
+- Priority scoring per scope
+- Supersession logic in load()
+- is_protected prevents forgetting
+"""
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from kernle import Kernle
+from kernle.core import MEMORY_TYPE_PRIORITIES, compute_priority_score
+from kernle.storage.base import Summary
+
+
+@pytest.fixture
+def agent_id():
+    return f"test-agent-{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture
+def k(agent_id):
+    return Kernle(agent_id=agent_id)
+
+
+# === Dataclass Tests ===
+
+
+class TestSummaryDataclass:
+    def test_summary_defaults(self):
+        s = Summary(
+            id="s1",
+            agent_id="agent1",
+            scope="quarter",
+            period_start="2025-01-01",
+            period_end="2025-03-31",
+            content="Q1 summary content",
+        )
+        assert s.is_protected is True
+        assert s.version == 1
+        assert s.deleted is False
+        assert s.key_themes is None
+        assert s.supersedes is None
+        assert s.epoch_id is None
+
+    def test_summary_with_all_fields(self):
+        now = datetime.now(timezone.utc)
+        s = Summary(
+            id="s2",
+            agent_id="agent1",
+            scope="year",
+            period_start="2025-01-01",
+            period_end="2025-12-31",
+            content="Annual summary",
+            epoch_id="epoch-1",
+            key_themes=["growth", "learning"],
+            supersedes=["s1-q1", "s1-q2", "s1-q3", "s1-q4"],
+            is_protected=True,
+            created_at=now,
+            updated_at=now,
+        )
+        assert s.scope == "year"
+        assert len(s.supersedes) == 4
+        assert s.key_themes == ["growth", "learning"]
+
+
+# === Storage Tests ===
+
+
+class TestStorageSummary:
+    def test_save_and_get_summary(self, k):
+        summary_id = k.summary_save(
+            content="Test summary content for the quarter",
+            scope="quarter",
+            period_start="2025-01-01",
+            period_end="2025-03-31",
+            key_themes=["testing", "development"],
+        )
+
+        assert summary_id is not None
+        assert len(summary_id) > 0
+
+        # Retrieve and verify
+        summary = k.summary_get(summary_id)
+        assert summary is not None
+        assert summary.id == summary_id
+        assert summary.scope == "quarter"
+        assert summary.period_start == "2025-01-01"
+        assert summary.period_end == "2025-03-31"
+        assert summary.content == "Test summary content for the quarter"
+        assert summary.key_themes == ["testing", "development"]
+        assert summary.is_protected is True
+
+    def test_get_nonexistent_summary(self, k):
+        result = k.summary_get("nonexistent-id")
+        assert result is None
+
+    def test_list_summaries_all(self, k):
+        # Create summaries at different scopes
+        k.summary_save(
+            content="Monthly summary",
+            scope="month",
+            period_start="2025-01-01",
+            period_end="2025-01-31",
+        )
+        k.summary_save(
+            content="Quarterly summary",
+            scope="quarter",
+            period_start="2025-01-01",
+            period_end="2025-03-31",
+        )
+        k.summary_save(
+            content="Yearly summary",
+            scope="year",
+            period_start="2025-01-01",
+            period_end="2025-12-31",
+        )
+
+        summaries = k.summary_list()
+        assert len(summaries) == 3
+
+    def test_list_summaries_by_scope(self, k):
+        k.summary_save(
+            content="Month 1",
+            scope="month",
+            period_start="2025-01-01",
+            period_end="2025-01-31",
+        )
+        k.summary_save(
+            content="Month 2",
+            scope="month",
+            period_start="2025-02-01",
+            period_end="2025-02-28",
+        )
+        k.summary_save(
+            content="Quarter 1",
+            scope="quarter",
+            period_start="2025-01-01",
+            period_end="2025-03-31",
+        )
+
+        month_summaries = k.summary_list(scope="month")
+        assert len(month_summaries) == 2
+
+        quarter_summaries = k.summary_list(scope="quarter")
+        assert len(quarter_summaries) == 1
+
+    def test_save_summary_with_epoch_id(self, k):
+        epoch_id = k.epoch_create(name="test-epoch")
+        summary_id = k.summary_save(
+            content="Epoch summary",
+            scope="epoch",
+            period_start="2025-01-01",
+            period_end="2025-06-30",
+            epoch_id=epoch_id,
+        )
+
+        summary = k.summary_get(summary_id)
+        assert summary.epoch_id == epoch_id
+        assert summary.scope == "epoch"
+
+
+# === Core API Tests ===
+
+
+class TestCoreSummary:
+    def test_summary_save_validates_scope(self, k):
+        with pytest.raises(ValueError, match="scope must be one of"):
+            k.summary_save(
+                content="Invalid",
+                scope="invalid_scope",
+                period_start="2025-01-01",
+                period_end="2025-01-31",
+            )
+
+    def test_summary_save_validates_content(self, k):
+        # Content too long (>10000)
+        with pytest.raises(ValueError):
+            k.summary_save(
+                content="x" * 10001,
+                scope="month",
+                period_start="2025-01-01",
+                period_end="2025-01-31",
+            )
+
+    def test_summary_list_validates_scope(self, k):
+        with pytest.raises(ValueError, match="scope must be one of"):
+            k.summary_list(scope="invalid")
+
+    def test_summary_list_no_scope_filter(self, k):
+        # Should not raise with None scope
+        result = k.summary_list(scope=None)
+        assert isinstance(result, list)
+
+    def test_valid_scopes(self, k):
+        for scope in ("month", "quarter", "year", "decade", "epoch"):
+            sid = k.summary_save(
+                content=f"Summary for {scope}",
+                scope=scope,
+                period_start="2025-01-01",
+                period_end="2025-12-31",
+            )
+            assert sid is not None
+
+    def test_summary_with_supersedes(self, k):
+        # Create lower-scope summaries
+        m1 = k.summary_save(
+            content="January summary",
+            scope="month",
+            period_start="2025-01-01",
+            period_end="2025-01-31",
+        )
+        m2 = k.summary_save(
+            content="February summary",
+            scope="month",
+            period_start="2025-02-01",
+            period_end="2025-02-28",
+        )
+        m3 = k.summary_save(
+            content="March summary",
+            scope="month",
+            period_start="2025-03-01",
+            period_end="2025-03-31",
+        )
+
+        # Create higher-scope summary that supersedes them
+        q1 = k.summary_save(
+            content="Q1 summary covering all three months",
+            scope="quarter",
+            period_start="2025-01-01",
+            period_end="2025-03-31",
+            supersedes=[m1, m2, m3],
+        )
+
+        summary = k.summary_get(q1)
+        assert summary.supersedes == [m1, m2, m3]
+
+
+# === Priority Scoring Tests ===
+
+
+class TestPriorityScoring:
+    def test_scope_priorities_in_type_map(self):
+        assert "summary_decade" in MEMORY_TYPE_PRIORITIES
+        assert "summary_epoch" in MEMORY_TYPE_PRIORITIES
+        assert "summary_year" in MEMORY_TYPE_PRIORITIES
+        assert "summary_quarter" in MEMORY_TYPE_PRIORITIES
+        assert "summary_month" in MEMORY_TYPE_PRIORITIES
+
+    def test_scope_priority_ordering(self):
+        """Higher scopes should have higher priority."""
+        assert MEMORY_TYPE_PRIORITIES["summary_decade"] > MEMORY_TYPE_PRIORITIES["summary_epoch"]
+        assert MEMORY_TYPE_PRIORITIES["summary_epoch"] > MEMORY_TYPE_PRIORITIES["summary_year"]
+        assert MEMORY_TYPE_PRIORITIES["summary_year"] > MEMORY_TYPE_PRIORITIES["summary_quarter"]
+        assert MEMORY_TYPE_PRIORITIES["summary_quarter"] > MEMORY_TYPE_PRIORITIES["summary_month"]
+
+    def test_decade_summary_higher_than_values(self):
+        assert MEMORY_TYPE_PRIORITIES["summary_decade"] > MEMORY_TYPE_PRIORITIES["value"]
+
+    def test_compute_priority_for_summary(self):
+        s = Summary(
+            id="s1",
+            agent_id="a1",
+            scope="year",
+            period_start="2025-01-01",
+            period_end="2025-12-31",
+            content="Year summary",
+        )
+        score = compute_priority_score("summary_year", s)
+        assert 0.0 < score <= 1.0
+
+    def test_different_scopes_different_scores(self):
+        s = Summary(
+            id="s1",
+            agent_id="a1",
+            scope="decade",
+            period_start="2020-01-01",
+            period_end="2029-12-31",
+            content="Decade summary",
+        )
+        decade_score = compute_priority_score("summary_decade", s)
+        month_score = compute_priority_score("summary_month", s)
+        assert decade_score > month_score
+
+
+# === Supersession Logic Tests ===
+
+
+class TestSupersessionLogic:
+    def test_superseded_summaries_excluded_from_load(self, k):
+        """When a higher-scope summary supersedes lower ones, load() should skip the lower ones."""
+        # Create monthly summaries
+        m1 = k.summary_save(
+            content="January: Focused on onboarding and learning the codebase",
+            scope="month",
+            period_start="2025-01-01",
+            period_end="2025-01-31",
+        )
+        m2 = k.summary_save(
+            content="February: Started contributing to core features",
+            scope="month",
+            period_start="2025-02-01",
+            period_end="2025-02-28",
+        )
+        m3 = k.summary_save(
+            content="March: Led first project independently",
+            scope="month",
+            period_start="2025-03-01",
+            period_end="2025-03-31",
+        )
+
+        # Create quarter summary superseding the months
+        q1 = k.summary_save(
+            content="Q1: Transitioned from onboarding to independent contributor",
+            scope="quarter",
+            period_start="2025-01-01",
+            period_end="2025-03-31",
+            supersedes=[m1, m2, m3],
+        )
+
+        # Load should include the quarter summary but not the superseded months
+        result = k.load(budget=50000)
+        summaries = result.get("summaries", [])
+
+        summary_ids = {s["id"] for s in summaries}
+        assert q1 in summary_ids, "Quarter summary should be included"
+        assert m1 not in summary_ids, "Superseded month 1 should be excluded"
+        assert m2 not in summary_ids, "Superseded month 2 should be excluded"
+        assert m3 not in summary_ids, "Superseded month 3 should be excluded"
+
+    def test_non_superseded_summaries_included(self, k):
+        """Summaries not superseded by higher scope should appear in load()."""
+        m1 = k.summary_save(
+            content="April summary: new quarter",
+            scope="month",
+            period_start="2025-04-01",
+            period_end="2025-04-30",
+        )
+
+        result = k.load(budget=50000)
+        summaries = result.get("summaries", [])
+        summary_ids = {s["id"] for s in summaries}
+        assert m1 in summary_ids
+
+
+# === Protection Tests ===
+
+
+class TestSummaryProtection:
+    def test_summaries_are_protected_by_default(self, k):
+        sid = k.summary_save(
+            content="Protected summary",
+            scope="quarter",
+            period_start="2025-01-01",
+            period_end="2025-03-31",
+        )
+
+        summary = k.summary_get(sid)
+        assert summary.is_protected is True
+
+    def test_protected_summary_not_in_forgetting_candidates(self, k):
+        """Protected summaries should not appear as forgetting candidates."""
+        k.summary_save(
+            content="This should never be forgotten",
+            scope="year",
+            period_start="2025-01-01",
+            period_end="2025-12-31",
+        )
+
+        # Get forgetting candidates - summaries shouldn't be there
+        # because they are protected by default and stored in a separate table
+        candidates = k._storage.get_forgetting_candidates()
+        for candidate in candidates:
+            assert not isinstance(candidate.record, Summary)
+
+
+# === Schema Version Test ===
+
+
+class TestSchemaVersion:
+    def test_schema_version_updated(self):
+        from kernle.storage.sqlite import SCHEMA_VERSION
+
+        assert SCHEMA_VERSION == 21

--- a/tests/test_privacy_enforcement.py
+++ b/tests/test_privacy_enforcement.py
@@ -367,7 +367,7 @@ class TestSchemaMigration:
 
         with storage._connect() as conn:
             version = conn.execute("SELECT version FROM schema_version").fetchone()
-            assert version[0] == 16
+            assert version[0] == 21
 
 
 class TestAllMemoryTypes:


### PR DESCRIPTION
## Summary

Implements KEP v3 fractal summarization (GitHub issue #176) - hierarchical temporal compression for agent memory.

- **Summary dataclass** in `storage/base.py` with fields: scope (month/quarter/year/decade/epoch), period_start/end, content, key_themes, supersedes, is_protected
- **agent_summaries table** with SQLite schema v21 migration and indexes
- **Storage methods**: save_summary, get_summary, list_summaries in SQLiteStorage (with Protocol defaults in base)
- **Core API**: summary_save, summary_get, summary_list with input validation
- **Priority scoring**: scope-based priorities (decade=0.95, epoch=0.85, year=0.80, quarter=0.50, month=0.35)
- **Load integration**: summaries included in context with supersession logic - higher-scope summaries replace covered lower-scope ones
- **CLI**: `kernle summary {write|list|show}` subcommand group
- **Tests**: 23 tests covering storage, core API, priority scoring, supersession logic, and protection

## Test plan

- [x] All 23 new tests pass (`tests/test_fractal_summarization.py`)
- [x] Full test suite passes (no new regressions - 10 pre-existing failures unchanged)
- [x] Pre-commit hooks pass (ruff, black, secrets detection)
- [x] Schema version correctly bumped to 21
- [x] Migration creates agent_summaries table for existing databases

Closes #176