### PR TITLE
test: add 70% coverage threshold to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest tests/ -v --tb=short --ignore=tests/test_postgres_storage.py
+          pytest tests/ -v --tb=short --ignore=tests/test_postgres_storage.py --cov=kernle --cov-report=xml --cov-fail-under=70
 
       - name: Upload coverage (Python 3.11 only)
         if: matrix.python-version == '3.11'


### PR DESCRIPTION
## Summary
- Adds `--cov=kernle --cov-report=xml --cov-fail-under=70` to the pytest command in CI
- Prevents coverage regression by failing builds that drop below 70%
- Generates XML coverage report for codecov upload

Closes #97

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>