### PR TITLE
feat: add KERNLE_DATA_DIR env var for configurable data path

### DIFF
--- a/kernle/cli/__main__.py
+++ b/kernle/cli/__main__.py
@@ -49,7 +49,7 @@ from kernle.cli.commands import (
 from kernle.cli.commands.import_cmd import cmd_import, cmd_migrate
 from kernle.cli.commands.setup import cmd_setup
 from kernle.cli.commands.stack import cmd_stack
-from kernle.utils import resolve_stack_id
+from kernle.utils import get_kernle_home, resolve_stack_id
 
 # Commerce CLI (optional - requires chainbased package)
 try:
@@ -403,7 +403,6 @@ def cmd_search(args, k: Kernle):
 
 def cmd_init(args, k: Kernle):
     """Initialize Kernle for a new environment."""
-    from pathlib import Path
 
     print("=" * 50)
     print("  🌱 Welcome to Kernle")
@@ -1155,7 +1154,7 @@ def cmd_boot(args, k: Kernle):
     elif action == "export":
         output = getattr(args, "output", None)
         k._export_boot_file()
-        boot_path = Path.home() / ".kernle" / k.stack_id / "boot.md"
+        boot_path = get_kernle_home() / k.stack_id / "boot.md"
         if output:
             # Copy to custom location
             config = k.boot_list()
@@ -1200,7 +1199,6 @@ def cmd_sync(args, k: Kernle):
     """Handle sync subcommands for local-to-cloud synchronization."""
     import os
     from datetime import datetime, timezone
-    from pathlib import Path
 
     # Load credentials with priority:
     # 1. ~/.kernle/credentials.json (preferred)
@@ -1212,7 +1210,7 @@ def cmd_sync(args, k: Kernle):
     user_id = None
 
     # Try credentials.json first (preferred)
-    credentials_path = Path.home() / ".kernle" / "credentials.json"
+    credentials_path = get_kernle_home() / "credentials.json"
     if credentials_path.exists():
         try:
             import json as json_module
@@ -1236,7 +1234,7 @@ def cmd_sync(args, k: Kernle):
         user_id = os.environ.get("KERNLE_USER_ID")
 
     # Legacy fallback: check config.json
-    config_path = Path.home() / ".kernle" / "config.json"
+    config_path = get_kernle_home() / "config.json"
     if config_path.exists() and (not backend_url or not auth_token):
         try:
             import json as json_module
@@ -2022,9 +2020,7 @@ def cmd_sync(args, k: Kernle):
 
 def get_credentials_path():
     """Get the path to the credentials file."""
-    from pathlib import Path
-
-    return Path.home() / ".kernle" / "credentials.json"
+    return get_kernle_home() / "credentials.json"
 
 
 def load_credentials():

--- a/kernle/cli/commands/stack.py
+++ b/kernle/cli/commands/stack.py
@@ -2,10 +2,10 @@
 
 import logging
 import shutil
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from kernle.storage.sqlite import validate_table_name
+from kernle.utils import get_kernle_home
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +27,7 @@ def cmd_stack(args: "argparse.Namespace", k: "Kernle") -> None:
 
 def _list_stacks(args: "argparse.Namespace", k: "Kernle") -> None:
     """List all local agents."""
-    kernle_dir = Path.home() / ".kernle"
+    kernle_dir = get_kernle_home()
 
     if not kernle_dir.exists():
         print("No agents found (Kernle not initialized)")
@@ -121,7 +121,7 @@ def _delete_stack(args: "argparse.Namespace", k: "Kernle") -> None:
         print("   Switch to a different stack first with: kernle -s <other> ...")
         return
 
-    kernle_dir = Path.home() / ".kernle"
+    kernle_dir = get_kernle_home()
     db_path = kernle_dir / "memories.db"
     agent_dir = kernle_dir / stack_id
 

--- a/kernle/cli/commands/subscription.py
+++ b/kernle/cli/commands/subscription.py
@@ -15,8 +15,9 @@ import sys
 import urllib.error
 import urllib.request
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import TYPE_CHECKING, Optional
+
+from kernle.utils import get_kernle_home
 
 if TYPE_CHECKING:
     import argparse
@@ -73,7 +74,7 @@ TIER_ORDER = ["free", "core", "pro", "enterprise"]
 
 def _load_credentials() -> dict:
     """Load credentials from ~/.kernle/credentials.json."""
-    creds_path = Path.home() / ".kernle" / "credentials.json"
+    creds_path = get_kernle_home() / "credentials.json"
     if not creds_path.exists():
         return {}
     try:

--- a/kernle/core.py
+++ b/kernle/core.py
@@ -14,7 +14,6 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
-# Import feature mixins
 from kernle.features import (
     AnxietyMixin,
     ConsolidationMixin,
@@ -54,6 +53,9 @@ from kernle.storage.base import (
     TRUST_DEPTH_DECAY,
     TRUST_THRESHOLDS,
 )
+
+# Import feature mixins
+from kernle.utils import get_kernle_home
 
 if TYPE_CHECKING:
     from kernle.storage import Storage as StorageProtocol
@@ -404,7 +406,7 @@ class Kernle(
             stack_id or os.environ.get("KERNLE_STACK_ID", "default")
         )
         self.checkpoint_dir = self._validate_checkpoint_dir(
-            checkpoint_dir or Path.home() / ".kernle" / "checkpoints"
+            checkpoint_dir or get_kernle_home() / "checkpoints"
         )
 
         # Store credentials for backwards compatibility
@@ -2256,7 +2258,7 @@ class Kernle(
         config = self.boot_list()
         if not config:
             # Remove boot file if config is empty
-            boot_path = Path.home() / ".kernle" / self.stack_id / "boot.md"
+            boot_path = get_kernle_home() / self.stack_id / "boot.md"
             if boot_path.exists():
                 boot_path.unlink()
             return
@@ -2275,7 +2277,7 @@ class Kernle(
         )
         lines.append("")
 
-        boot_path = Path.home() / ".kernle" / self.stack_id / "boot.md"
+        boot_path = get_kernle_home() / self.stack_id / "boot.md"
         boot_path.parent.mkdir(parents=True, exist_ok=True)
         boot_path.write_text("\n".join(lines), encoding="utf-8")
 

--- a/kernle/logging_config.py
+++ b/kernle/logging_config.py
@@ -6,7 +6,8 @@ to diagnose continuity issues and understand memory flow.
 
 import logging
 from datetime import datetime
-from pathlib import Path
+
+from kernle.utils import get_kernle_home
 
 
 def setup_kernle_logging(stack_id: str = "default", level: str = "INFO") -> logging.Logger:
@@ -23,7 +24,7 @@ def setup_kernle_logging(stack_id: str = "default", level: str = "INFO") -> logg
         Configured logger
     """
     # Create logs directory
-    log_dir = Path.home() / ".kernle" / "logs"
+    log_dir = get_kernle_home() / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
 
     # Daily log file
@@ -72,7 +73,7 @@ def log_memory_event(event_type: str, details: str, stack_id: str = "default"):
         details: Human-readable details
         stack_id: Stack identifier
     """
-    log_dir = Path.home() / ".kernle" / "logs"
+    log_dir = get_kernle_home() / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
 
     today = datetime.now().strftime("%Y-%m-%d")

--- a/kernle/storage/sqlite.py
+++ b/kernle/storage/sqlite.py
@@ -16,6 +16,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+from kernle.utils import get_kernle_home
+
 from .base import (
     Belief,
     DiagnosticReport,
@@ -920,7 +922,7 @@ class SQLiteStorage:
         embedder: Optional[EmbeddingProvider] = None,
     ):
         self.stack_id = stack_id
-        self.db_path = self._validate_db_path(db_path or Path.home() / ".kernle" / "memories.db")
+        self.db_path = self._validate_db_path(db_path or get_kernle_home() / "memories.db")
         self.cloud_storage = cloud_storage  # For sync
 
         # Connectivity cache
@@ -1115,7 +1117,7 @@ class SQLiteStorage:
         auth_token = None
 
         # Try credentials.json first
-        credentials_path = Path.home() / ".kernle" / "credentials.json"
+        credentials_path = get_kernle_home() / "credentials.json"
         if credentials_path.exists():
             try:
                 with open(credentials_path) as f:
@@ -1132,7 +1134,7 @@ class SQLiteStorage:
 
         # Try config.json as fallback
         if not backend_url or not auth_token:
-            config_path = Path.home() / ".kernle" / "config.json"
+            config_path = get_kernle_home() / "config.json"
             if config_path.exists():
                 try:
                     with open(config_path) as f:
@@ -5659,7 +5661,7 @@ class SQLiteStorage:
             return False
 
         # Check config file
-        config_path = Path.home() / ".kernle" / "config.json"
+        config_path = get_kernle_home() / "config.json"
         if config_path.exists():
             try:
                 with open(config_path) as f:

--- a/kernle/utils.py
+++ b/kernle/utils.py
@@ -6,7 +6,16 @@ import hashlib
 import os
 import platform
 import subprocess
+from pathlib import Path
 from typing import Optional
+
+
+def get_kernle_home() -> Path:
+    """Get the Kernle data directory. Uses KERNLE_DATA_DIR env var if set, otherwise ~/.kernle."""
+    custom = os.environ.get("KERNLE_DATA_DIR")
+    if custom:
+        return Path(custom)
+    return Path.home() / ".kernle"
 
 
 def _get_git_root() -> Optional[str]:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,10 @@
 """Tests for kernle.utils module."""
 
 import os
+from pathlib import Path
 from unittest.mock import patch
 
-from kernle.utils import generate_default_stack_id, resolve_stack_id
+from kernle.utils import generate_default_stack_id, get_kernle_home, resolve_stack_id
 
 
 class TestGenerateDefaultAgentId:
@@ -129,3 +130,31 @@ class TestResolveAgentId:
         with patch.dict(os.environ, {"KERNLE_STACK_ID": "from-env"}):
             result = resolve_stack_id(None)
             assert result == "from-env"
+
+
+class TestGetKernleHome:
+    """Tests for get_kernle_home function."""
+
+    def test_default_returns_dot_kernle(self, monkeypatch):
+        """Without env var, should return ~/.kernle."""
+        monkeypatch.delenv("KERNLE_DATA_DIR", raising=False)
+        result = get_kernle_home()
+        assert result == Path.home() / ".kernle"
+
+    def test_env_var_overrides_default(self, monkeypatch):
+        """KERNLE_DATA_DIR should override the default path."""
+        monkeypatch.setenv("KERNLE_DATA_DIR", "/tmp/custom")
+        result = get_kernle_home()
+        assert result == Path("/tmp/custom")
+
+    def test_env_var_returns_path_object(self, monkeypatch):
+        """Result should always be a Path object."""
+        monkeypatch.setenv("KERNLE_DATA_DIR", "/tmp/custom")
+        result = get_kernle_home()
+        assert isinstance(result, Path)
+
+    def test_default_returns_path_object(self, monkeypatch):
+        """Default result should also be a Path object."""
+        monkeypatch.delenv("KERNLE_DATA_DIR", raising=False)
+        result = get_kernle_home()
+        assert isinstance(result, Path)


### PR DESCRIPTION
Closes #212

## Summary

- Add `get_kernle_home()` function in `kernle/utils.py` that returns `KERNLE_DATA_DIR` env var path if set, otherwise `~/.kernle`
- Replace all hardcoded `Path.home() / ".kernle"` references (15 occurrences across 7 files) with `get_kernle_home()`
- Add tests for the new function in `tests/test_utils.py`

## Files changed

- `kernle/utils.py` - New `get_kernle_home()` function
- `kernle/core.py` - 3 references updated (checkpoints, boot.md)
- `kernle/storage/sqlite.py` - 4 references updated (db path, credentials, config)
- `kernle/logging_config.py` - 2 references updated (log directory)
- `kernle/cli/__main__.py` - 4 references updated (boot, credentials, config)
- `kernle/cli/commands/stack.py` - 2 references updated (stack listing/deletion)
- `kernle/cli/commands/subscription.py` - 1 reference updated (credentials)
- `tests/test_utils.py` - 4 new tests for `get_kernle_home()`

## Test plan

- [x] `tests/test_utils.py` - 17 passed (4 new + 13 existing)
- [x] `tests/test_core.py` - 80 passed