### PR TITLE
test: replace tautological assertions with behavior-specific checks

### DIFF
--- a/tests/test_anxiety.py
+++ b/tests/test_anxiety.py
@@ -98,7 +98,7 @@ class TestAnxietyDimensions:
         dim = report["dimensions"]["consolidation_debt"]
 
         # Fresh instance with no episodes
-        assert dim["raw_value"] >= 0  # Count of unreflected episodes
+        assert dim["raw_value"] == 0  # Count of unreflected episodes
 
     def test_consolidation_debt_with_unreflected(self, k):
         """Multiple unreflected episodes should increase consolidation debt."""
@@ -125,7 +125,7 @@ class TestAnxietyDimensions:
 
         # New instance with minimal data = low confidence = high anxiety
         # (inverted: high coherence = low anxiety)
-        assert dim["raw_value"] >= 0  # Identity confidence
+        assert dim["raw_value"] == 0  # Identity confidence (no data = zero)
 
     def test_identity_coherence_with_data(self, k):
         """Strong identity data should reduce identity anxiety."""
@@ -148,8 +148,8 @@ class TestAnxietyDimensions:
         report = k.get_anxiety_report()
         dim = report["dimensions"]["memory_uncertainty"]
 
-        # Fresh instance might have 0 beliefs
-        assert dim["score"] >= 0
+        # Fresh instance with 0 beliefs = no uncertainty
+        assert dim["score"] == 0
 
     def test_memory_uncertainty_with_low_confidence(self, k):
         """Low confidence beliefs should increase uncertainty anxiety."""
@@ -367,7 +367,6 @@ class TestCheckpointAgeTracking:
         # Immediately after, should be very recent
         age = k._get_checkpoint_age_minutes()
         assert age is not None
-        assert age >= 0
         assert age < 5  # Should be less than 5 minutes
 
     def test_checkpoint_age_no_checkpoint(self, k):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -204,9 +204,9 @@ class TestLoadMethods:
         assert isinstance(meta["budget_total"], int)
         assert isinstance(meta["excluded_count"], int)
         assert meta["budget_total"] == 8000
-        assert meta["budget_used"] >= 0
+        assert meta["budget_used"] > 0
         assert meta["budget_used"] <= meta["budget_total"]
-        assert meta["excluded_count"] >= 0
+        assert meta["excluded_count"] == 0  # 8000 budget is generous enough for all items
 
     def test_load_meta_excluded_count_with_low_budget(self, kernle_instance, populated_storage):
         """Test that excluded_count increases when budget is too small."""

--- a/tests/test_metacognition.py
+++ b/tests/test_metacognition.py
@@ -291,8 +291,8 @@ class TestGetCompetenceBoundaries:
 
         assert 0.0 <= boundaries["overall_confidence"] <= 1.0
         assert 0.0 <= boundaries["success_rate"] <= 1.0
-        assert boundaries["experience_depth"] >= 0
-        assert boundaries["knowledge_breadth"] >= 0
+        assert boundaries["experience_depth"] >= 5  # at least 5 episodes in fixture
+        assert boundaries["knowledge_breadth"] >= 3  # python, docker, kubernetes domains
 
     def test_experience_depth_counts_episodes(self, kernle):
         """Should count episodes for experience depth."""

--- a/tests/test_privacy_enforcement.py
+++ b/tests/test_privacy_enforcement.py
@@ -326,7 +326,7 @@ class TestAccessControl:
             [rid for rid in result_ids if rid in ["episode_private", "episode_empty"]]
         )
 
-        assert accessible_count >= 0  # Should see accessible ones
+        assert accessible_count > 0  # Should see accessible ones
         assert private_count == 0  # Should not see private ones
 
 


### PR DESCRIPTION
Closes #213

## Summary

- Replaced 9 tautological assertions across 4 test files that could never fail (e.g., `assert count >= 0` where count is a list length)
- Each assertion now tests actual expected behavior:
  - `test_privacy_enforcement.py`: `accessible_count >= 0` -> `> 0` (search should find accessible episodes)
  - `test_core.py`: `budget_used >= 0` -> `> 0` (populated storage uses nonzero budget); `excluded_count >= 0` -> `== 0` (8000 budget fits everything)
  - `test_anxiety.py`: 4 assertions fixed — fresh instance should have exactly 0 for counts/scores, removed redundant `age >= 0` (already covered by `age < 5`)
  - `test_metacognition.py`: `experience_depth >= 0` -> `>= 5` (at least 5 episodes); `knowledge_breadth >= 0` -> `>= 3` (at least 3 domains)

## Test plan

- [x] All 177 tests in the 4 affected files pass
- [x] Full test suite: 1892 passed (6 pre-existing failures unrelated to this change)