### PR TITLE
fix: reject path traversal in stack_id validation

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -875,6 +875,22 @@ class TestInputValidation:
         # Should be sanitized to only alphanumeric and -_.
         assert kernle.stack_id == "testagent"
 
+    @pytest.mark.parametrize(
+        "bad_id,match",
+        [
+            ("..", "relative path component"),
+            (".", "relative path component"),
+            ("../x", "path separators"),
+            ("nested/evil", "path separators"),
+            ("a\\b", "path separators"),
+            ("foo/../bar", "path separators"),
+        ],
+    )
+    def test_validate_stack_id_path_traversal(self, bad_id, match):
+        """Test that path traversal stack IDs are rejected."""
+        with pytest.raises(ValueError, match=match):
+            Kernle(stack_id=bad_id)
+
     def test_validate_string_too_long(self, kernle_instance):
         """Test that strings exceeding max length raise error."""
         kernle, storage = kernle_instance


### PR DESCRIPTION
Closes #210

## Summary

- Harden `_validate_stack_id()` in `Kernle` (core.py) to reject stack IDs containing `/`, `\`, or that are `.`/`..` path components, **before** sanitization
- Add defense-in-depth validation in `SQLiteStorage.__init__()` (sqlite.py) with the same checks, since `stack_id` is used directly in filesystem paths (`self._agent_dir = self.db_path.parent / stack_id`)
- Add 12 parametrized regression tests (6 at core layer, 6 at storage layer) covering: `..`, `.`, `../x`, `nested/evil`, `a\b`, `foo/../bar`

## Test plan

- [x] All 12 new path traversal tests pass
- [x] All pre-existing tests continue to pass (136 passed, 6 pre-existing failures unrelated to this change)
- [x] Pre-commit hooks pass (ruff, black, secrets detection)