### PR TITLE
fix: exclude commerce/comms tests from CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest tests/ -v --tb=short --ignore=tests/test_postgres_storage.py --cov=kernle --cov-report=xml --cov-fail-under=70
+          pytest tests/ -v --tb=short --ignore=tests/test_postgres_storage.py --ignore=tests/commerce --ignore=tests/comms --ignore=tests/test_belief_revision.py --cov=kernle --cov-report=xml --cov-fail-under=70
 
       - name: Upload coverage (Python 3.11 only)
         if: matrix.python-version == '3.11'


### PR DESCRIPTION
Closes #215

## Summary
- Added `--ignore=tests/commerce --ignore=tests/comms --ignore=tests/test_belief_revision.py` to the pytest command in the CI test workflow
- These test directories/files reference modules (commerce, comms, belief_revision) that were moved out of the kernle core package and cause import failures in CI

## Test plan
- [x] YAML validated with `yaml.safe_load()`
- [x] Pre-commit hooks pass (including `check yaml`)
- [x] Local test run: 1892 passed, 6 pre-existing failures (sqlite-vec/provenance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)