### PR TITLE
refactor: rename consolidate CLI command to promote

### DIFF
--- a/kernle/cli/__main__.py
+++ b/kernle/cli/__main__.py
@@ -3157,27 +3157,41 @@ def main():
     )
     p_promote.add_argument("--json", action="store_true", help="Output JSON")
 
-    # consolidate (kept as alias / legacy guided reflection)
-    p_consolidate = subparsers.add_parser("consolidate", help="Output guided reflection prompt")
+    # consolidate (deprecated alias for promote)
+    p_consolidate = subparsers.add_parser(
+        "consolidate",
+        help="(DEPRECATED: use 'promote') Promote recurring patterns into beliefs",
+    )
+    p_consolidate.add_argument(
+        "--auto",
+        action="store_true",
+        help="Create beliefs automatically (default: suggestions only)",
+    )
+    p_consolidate.add_argument(
+        "--min-occurrences",
+        type=int,
+        default=2,
+        help="Minimum times a lesson must appear to be promoted (default: 2)",
+    )
     p_consolidate.add_argument(
         "--min-episodes",
-        "-m",
         type=int,
         default=3,
-        help="(Legacy) Minimum episodes for old consolidation",
+        help="Minimum episodes required to run (default: 3)",
+    )
+    p_consolidate.add_argument(
+        "--confidence",
+        type=float,
+        default=0.7,
+        help="Initial confidence for auto-created beliefs (default: 0.7)",
     )
     p_consolidate.add_argument(
         "--limit",
-        "-n",
         type=int,
-        default=20,
-        help="Number of recent episodes to include (default: 20)",
+        default=50,
+        help="Maximum episodes to scan (default: 50)",
     )
-    p_consolidate.add_argument(
-        "--advanced",
-        action="store_true",
-        help="Run advanced consolidation scaffolds (cross-domain, belief->value, entity model->belief)",
-    )
+    p_consolidate.add_argument("--json", action="store_true", help="Output JSON")
 
     # temporal
     p_temporal = subparsers.add_parser("when", help="Query by time")

--- a/kernle/cli/commands/identity.py
+++ b/kernle/cli/commands/identity.py
@@ -1,6 +1,7 @@
-"""Identity and consolidation commands for Kernle CLI."""
+"""Identity, promotion, and consolidation commands for Kernle CLI."""
 
 import json
+import sys
 from collections import Counter
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
@@ -153,155 +154,12 @@ def _print_drive_pattern_analysis(episodes, k: "Kernle"):
 
 
 def cmd_consolidate(args, k: "Kernle"):
-    """Output guided reflection prompt for memory consolidation.
-
-    This command fetches recent episodes and existing beliefs,
-    then outputs a structured prompt to guide the agent through
-    reflection and pattern identification. The AGENT does the
-    reasoning - Kernle just provides the data and structure.
-    """
-    # Advanced consolidation mode
-    if getattr(args, "advanced", False):
-        limit = getattr(args, "limit", 100) or 100
-        result = k.scaffold_advanced_consolidation(episode_limit=limit)
-        print(result["scaffold"])
-        return
-
-    # Get episode limit from args (default 20)
-    limit = getattr(args, "limit", 20) or 20
-
-    # Fetch recent episodes with full details
-    episodes = k._storage.get_episodes(limit=limit)
-    episodes = [ep for ep in episodes if not ep.is_forgotten]
-
-    # Fetch existing beliefs for context
-    beliefs = k._storage.get_beliefs(limit=20)
-    beliefs = [b for b in beliefs if b.is_active and not b.is_forgotten]
-    beliefs = sorted(beliefs, key=lambda b: b.confidence, reverse=True)
-
-    # Count lessons across episodes
-    all_lessons = []
-    for ep in episodes:
-        if ep.lessons:
-            all_lessons.extend(ep.lessons)
-
-    # Find repeated lessons
-    lesson_counts = Counter(all_lessons)
-    repeated_lessons = [(lesson, count) for lesson, count in lesson_counts.items() if count >= 2]
-    repeated_lessons.sort(key=lambda x: -x[1])
-
-    # Output the reflection prompt
-    print("## Memory Consolidation - Reflection Prompt")
-    print()
+    """Deprecated alias for 'kernle promote'. Use 'kernle promote' instead."""
     print(
-        f"You have {len(episodes)} recent episodes to reflect on. Review them and identify patterns."
+        "WARNING: 'kernle consolidate' is deprecated. " "Use 'kernle promote' instead.",
+        file=sys.stderr,
     )
-    print()
-
-    # Recent Episodes section
-    print("### Recent Episodes:")
-    if not episodes:
-        print("No episodes recorded yet.")
-    else:
-        for i, ep in enumerate(episodes, 1):
-            # Format date
-            date_str = ep.created_at.strftime("%Y-%m-%d") if ep.created_at else "unknown"
-
-            # Outcome type indicator
-            outcome_icon = (
-                "✓"
-                if ep.outcome_type == "success"
-                else (
-                    "○"
-                    if ep.outcome_type == "partial"
-                    else "✗" if ep.outcome_type == "failure" else "•"
-                )
-            )
-
-            print(f'{i}. [{date_str}] {outcome_icon} "{ep.objective}"')
-            print(f"   Outcome: {ep.outcome}")
-
-            if ep.lessons:
-                lessons_str = json.dumps(ep.lessons)
-                print(f"   Lessons: {lessons_str}")
-
-            # Emotional context if present
-            if ep.emotional_valence != 0 or ep.emotional_arousal != 0:
-                valence_label = (
-                    "positive"
-                    if ep.emotional_valence > 0.2
-                    else "negative" if ep.emotional_valence < -0.2 else "neutral"
-                )
-                arousal_label = (
-                    "high"
-                    if ep.emotional_arousal > 0.6
-                    else "low" if ep.emotional_arousal < 0.3 else "moderate"
-                )
-                print(f"   Emotion: {valence_label}, {arousal_label} intensity")
-                if ep.emotional_tags:
-                    print(f"   Feelings: {', '.join(ep.emotional_tags)}")
-
-            print()
-
-    # Current Beliefs section
-    print("### Current Beliefs (for context):")
-    if not beliefs:
-        print("No beliefs recorded yet.")
-    else:
-        for b in beliefs[:10]:  # Limit to top 10 by confidence
-            print(f'- "{b.statement}" (confidence: {b.confidence:.2f})')
-    print()
-
-    # Repeated Lessons section (if any)
-    if repeated_lessons:
-        print("### Patterns Detected:")
-        print("These lessons appear in multiple episodes:")
-        for lesson, count in repeated_lessons[:5]:
-            print(f'- "{lesson}" (appears {count} times)')
-        print()
-
-    # High-Arousal Episodes section
-    high_arousal = [ep for ep in episodes if ep.emotional_arousal > 0.6]
-    if high_arousal:
-        high_arousal.sort(key=lambda ep: ep.emotional_arousal, reverse=True)
-        print("### HIGH-AROUSAL EPISODES (may be worth extra reflection):")
-        for ep in high_arousal:
-            date_str = ep.created_at.strftime("%Y-%m-%d") if ep.created_at else "unknown"
-            valence_label = (
-                "positive"
-                if ep.emotional_valence > 0.2
-                else "negative" if ep.emotional_valence < -0.2 else "neutral"
-            )
-            print(
-                f'- [{date_str}] "{ep.objective}" '
-                f"(arousal: {ep.emotional_arousal:.2f}, valence: {valence_label})"
-            )
-            if ep.emotional_tags:
-                print(f"  Feelings: {', '.join(ep.emotional_tags)}")
-        print()
-
-    # Drive Pattern Analysis section
-    _print_drive_pattern_analysis(episodes, k)
-
-    # Reflection Questions
-    print("### Reflection Questions:")
-    print("1. Do any patterns emerge across these episodes?")
-    print("2. Are there lessons that appear multiple times?")
-    print("3. Do any episodes contradict existing beliefs?")
-    print("4. What new beliefs (if any) should be added?")
-    print("5. Should any existing beliefs be reinforced or revised?")
-    print()
-
-    # Instructions for the agent
-    print("### Actions:")
-    print(f'To add a new belief: kernle -a {k.agent_id} belief add "statement" --confidence 0.8')
-    print(f"To reinforce existing: kernle -a {k.agent_id} belief reinforce <belief_id>")
-    print(
-        f'To revise a belief: kernle -a {k.agent_id} belief revise <belief_id> "new statement" --reason "why"'
-    )
-    print()
-    print("---")
-    print("Note: You (the agent) do the reasoning. Kernle just provides the data.")
+    cmd_promote(args, k)
 
 
 def cmd_identity(args, k: "Kernle"):

--- a/kernle/core.py
+++ b/kernle/core.py
@@ -5325,9 +5325,10 @@ class Kernle(
         return build_epoch_closing_scaffold(self, epoch_id)
 
     def consolidate(self, min_episodes: int = 3) -> Dict[str, Any]:
-        """Run memory consolidation.
+        """Deprecated: use promote() instead.
 
-        Analyzes recent episodes to extract patterns, lessons, and beliefs.
+        Run memory consolidation (legacy). Analyzes recent episodes to
+        extract patterns, lessons, and beliefs.
 
         Args:
             min_episodes: Minimum episodes required to consolidate
@@ -5335,6 +5336,13 @@ class Kernle(
         Returns:
             Consolidation results
         """
+        import warnings
+
+        warnings.warn(
+            "Kernle.consolidate() is deprecated, use Kernle.promote() instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         episodes = self._storage.get_episodes(limit=50)
 
         if len(episodes) < min_episodes:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,6 +17,7 @@ from kernle.cli.__main__ import (
     cmd_episode,
     cmd_load,
     cmd_note,
+    cmd_promote,
     cmd_search,
     cmd_status,
     cmd_temporal,
@@ -586,122 +587,160 @@ class TestDriveCommands:
         assert "Drive 'nonexistent' not found" in fake_out.getvalue()
 
 
-class TestConsolidateCommand:
-    """Test memory consolidation command (reflection prompt output)."""
+class TestPromoteCommand:
+    """Test promote command (episode -> belief promotion)."""
 
-    def test_cmd_consolidate_outputs_reflection_prompt(self, mock_kernle):
-        """Test consolidate command outputs guided reflection prompt."""
-        from datetime import datetime
-
-        # Create mock episode objects
-        mock_episode = Mock()
-        mock_episode.objective = "Debug OAuth flow"
-        mock_episode.outcome = "Fixed CORS and token verification"
-        mock_episode.outcome_type = "success"
-        mock_episode.lessons = ["Always check CORS first", "Use JWKS for token verification"]
-        mock_episode.created_at = datetime(2024, 1, 15)
-        mock_episode.emotional_valence = 0.5
-        mock_episode.emotional_arousal = 0.3
-        mock_episode.emotional_tags = ["satisfaction"]
-        mock_episode.is_forgotten = False
-
-        # Create mock belief objects
-        mock_belief = Mock()
-        mock_belief.statement = "Test before committing"
-        mock_belief.confidence = 0.85
-        mock_belief.is_active = True
-        mock_belief.is_forgotten = False
-
-        # Mock storage
-        mock_storage = Mock()
-        mock_storage.get_episodes.return_value = [mock_episode]
-        mock_storage.get_beliefs.return_value = [mock_belief]
-        mock_kernle._storage = mock_storage
+    def test_cmd_promote_shows_suggestions(self, mock_kernle):
+        """Test promote command shows promotion suggestions."""
+        mock_kernle.promote.return_value = {
+            "episodes_scanned": 10,
+            "patterns_found": 2,
+            "suggestions": [
+                {
+                    "lesson": "Always test first",
+                    "count": 3,
+                    "source_episodes": ["ep1", "ep2", "ep3"],
+                    "promoted": False,
+                },
+            ],
+            "beliefs_created": 0,
+        }
         mock_kernle.agent_id = "test_agent"
 
-        args = argparse.Namespace(min_episodes=3, limit=20)
+        args = argparse.Namespace(
+            auto=False,
+            min_occurrences=2,
+            min_episodes=3,
+            confidence=0.7,
+            limit=50,
+            json=False,
+        )
 
         with patch("sys.stdout", new=StringIO()) as fake_out:
-            cmd_consolidate(args, mock_kernle)
+            cmd_promote(args, mock_kernle)
 
         output = fake_out.getvalue()
-
-        # Check output structure
-        assert "## Memory Consolidation - Reflection Prompt" in output
-        assert "1 recent episodes" in output
-        assert "### Recent Episodes:" in output
-        assert "Debug OAuth flow" in output
-        assert "Fixed CORS and token verification" in output
-        assert '["Always check CORS first", "Use JWKS for token verification"]' in output
-        assert "### Current Beliefs (for context):" in output
-        assert "Test before committing" in output
-        assert "confidence: 0.85" in output
-        assert "### Reflection Questions:" in output
-        assert "kernle -a test_agent belief add" in output
-        assert "kernle -a test_agent belief reinforce" in output
-        assert "You (the agent) do the reasoning" in output
-
-    def test_cmd_consolidate_with_repeated_lessons(self, mock_kernle):
-        """Test that repeated lessons are detected and shown."""
-        from datetime import datetime
-
-        # Create mock episodes with repeated lessons
-        mock_ep1 = Mock()
-        mock_ep1.objective = "Task 1"
-        mock_ep1.outcome = "Done"
-        mock_ep1.outcome_type = "success"
-        mock_ep1.lessons = ["Always test first"]
-        mock_ep1.created_at = datetime(2024, 1, 15)
-        mock_ep1.emotional_valence = 0.0
-        mock_ep1.emotional_arousal = 0.0
-        mock_ep1.emotional_tags = None
-        mock_ep1.is_forgotten = False
-
-        mock_ep2 = Mock()
-        mock_ep2.objective = "Task 2"
-        mock_ep2.outcome = "Done"
-        mock_ep2.outcome_type = "success"
-        mock_ep2.lessons = ["Always test first"]  # Same lesson
-        mock_ep2.created_at = datetime(2024, 1, 16)
-        mock_ep2.emotional_valence = 0.0
-        mock_ep2.emotional_arousal = 0.0
-        mock_ep2.emotional_tags = None
-        mock_ep2.is_forgotten = False
-
-        mock_storage = Mock()
-        mock_storage.get_episodes.return_value = [mock_ep1, mock_ep2]
-        mock_storage.get_beliefs.return_value = []
-        mock_kernle._storage = mock_storage
-        mock_kernle.agent_id = "test_agent"
-
-        args = argparse.Namespace(min_episodes=3, limit=20)
-
-        with patch("sys.stdout", new=StringIO()) as fake_out:
-            cmd_consolidate(args, mock_kernle)
-
-        output = fake_out.getvalue()
-
-        # Check pattern detection
-        assert "### Patterns Detected:" in output
+        assert "Promotion Results" in output
+        assert "Episodes scanned: 10" in output
+        assert "Patterns found: 2" in output
         assert "Always test first" in output
-        assert "appears 2 times" in output
 
-    def test_cmd_consolidate_no_episodes(self, mock_kernle):
-        """Test consolidate command with no episodes."""
-        mock_storage = Mock()
-        mock_storage.get_episodes.return_value = []
-        mock_storage.get_beliefs.return_value = []
-        mock_kernle._storage = mock_storage
+    def test_cmd_promote_no_patterns(self, mock_kernle):
+        """Test promote command with no patterns found."""
+        mock_kernle.promote.return_value = {
+            "episodes_scanned": 5,
+            "patterns_found": 0,
+            "suggestions": [],
+            "beliefs_created": 0,
+        }
         mock_kernle.agent_id = "test_agent"
 
-        args = argparse.Namespace(min_episodes=3, limit=20)
+        args = argparse.Namespace(
+            auto=False,
+            min_occurrences=2,
+            min_episodes=3,
+            confidence=0.7,
+            limit=50,
+            json=False,
+        )
 
         with patch("sys.stdout", new=StringIO()) as fake_out:
-            cmd_consolidate(args, mock_kernle)
+            cmd_promote(args, mock_kernle)
 
         output = fake_out.getvalue()
-        assert "0 recent episodes" in output
-        assert "No episodes recorded yet" in output
+        assert "No recurring patterns found" in output
+
+    def test_cmd_promote_json_output(self, mock_kernle):
+        """Test promote command with JSON output."""
+        result = {
+            "episodes_scanned": 10,
+            "patterns_found": 1,
+            "suggestions": [],
+            "beliefs_created": 0,
+        }
+        mock_kernle.promote.return_value = result
+
+        args = argparse.Namespace(
+            auto=False,
+            min_occurrences=2,
+            min_episodes=3,
+            confidence=0.7,
+            limit=50,
+            json=True,
+        )
+
+        with patch("sys.stdout", new=StringIO()) as fake_out:
+            cmd_promote(args, mock_kernle)
+
+        output = fake_out.getvalue()
+        parsed = json.loads(output)
+        assert parsed["episodes_scanned"] == 10
+
+
+class TestConsolidateDeprecatedAlias:
+    """Test that 'consolidate' works as a deprecated alias for 'promote'."""
+
+    def test_cmd_consolidate_prints_deprecation_warning(self, mock_kernle):
+        """Test consolidate command prints deprecation warning to stderr."""
+        mock_kernle.promote.return_value = {
+            "episodes_scanned": 5,
+            "patterns_found": 0,
+            "suggestions": [],
+            "beliefs_created": 0,
+        }
+        mock_kernle.agent_id = "test_agent"
+
+        args = argparse.Namespace(
+            auto=False,
+            min_occurrences=2,
+            min_episodes=3,
+            confidence=0.7,
+            limit=50,
+            json=False,
+        )
+
+        with patch("sys.stderr", new=StringIO()) as fake_err:
+            with patch("sys.stdout", new=StringIO()):
+                cmd_consolidate(args, mock_kernle)
+
+        err_output = fake_err.getvalue()
+        assert "deprecated" in err_output.lower()
+        assert "promote" in err_output
+
+    def test_cmd_consolidate_delegates_to_promote(self, mock_kernle):
+        """Test consolidate command delegates to promote and produces same output."""
+        mock_kernle.promote.return_value = {
+            "episodes_scanned": 10,
+            "patterns_found": 1,
+            "suggestions": [
+                {
+                    "lesson": "Always test first",
+                    "count": 3,
+                    "source_episodes": ["ep1", "ep2", "ep3"],
+                    "promoted": False,
+                },
+            ],
+            "beliefs_created": 0,
+        }
+        mock_kernle.agent_id = "test_agent"
+
+        args = argparse.Namespace(
+            auto=False,
+            min_occurrences=2,
+            min_episodes=3,
+            confidence=0.7,
+            limit=50,
+            json=False,
+        )
+
+        with patch("sys.stderr", new=StringIO()):
+            with patch("sys.stdout", new=StringIO()) as fake_out:
+                cmd_consolidate(args, mock_kernle)
+
+        output = fake_out.getvalue()
+        # Should produce promote output, not the old consolidation output
+        assert "Promotion Results" in output
+        assert "Always test first" in output
 
 
 class TestTemporalCommand:


### PR DESCRIPTION
## Summary
- Renames `kernle consolidate` to `kernle promote` for terminology consistency
- Episode->belief extraction is 'promotion', not 'consolidation'
- Keeps `consolidate` as deprecated alias with warning
- Does not affect KEP v3 two-tier consolidation system

## Changes
- `cmd_consolidate` now prints a deprecation warning to stderr and delegates to `cmd_promote`
- `Kernle.consolidate()` method now emits a `DeprecationWarning` (keeps existing behavior)
- CLI parser for `consolidate` updated to match `promote`'s args
- Updated tests across 4 test files to reflect the new behavior

Closes #81

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>