### PR TITLE
feat: implement SQLiteStack conforming to StackProtocol (#247)

### DIFF
--- a/kernle/stack/__init__.py
+++ b/kernle/stack/__init__.py
@@ -1,0 +1,8 @@
+"""kernle.stack - Memory stack implementations.
+
+The default SQLiteStack wraps SQLiteStorage and conforms to StackProtocol.
+"""
+
+from kernle.stack.sqlite_stack import SQLiteStack
+
+__all__ = ["SQLiteStack"]

--- a/kernle/stack/sqlite_stack.py
+++ b/kernle/stack/sqlite_stack.py
@@ -1,0 +1,1022 @@
+"""SQLiteStack - StackProtocol implementation wrapping SQLiteStorage.
+
+This is the default memory stack implementation. It wraps the existing
+SQLiteStorage backend and adds:
+- StackProtocol interface conformance
+- Feature mixins (anxiety, consolidation, emotions, forgetting, knowledge,
+  metamemory, suggestions) applied the same way as on Kernle
+- Composition hooks (on_attach, on_detach, on_model_changed)
+- Component registry infrastructure (for v0.5.0 stack components)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from kernle.features import (
+    AnxietyMixin,
+    ConsolidationMixin,
+    EmotionsMixin,
+    ForgettingMixin,
+    KnowledgeMixin,
+    MetaMemoryMixin,
+    SuggestionsMixin,
+)
+from kernle.protocols import (
+    InferenceService,
+    StackComponentProtocol,
+)
+from kernle.protocols import (
+    SearchResult as ProtocolSearchResult,
+)
+from kernle.protocols import (
+    SyncResult as ProtocolSyncResult,
+)
+from kernle.storage.sqlite import SQLiteStorage
+from kernle.types import (
+    Belief,
+    Drive,
+    Episode,
+    Epoch,
+    Goal,
+    MemorySuggestion,
+    Note,
+    Playbook,
+    RawEntry,
+    Relationship,
+    SelfNarrative,
+    Summary,
+    TrustAssessment,
+    Value,
+)
+
+logger = logging.getLogger(__name__)
+
+# Default token budget for memory loading
+DEFAULT_TOKEN_BUDGET = 8000
+MAX_TOKEN_BUDGET = 50000
+MIN_TOKEN_BUDGET = 100
+DEFAULT_MAX_ITEM_CHARS = 500
+TOKEN_ESTIMATION_SAFETY_MARGIN = 1.3
+
+# Priority scores for each memory type (higher = more important)
+MEMORY_TYPE_PRIORITIES = {
+    "value": 0.90,
+    "self_narrative": 0.90,
+    "summary_decade": 0.95,
+    "summary_epoch": 0.85,
+    "summary_year": 0.80,
+    "belief": 0.70,
+    "goal": 0.65,
+    "drive": 0.60,
+    "summary_quarter": 0.50,
+    "episode": 0.40,
+    "summary_month": 0.35,
+    "note": 0.35,
+    "relationship": 0.30,
+}
+
+
+def _estimate_tokens(text: str) -> int:
+    """Estimate token count from text (~4 chars/token with safety margin)."""
+    if not text:
+        return 0
+    return int(len(text) // 4 * TOKEN_ESTIMATION_SAFETY_MARGIN)
+
+
+def _truncate_at_word_boundary(text: str, max_chars: int) -> str:
+    """Truncate text at a word boundary with ellipsis."""
+    if not text or len(text) <= max_chars:
+        return text
+    target = max_chars - 3
+    if target <= 0:
+        return "..."
+    truncated = text[:target]
+    last_space = truncated.rfind(" ")
+    if last_space > target // 2:
+        truncated = truncated[:last_space]
+    return truncated + "..."
+
+
+def _compute_priority_score(memory_type: str, record: Any) -> float:
+    """Compute priority score for budget-based selection."""
+    base = MEMORY_TYPE_PRIORITIES.get(memory_type, 0.20)
+    bonus = 0.0
+    if memory_type == "value":
+        bonus = getattr(record, "priority", 50) / 1000.0
+    elif memory_type == "belief":
+        bonus = getattr(record, "confidence", 0.8) / 10.0
+    elif memory_type == "drive":
+        bonus = getattr(record, "intensity", 0.5) / 10.0
+    return base + bonus
+
+
+class SQLiteStack(
+    AnxietyMixin,
+    ConsolidationMixin,
+    EmotionsMixin,
+    ForgettingMixin,
+    KnowledgeMixin,
+    MetaMemoryMixin,
+    SuggestionsMixin,
+):
+    """SQLite-backed memory stack conforming to StackProtocol.
+
+    Wraps SQLiteStorage and exposes the full StackProtocol interface.
+    Works in detached mode (no core attached) for read/write/search.
+    Feature mixins are applied the same way as on Kernle.
+    """
+
+    def __init__(
+        self,
+        stack_id: str,
+        db_path: Optional[Path] = None,
+        cloud_storage: Optional[Any] = None,
+        embedder: Optional[Any] = None,
+    ):
+        self._backend = SQLiteStorage(
+            stack_id=stack_id,
+            db_path=db_path,
+            cloud_storage=cloud_storage,
+            embedder=embedder,
+        )
+        # Alias for mixin compatibility (mixins access self._storage)
+        self._storage = self._backend
+
+        # Component registry (v0.5.0 infrastructure)
+        self._components: Dict[str, StackComponentProtocol] = {}
+
+        # Composition state
+        self._attached_core_id: Optional[str] = None
+        self._inference: Optional[InferenceService] = None
+
+    # ---- Properties ----
+
+    @property
+    def stack_id(self) -> str:
+        return self._backend.stack_id
+
+    @property
+    def schema_version(self) -> int:
+        from kernle.storage.sqlite import SCHEMA_VERSION
+
+        return SCHEMA_VERSION
+
+    # ---- Component Management ----
+
+    @property
+    def components(self) -> Dict[str, StackComponentProtocol]:
+        return dict(self._components)
+
+    def add_component(self, component: StackComponentProtocol) -> None:
+        """Add a component to this stack."""
+        name = component.name
+        if name in self._components:
+            raise ValueError(f"Component '{name}' already registered")
+        component.attach(self.stack_id, self._inference)
+        self._components[name] = component
+
+    def remove_component(self, name: str) -> None:
+        """Remove a component by name."""
+        if name not in self._components:
+            raise ValueError(f"Component '{name}' not found")
+        component = self._components[name]
+        if component.required:
+            raise ValueError(f"Cannot remove required component '{name}'")
+        component.detach()
+        del self._components[name]
+
+    def get_component(self, name: str) -> Optional[StackComponentProtocol]:
+        return self._components.get(name)
+
+    def maintenance(self) -> Dict[str, Any]:
+        """Run maintenance on all components."""
+        results: Dict[str, Any] = {}
+        for name, component in self._components.items():
+            try:
+                stats = component.on_maintenance()
+                if stats:
+                    results[name] = stats
+            except Exception as e:
+                logger.warning(f"Component '{name}' maintenance failed: {e}")
+                results[name] = {"error": str(e)}
+        return results
+
+    # ---- Write Operations ----
+
+    def save_episode(self, episode: Episode) -> str:
+        return self._backend.save_episode(episode)
+
+    def save_belief(self, belief: Belief) -> str:
+        return self._backend.save_belief(belief)
+
+    def save_value(self, value: Value) -> str:
+        return self._backend.save_value(value)
+
+    def save_goal(self, goal: Goal) -> str:
+        return self._backend.save_goal(goal)
+
+    def save_note(self, note: Note) -> str:
+        return self._backend.save_note(note)
+
+    def save_drive(self, drive: Drive) -> str:
+        return self._backend.save_drive(drive)
+
+    def save_relationship(self, relationship: Relationship) -> str:
+        return self._backend.save_relationship(relationship)
+
+    def save_raw(self, raw: RawEntry) -> str:
+        return self._backend.save_raw(
+            blob=raw.blob or raw.content or "",
+            source=raw.source,
+        )
+
+    def save_playbook(self, playbook: Playbook) -> str:
+        return self._backend.save_playbook(playbook)
+
+    def save_epoch(self, epoch: Epoch) -> str:
+        return self._backend.save_epoch(epoch)
+
+    def save_summary(self, summary: Summary) -> str:
+        return self._backend.save_summary(summary)
+
+    def save_self_narrative(self, narrative: SelfNarrative) -> str:
+        return self._backend.save_self_narrative(narrative)
+
+    def save_suggestion(self, suggestion: MemorySuggestion) -> str:
+        return self._backend.save_suggestion(suggestion)
+
+    # ---- Batch Write ----
+
+    def save_episodes_batch(self, episodes: List[Episode]) -> List[str]:
+        return self._backend.save_episodes_batch(episodes)
+
+    def save_beliefs_batch(self, beliefs: List[Belief]) -> List[str]:
+        return self._backend.save_beliefs_batch(beliefs)
+
+    def save_notes_batch(self, notes: List[Note]) -> List[str]:
+        return self._backend.save_notes_batch(notes)
+
+    # ---- Read Operations ----
+
+    def get_episodes(
+        self,
+        *,
+        limit: int = 50,
+        tags: Optional[List[str]] = None,
+        context: Optional[str] = None,
+        include_forgotten: bool = False,
+    ) -> List[Episode]:
+        episodes = self._backend.get_episodes(limit=limit, tags=tags)
+        if not include_forgotten:
+            episodes = [e for e in episodes if not e.is_forgotten]
+        return episodes
+
+    def get_beliefs(
+        self,
+        *,
+        limit: int = 50,
+        belief_type: Optional[str] = None,
+        min_confidence: Optional[float] = None,
+        context: Optional[str] = None,
+        include_forgotten: bool = False,
+    ) -> List[Belief]:
+        beliefs = self._backend.get_beliefs(limit=limit)
+        if belief_type:
+            beliefs = [b for b in beliefs if b.belief_type == belief_type]
+        if min_confidence is not None:
+            beliefs = [b for b in beliefs if b.confidence >= min_confidence]
+        if not include_forgotten:
+            beliefs = [b for b in beliefs if not b.is_forgotten]
+        return beliefs
+
+    def get_values(
+        self,
+        *,
+        limit: int = 50,
+        context: Optional[str] = None,
+        include_forgotten: bool = False,
+    ) -> List[Value]:
+        values = self._backend.get_values(limit=limit)
+        if not include_forgotten:
+            values = [v for v in values if not v.is_forgotten]
+        return values
+
+    def get_goals(
+        self,
+        *,
+        limit: int = 50,
+        status: Optional[str] = None,
+        context: Optional[str] = None,
+        include_forgotten: bool = False,
+    ) -> List[Goal]:
+        goals = self._backend.get_goals(status=status, limit=limit)
+        if not include_forgotten:
+            goals = [g for g in goals if not g.is_forgotten]
+        return goals
+
+    def get_notes(
+        self,
+        *,
+        limit: int = 50,
+        note_type: Optional[str] = None,
+        context: Optional[str] = None,
+        include_forgotten: bool = False,
+    ) -> List[Note]:
+        notes = self._backend.get_notes(limit=limit, note_type=note_type)
+        if not include_forgotten:
+            notes = [n for n in notes if not n.is_forgotten]
+        return notes
+
+    def get_drives(self, *, include_expired: bool = False) -> List[Drive]:
+        return self._backend.get_drives()
+
+    def get_relationships(
+        self,
+        *,
+        entity_id: Optional[str] = None,
+        entity_type: Optional[str] = None,
+        min_trust: Optional[float] = None,
+    ) -> List[Relationship]:
+        rels = self._backend.get_relationships(entity_type=entity_type)
+        if entity_id:
+            rels = [r for r in rels if r.entity_name == entity_id]
+        if min_trust is not None:
+            rels = [r for r in rels if (r.sentiment + 1) / 2 >= min_trust]
+        return rels
+
+    def get_raw(
+        self,
+        *,
+        limit: int = 50,
+        tags: Optional[List[str]] = None,
+    ) -> List[RawEntry]:
+        entries = self._backend.list_raw(limit=limit)
+        if tags:
+            tag_set = set(tags)
+            entries = [e for e in entries if e.tags and tag_set.intersection(e.tags)]
+        return entries
+
+    def get_memory(self, memory_type: str, memory_id: str) -> Optional[Any]:
+        return self._backend.get_memory(memory_type, memory_id)
+
+    # ---- Search ----
+
+    def search(
+        self,
+        query: str,
+        *,
+        limit: int = 10,
+        record_types: Optional[List[str]] = None,
+        context: Optional[str] = None,
+        min_confidence: Optional[float] = None,
+    ) -> List[ProtocolSearchResult]:
+        storage_results = self._backend.search(
+            query=query,
+            limit=limit,
+            record_types=record_types,
+        )
+        results = []
+        for sr in storage_results:
+            record = sr.record
+            content = ""
+            if sr.record_type == "episode":
+                content = f"{record.objective}: {record.outcome}"
+            elif sr.record_type == "belief":
+                content = record.statement
+            elif sr.record_type == "value":
+                content = f"{record.name}: {record.statement}"
+            elif sr.record_type == "goal":
+                content = f"{record.title}: {record.description or ''}"
+            elif sr.record_type == "note":
+                content = record.content
+            elif sr.record_type == "relationship":
+                content = f"{record.entity_name}: {record.notes or ''}"
+            else:
+                content = str(record)[:200]
+
+            if min_confidence is not None:
+                record_conf = getattr(record, "confidence", 1.0)
+                if record_conf < min_confidence:
+                    continue
+
+            results.append(
+                ProtocolSearchResult(
+                    memory_type=sr.record_type,
+                    memory_id=record.id,
+                    content=content,
+                    score=sr.score,
+                    metadata={
+                        "confidence": getattr(record, "confidence", None),
+                    },
+                )
+            )
+        return results
+
+    # ---- Working Memory ----
+
+    def load(
+        self,
+        *,
+        token_budget: int = DEFAULT_TOKEN_BUDGET,
+        context: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Assemble working memory within a token budget."""
+        budget = max(MIN_TOKEN_BUDGET, min(MAX_TOKEN_BUDGET, token_budget))
+        remaining = budget
+
+        # Fetch candidates from all types
+        batched = self._backend.load_all(
+            values_limit=None,
+            beliefs_limit=None,
+            goals_limit=None,
+            goals_status="active",
+            episodes_limit=None,
+            notes_limit=None,
+            drives_limit=None,
+            relationships_limit=None,
+        )
+
+        if batched is None:
+            # Fallback to individual queries
+            return {
+                "values": [
+                    {"id": v.id, "name": v.name, "statement": v.statement, "priority": v.priority}
+                    for v in self._backend.get_values(limit=50)
+                ],
+                "beliefs": [
+                    {"id": b.id, "statement": b.statement, "confidence": b.confidence}
+                    for b in self._backend.get_beliefs(limit=50)
+                ],
+                "goals": [
+                    {"id": g.id, "title": g.title, "status": g.status}
+                    for g in self._backend.get_goals(limit=50)
+                ],
+                "episodes": [
+                    {"id": e.id, "objective": e.objective, "outcome": e.outcome}
+                    for e in self._backend.get_episodes(limit=20)
+                ],
+                "_meta": {"budget_used": budget, "budget_total": budget},
+            }
+
+        # Build candidate list with priorities
+        candidates = []
+        for v in batched.get("values", []):
+            candidates.append((_compute_priority_score("value", v), "value", v))
+        for b in batched.get("beliefs", []):
+            candidates.append((_compute_priority_score("belief", b), "belief", b))
+        for g in batched.get("goals", []):
+            candidates.append((_compute_priority_score("goal", g), "goal", g))
+        for d in batched.get("drives", []):
+            candidates.append((_compute_priority_score("drive", d), "drive", d))
+        for e in batched.get("episodes", []):
+            candidates.append((_compute_priority_score("episode", e), "episode", e))
+        for n in batched.get("notes", []):
+            candidates.append((_compute_priority_score("note", n), "note", n))
+        for r in batched.get("relationships", []):
+            candidates.append((_compute_priority_score("relationship", r), "relationship", r))
+
+        # Summaries
+        all_summaries = self._backend.list_summaries(self.stack_id)
+        superseded_ids = set()
+        for s in all_summaries:
+            if s.supersedes:
+                superseded_ids.update(s.supersedes)
+        for s in all_summaries:
+            if s.id not in superseded_ids:
+                scope_key = f"summary_{s.scope}"
+                candidates.append((_compute_priority_score(scope_key, s), "summary", s))
+
+        # Self-narratives
+        active_narratives = self._backend.list_self_narratives(self.stack_id, active_only=True)
+        for n in active_narratives:
+            candidates.append((_compute_priority_score("self_narrative", n), "self_narrative", n))
+
+        candidates.sort(key=lambda x: x[0], reverse=True)
+
+        selected: Dict[str, list] = {
+            "values": [],
+            "beliefs": [],
+            "goals": [],
+            "drives": [],
+            "episodes": [],
+            "notes": [],
+            "relationships": [],
+            "summaries": [],
+            "self_narratives": [],
+        }
+
+        for priority, memory_type, record in candidates:
+            text = self._record_to_text(memory_type, record)
+            text = _truncate_at_word_boundary(text, DEFAULT_MAX_ITEM_CHARS)
+            tokens = _estimate_tokens(text)
+            if tokens <= remaining:
+                key = (
+                    memory_type + "s"
+                    if memory_type not in ("summary", "self_narrative")
+                    else ("summaries" if memory_type == "summary" else "self_narratives")
+                )
+                if key in selected:
+                    selected[key].append(record)
+                remaining -= tokens
+            if remaining <= 0:
+                break
+
+        # Format output
+        result: Dict[str, Any] = {
+            "values": [
+                {"id": v.id, "name": v.name, "statement": v.statement, "priority": v.priority}
+                for v in selected["values"]
+            ],
+            "beliefs": [
+                {
+                    "id": b.id,
+                    "statement": b.statement,
+                    "belief_type": b.belief_type,
+                    "confidence": b.confidence,
+                }
+                for b in selected["beliefs"]
+            ],
+            "goals": [
+                {
+                    "id": g.id,
+                    "title": g.title,
+                    "description": g.description,
+                    "priority": g.priority,
+                    "status": g.status,
+                }
+                for g in selected["goals"]
+            ],
+            "drives": [
+                {
+                    "id": d.id,
+                    "drive_type": d.drive_type,
+                    "intensity": d.intensity,
+                    "focus_areas": d.focus_areas,
+                }
+                for d in selected["drives"]
+            ],
+            "episodes": [
+                {
+                    "id": e.id,
+                    "objective": e.objective,
+                    "outcome": e.outcome,
+                    "tags": e.tags,
+                    "created_at": e.created_at.isoformat() if e.created_at else None,
+                }
+                for e in selected["episodes"]
+            ],
+            "notes": [
+                {
+                    "id": n.id,
+                    "content": n.content,
+                    "note_type": n.note_type,
+                    "tags": n.tags,
+                    "created_at": n.created_at.isoformat() if n.created_at else None,
+                }
+                for n in selected["notes"]
+            ],
+            "relationships": [
+                {
+                    "entity_name": r.entity_name,
+                    "entity_type": r.entity_type,
+                    "sentiment": r.sentiment,
+                    "notes": r.notes,
+                }
+                for r in selected["relationships"]
+            ],
+            "_meta": {
+                "budget_used": budget - remaining,
+                "budget_total": budget,
+            },
+        }
+
+        if selected["summaries"]:
+            result["summaries"] = [
+                {
+                    "id": s.id,
+                    "scope": s.scope,
+                    "content": _truncate_at_word_boundary(s.content, DEFAULT_MAX_ITEM_CHARS),
+                }
+                for s in selected["summaries"]
+            ]
+
+        if selected["self_narratives"]:
+            result["self_narratives"] = [
+                {
+                    "id": sn.id,
+                    "narrative_type": sn.narrative_type,
+                    "content": _truncate_at_word_boundary(sn.content, DEFAULT_MAX_ITEM_CHARS),
+                }
+                for sn in selected["self_narratives"]
+            ]
+
+        # Track access for salience
+        accesses = []
+        for key in ("values", "beliefs", "goals", "drives", "episodes", "notes", "relationships"):
+            for rec in selected[key]:
+                type_name = key.rstrip("s") if key != "values" else "value"
+                accesses.append((type_name, rec.id))
+        if accesses:
+            self._backend.record_access_batch(accesses)
+
+        return result
+
+    # ---- Meta-Memory ----
+
+    def record_access(self, memory_type: str, memory_id: str) -> bool:
+        return self._backend.record_access(memory_type, memory_id)
+
+    def update_memory_meta(
+        self,
+        memory_type: str,
+        memory_id: str,
+        *,
+        confidence: Optional[float] = None,
+        tags: Optional[List[str]] = None,
+    ) -> bool:
+        return self._backend.update_memory_meta(memory_type, memory_id, confidence=confidence)
+
+    def forget_memory(
+        self,
+        memory_type: str,
+        memory_id: str,
+        reason: str,
+    ) -> bool:
+        return self._backend.forget_memory(memory_type, memory_id, reason)
+
+    def recover_memory(self, memory_type: str, memory_id: str) -> bool:
+        return self._backend.recover_memory(memory_type, memory_id)
+
+    def protect_memory(
+        self,
+        memory_type: str,
+        memory_id: str,
+        protected: bool = True,
+    ) -> bool:
+        return self._backend.protect_memory(memory_type, memory_id, protected)
+
+    # ---- Trust Layer ----
+
+    def save_trust_assessment(self, assessment: TrustAssessment) -> str:
+        return self._backend.save_trust_assessment(assessment)
+
+    def get_trust_assessments(
+        self,
+        *,
+        entity_id: Optional[str] = None,
+        domain: Optional[str] = None,
+    ) -> List[TrustAssessment]:
+        assessments = self._backend.get_trust_assessments()
+        if entity_id:
+            assessments = [a for a in assessments if a.entity == entity_id]
+        return assessments
+
+    def compute_trust(
+        self,
+        entity_id: str,
+        domain: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Compute aggregate trust for an entity."""
+        assessment = self._backend.get_trust_assessment(entity_id)
+        if not assessment:
+            return {
+                "entity": entity_id,
+                "domain": domain or "general",
+                "score": 0.5,
+                "source": "default",
+            }
+        dimensions = assessment.dimensions or {}
+        d = domain or "general"
+        dim_data = dimensions.get(d, {})
+        score = dim_data.get("score", 0.5) if isinstance(dim_data, dict) else 0.5
+        return {
+            "entity": entity_id,
+            "domain": d,
+            "score": score,
+            "source": "assessment",
+        }
+
+    # ---- Features ----
+
+    def consolidate(
+        self,
+        *,
+        context: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Run memory consolidation."""
+        episodes = self._backend.get_episodes(limit=50)
+        if len(episodes) < 3:
+            return {
+                "consolidated": 0,
+                "lessons_found": 0,
+                "message": "Need at least 3 episodes to consolidate",
+            }
+        all_lessons = []
+        for ep in episodes:
+            if ep.lessons:
+                all_lessons.extend(ep.lessons)
+        lesson_counts = Counter(all_lessons)
+        common = [lesson for lesson, cnt in lesson_counts.items() if cnt >= 2]
+        return {
+            "consolidated": len(episodes),
+            "lessons_found": len(common),
+            "common_lessons": common[:5],
+        }
+
+    def apply_forgetting(
+        self,
+        *,
+        protect_identity: bool = True,
+    ) -> Dict[str, Any]:
+        """Apply salience-based forgetting."""
+        report = self.run_forgetting_cycle(
+            threshold=0.3,
+            limit=10,
+            dry_run=False,
+        )
+        return {
+            "forgotten": report.get("forgotten", 0),
+            "candidates": report.get("candidate_count", 0),
+            "protected": report.get("protected", 0),
+        }
+
+    # ---- Sync ----
+
+    def sync(self) -> ProtocolSyncResult:
+        storage_result = self._backend.sync()
+        return ProtocolSyncResult(
+            pushed=storage_result.pushed,
+            pulled=storage_result.pulled,
+            conflicts=storage_result.conflict_count,
+            errors=storage_result.errors,
+        )
+
+    def pull_changes(self, *, since: Optional[datetime] = None) -> ProtocolSyncResult:
+        storage_result = self._backend.pull_changes(since=since)
+        return ProtocolSyncResult(
+            pushed=storage_result.pushed,
+            pulled=storage_result.pulled,
+            conflicts=storage_result.conflict_count,
+            errors=storage_result.errors,
+        )
+
+    def get_pending_sync_count(self) -> int:
+        return self._backend.get_pending_sync_count()
+
+    def is_online(self) -> bool:
+        return self._backend.is_online()
+
+    # ---- Stats & Export ----
+
+    def get_stats(self) -> Dict[str, int]:
+        return self._backend.get_stats()
+
+    def dump(
+        self,
+        *,
+        format: str = "markdown",
+        include_raw: bool = True,
+        include_forgotten: bool = False,
+    ) -> str:
+        """Export all memories as a formatted string."""
+        if format == "json":
+            return self._dump_json(include_raw, include_forgotten)
+        return self._dump_markdown(include_raw, include_forgotten)
+
+    def export(self, path: str, *, format: str = "markdown") -> None:
+        """Export all memories to a file."""
+        content = self.dump(format=format)
+        if format == "markdown" and path.endswith(".json"):
+            content = self.dump(format="json")
+        elif format == "json" and (path.endswith(".md") or path.endswith(".markdown")):
+            content = self.dump(format="markdown")
+        export_path = Path(path)
+        export_path.parent.mkdir(parents=True, exist_ok=True)
+        export_path.write_text(content, encoding="utf-8")
+
+    # ---- Composition Hooks ----
+
+    def on_attach(
+        self,
+        core_id: str,
+        inference: Optional[InferenceService] = None,
+    ) -> None:
+        self._attached_core_id = core_id
+        self._inference = inference
+        for component in self._components.values():
+            component.set_inference(inference)
+
+    def on_detach(self, core_id: str) -> None:
+        self._attached_core_id = None
+        self._inference = None
+        for component in self._components.values():
+            component.set_inference(None)
+
+    def on_model_changed(
+        self,
+        inference: Optional[InferenceService],
+    ) -> None:
+        self._inference = inference
+        for component in self._components.values():
+            component.set_inference(inference)
+
+    # ---- Private Helpers ----
+
+    @staticmethod
+    def _record_to_text(memory_type: str, record: Any) -> str:
+        """Get text representation of a record for token estimation."""
+        if memory_type == "value":
+            return f"{record.name}: {record.statement}"
+        elif memory_type == "belief":
+            return record.statement
+        elif memory_type == "goal":
+            return f"{record.title} {record.description or ''}"
+        elif memory_type == "drive":
+            return f"{record.drive_type}: {record.focus_areas or ''}"
+        elif memory_type == "episode":
+            return f"{record.objective} {record.outcome}"
+        elif memory_type == "note":
+            return record.content
+        elif memory_type == "relationship":
+            return f"{record.entity_name}: {record.notes or ''}"
+        elif memory_type == "summary":
+            return f"[{record.scope}] {record.content}"
+        elif memory_type == "self_narrative":
+            return f"[{record.narrative_type}] {record.content}"
+        return str(record)
+
+    def _dump_markdown(self, include_raw: bool, include_forgotten: bool) -> str:
+        """Export memory as markdown."""
+        lines = [
+            f"# Memory Dump for {self.stack_id}",
+            f"_Exported at {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}_",
+            "",
+        ]
+        values = self._backend.get_values(limit=100)
+        if values:
+            lines.append("## Values")
+            for v in sorted(values, key=lambda x: x.priority, reverse=True):
+                lines.append(f"- **{v.name}** (priority {v.priority}): {v.statement}")
+            lines.append("")
+
+        beliefs = self._backend.get_beliefs(limit=100)
+        if beliefs:
+            lines.append("## Beliefs")
+            for b in sorted(beliefs, key=lambda x: x.confidence, reverse=True):
+                lines.append(f"- [{b.confidence:.0%}] {b.statement}")
+            lines.append("")
+
+        goals = self._backend.get_goals(status=None, limit=100)
+        if goals:
+            lines.append("## Goals")
+            for g in goals:
+                icon = "+" if g.status == "completed" else "o" if g.status == "active" else "-"
+                lines.append(f"- {icon} [{g.priority}] {g.title}")
+            lines.append("")
+
+        episodes = self._backend.get_episodes(limit=100)
+        if episodes:
+            lines.append("## Episodes")
+            for e in episodes:
+                date_str = e.created_at.strftime("%Y-%m-%d") if e.created_at else "unknown"
+                lines.append(f"### {e.objective}")
+                lines.append(f"*{date_str}* | {e.outcome}")
+                if e.lessons:
+                    for lesson in e.lessons:
+                        lines.append(f"  - {lesson}")
+                lines.append("")
+
+        notes = self._backend.get_notes(limit=100)
+        if notes:
+            lines.append("## Notes")
+            for n in notes:
+                lines.append(f"- [{n.note_type}] {n.content}")
+            lines.append("")
+
+        if include_raw:
+            raw_entries = self._backend.list_raw(limit=100)
+            if raw_entries:
+                lines.append("## Raw Entries")
+                for r in raw_entries:
+                    status = "done" if r.processed else "pending"
+                    lines.append(f"- [{status}] {r.content or r.blob or ''}")
+                lines.append("")
+
+        return "\n".join(lines)
+
+    def _dump_json(self, include_raw: bool, include_forgotten: bool) -> str:
+        """Export memory as JSON."""
+
+        def _dt(dt: Optional[datetime]) -> Optional[str]:
+            return dt.isoformat() if dt else None
+
+        data: Dict[str, Any] = {
+            "stack_id": self.stack_id,
+            "exported_at": datetime.now(timezone.utc).isoformat(),
+            "values": [
+                {"id": v.id, "name": v.name, "statement": v.statement, "priority": v.priority}
+                for v in self._backend.get_values(limit=100)
+            ],
+            "beliefs": [
+                {"id": b.id, "statement": b.statement, "confidence": b.confidence}
+                for b in self._backend.get_beliefs(limit=100)
+            ],
+            "goals": [
+                {"id": g.id, "title": g.title, "status": g.status, "priority": g.priority}
+                for g in self._backend.get_goals(status=None, limit=100)
+            ],
+            "episodes": [
+                {
+                    "id": e.id,
+                    "objective": e.objective,
+                    "outcome": e.outcome,
+                    "created_at": _dt(e.created_at),
+                }
+                for e in self._backend.get_episodes(limit=100)
+            ],
+            "notes": [
+                {"id": n.id, "content": n.content, "note_type": n.note_type}
+                for n in self._backend.get_notes(limit=100)
+            ],
+        }
+        if include_raw:
+            data["raw_entries"] = [
+                {"id": r.id, "content": r.content, "processed": r.processed}
+                for r in self._backend.list_raw(limit=100)
+            ]
+        return json.dumps(data, indent=2, default=str)
+
+    # ---- Mixin compatibility helpers ----
+    # These are needed by the mixins that reference methods on Kernle
+    # that don't exist on the stack. We provide minimal stubs.
+
+    def load_checkpoint(self) -> Optional[Dict[str, Any]]:
+        """Load checkpoint (stub for mixin compatibility)."""
+        # Checkpoints are a Kernle concept, not a stack concept.
+        # Return None to signal no checkpoint.
+        return None
+
+    def list_raw(self, processed: Optional[bool] = None, limit: int = 100) -> List[Any]:
+        """List raw entries (mixin compatibility)."""
+        entries = self._backend.list_raw(processed=processed, limit=limit)
+        # Return as dicts for AnxietyMixin compatibility
+        result = []
+        for e in entries:
+            result.append(
+                {
+                    "id": e.id,
+                    "captured_at": e.captured_at.isoformat() if e.captured_at else None,
+                    "timestamp": e.timestamp.isoformat() if e.timestamp else None,
+                    "content": e.content,
+                    "processed": e.processed,
+                }
+            )
+        return result
+
+    def get_identity_confidence(self) -> float:
+        """Get identity confidence (mixin compatibility).
+
+        Measures coherence from values and beliefs.
+        """
+        values = self._backend.get_values(limit=10)
+        beliefs = self._backend.get_beliefs(limit=20)
+        if not values and not beliefs:
+            return 0.0
+        total_conf = 0.0
+        count = 0
+        for v in values:
+            total_conf += v.confidence
+            count += 1
+        for b in beliefs:
+            total_conf += b.confidence
+            count += 1
+        return total_conf / count if count > 0 else 0.0
+
+    def get_sync_status(self) -> Dict[str, Any]:
+        """Get sync status (mixin compatibility)."""
+        return {
+            "online": self._backend.is_online(),
+            "pending": self._backend.get_pending_sync_count(),
+        }
+
+    def synthesize_identity(self) -> Dict[str, Any]:
+        """Synthesize identity (stub for mixin compatibility)."""
+        return {"confidence": self.get_identity_confidence()}
+
+    def checkpoint(self, **kwargs: Any) -> Optional[Dict[str, Any]]:
+        """Checkpoint (stub for mixin compatibility)."""
+        return None
+
+    def episode(self, **kwargs: Any) -> Optional[str]:
+        """Episode creation (stub for mixin compatibility)."""
+        return None
+
+    def boot_list(self) -> Dict[str, str]:
+        """Boot config (stub for mixin compatibility)."""
+        return {}

--- a/tests/test_sqlite_stack.py
+++ b/tests/test_sqlite_stack.py
@@ -1,0 +1,812 @@
+"""Tests for SQLiteStack conforming to StackProtocol.
+
+Tests cover:
+- Basic CRUD for each memory type through the stack
+- Detached mode operation (no core attached)
+- Composition hooks (on_attach, on_detach, on_model_changed)
+- Component registry (add/remove)
+- Search, load, stats, dump/export
+- Meta-memory operations (forget, recover, protect, record_access)
+- Trust layer
+- Feature methods (consolidate, apply_forgetting)
+"""
+
+import json
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from kernle.protocols import (
+    InferenceService,
+    StackComponentProtocol,
+)
+from kernle.protocols import (
+    SearchResult as ProtocolSearchResult,
+)
+from kernle.protocols import (
+    SyncResult as ProtocolSyncResult,
+)
+from kernle.stack import SQLiteStack
+from kernle.types import (
+    Belief,
+    Drive,
+    Episode,
+    Epoch,
+    Goal,
+    MemorySuggestion,
+    Note,
+    Playbook,
+    RawEntry,
+    Relationship,
+    SelfNarrative,
+    Summary,
+    TrustAssessment,
+    Value,
+)
+
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    """Create a temp database path."""
+    return tmp_path / "test_stack.db"
+
+
+@pytest.fixture
+def stack(tmp_db):
+    """Create an SQLiteStack instance with a temp database."""
+    return SQLiteStack(stack_id="test-stack", db_path=tmp_db)
+
+
+@pytest.fixture
+def stack_id():
+    return "test-stack"
+
+
+def _make_episode(stack_id: str, **overrides) -> Episode:
+    defaults = {
+        "id": str(uuid.uuid4()),
+        "stack_id": stack_id,
+        "objective": "Test objective",
+        "outcome": "Test outcome",
+        "created_at": datetime.now(timezone.utc),
+    }
+    defaults.update(overrides)
+    return Episode(**defaults)
+
+
+def _make_belief(stack_id: str, **overrides) -> Belief:
+    defaults = {
+        "id": str(uuid.uuid4()),
+        "stack_id": stack_id,
+        "statement": "Test belief",
+        "confidence": 0.8,
+    }
+    defaults.update(overrides)
+    return Belief(**defaults)
+
+
+def _make_value(stack_id: str, **overrides) -> Value:
+    defaults = {
+        "id": str(uuid.uuid4()),
+        "stack_id": stack_id,
+        "name": "Test Value",
+        "statement": "Test value statement",
+        "priority": 50,
+    }
+    defaults.update(overrides)
+    return Value(**defaults)
+
+
+def _make_goal(stack_id: str, **overrides) -> Goal:
+    defaults = {
+        "id": str(uuid.uuid4()),
+        "stack_id": stack_id,
+        "title": "Test goal",
+        "status": "active",
+    }
+    defaults.update(overrides)
+    return Goal(**defaults)
+
+
+def _make_note(stack_id: str, **overrides) -> Note:
+    defaults = {
+        "id": str(uuid.uuid4()),
+        "stack_id": stack_id,
+        "content": "Test note content",
+    }
+    defaults.update(overrides)
+    return Note(**defaults)
+
+
+def _make_drive(stack_id: str, **overrides) -> Drive:
+    defaults = {
+        "id": str(uuid.uuid4()),
+        "stack_id": stack_id,
+        "drive_type": "curiosity",
+        "intensity": 0.7,
+    }
+    defaults.update(overrides)
+    return Drive(**defaults)
+
+
+def _make_relationship(stack_id: str, **overrides) -> Relationship:
+    defaults = {
+        "id": str(uuid.uuid4()),
+        "stack_id": stack_id,
+        "entity_name": "alice",
+        "entity_type": "human",
+        "relationship_type": "collaborator",
+    }
+    defaults.update(overrides)
+    return Relationship(**defaults)
+
+
+# ===========================================================================
+# Properties
+# ===========================================================================
+
+
+class TestProperties:
+    def test_stack_id(self, stack):
+        assert stack.stack_id == "test-stack"
+
+    def test_schema_version(self, stack):
+        assert isinstance(stack.schema_version, int)
+        assert stack.schema_version > 0
+
+
+# ===========================================================================
+# Write + Read: Episodes
+# ===========================================================================
+
+
+class TestEpisodes:
+    def test_save_and_get(self, stack, stack_id):
+        ep = _make_episode(stack_id, objective="Learn Python", outcome="Completed tutorial")
+        eid = stack.save_episode(ep)
+        assert eid == ep.id
+
+        episodes = stack.get_episodes(limit=10)
+        assert len(episodes) >= 1
+        found = [e for e in episodes if e.id == ep.id]
+        assert len(found) == 1
+        assert found[0].objective == "Learn Python"
+
+    def test_batch_save(self, stack, stack_id):
+        eps = [_make_episode(stack_id, objective=f"Task {i}") for i in range(3)]
+        ids = stack.save_episodes_batch(eps)
+        assert len(ids) == 3
+
+    def test_get_memory(self, stack, stack_id):
+        ep = _make_episode(stack_id)
+        stack.save_episode(ep)
+        result = stack.get_memory("episode", ep.id)
+        assert result is not None
+        assert result.id == ep.id
+
+
+# ===========================================================================
+# Write + Read: Beliefs
+# ===========================================================================
+
+
+class TestBeliefs:
+    def test_save_and_get(self, stack, stack_id):
+        b = _make_belief(stack_id, statement="Python is great")
+        bid = stack.save_belief(b)
+        assert bid == b.id
+
+        beliefs = stack.get_beliefs(limit=10)
+        assert any(bl.id == b.id for bl in beliefs)
+
+    def test_filter_by_type(self, stack, stack_id):
+        b1 = _make_belief(stack_id, belief_type="fact", statement="Fact 1")
+        b2 = _make_belief(stack_id, belief_type="opinion", statement="Opinion 1")
+        stack.save_belief(b1)
+        stack.save_belief(b2)
+
+        facts = stack.get_beliefs(belief_type="fact")
+        assert all(b.belief_type == "fact" for b in facts)
+
+    def test_filter_by_confidence(self, stack, stack_id):
+        b1 = _make_belief(stack_id, confidence=0.9, statement="High conf")
+        b2 = _make_belief(stack_id, confidence=0.3, statement="Low conf")
+        stack.save_belief(b1)
+        stack.save_belief(b2)
+
+        high = stack.get_beliefs(min_confidence=0.5)
+        assert all(b.confidence >= 0.5 for b in high)
+
+    def test_batch_save(self, stack, stack_id):
+        beliefs = [_make_belief(stack_id, statement=f"Belief {i}") for i in range(3)]
+        ids = stack.save_beliefs_batch(beliefs)
+        assert len(ids) == 3
+
+
+# ===========================================================================
+# Write + Read: Values
+# ===========================================================================
+
+
+class TestValues:
+    def test_save_and_get(self, stack, stack_id):
+        v = _make_value(stack_id)
+        vid = stack.save_value(v)
+        assert vid == v.id
+
+        values = stack.get_values()
+        assert any(val.id == v.id for val in values)
+
+
+# ===========================================================================
+# Write + Read: Goals
+# ===========================================================================
+
+
+class TestGoals:
+    def test_save_and_get(self, stack, stack_id):
+        g = _make_goal(stack_id, title="Ship v1.0")
+        gid = stack.save_goal(g)
+        assert gid == g.id
+
+        goals = stack.get_goals(status="active")
+        assert any(gl.id == g.id for gl in goals)
+
+
+# ===========================================================================
+# Write + Read: Notes
+# ===========================================================================
+
+
+class TestNotes:
+    def test_save_and_get(self, stack, stack_id):
+        n = _make_note(stack_id)
+        nid = stack.save_note(n)
+        assert nid == n.id
+
+        notes = stack.get_notes()
+        assert any(nt.id == n.id for nt in notes)
+
+    def test_batch_save(self, stack, stack_id):
+        notes = [_make_note(stack_id, content=f"Note {i}") for i in range(3)]
+        ids = stack.save_notes_batch(notes)
+        assert len(ids) == 3
+
+
+# ===========================================================================
+# Write + Read: Drives
+# ===========================================================================
+
+
+class TestDrives:
+    def test_save_and_get(self, stack, stack_id):
+        d = _make_drive(stack_id)
+        did = stack.save_drive(d)
+        assert did == d.id
+
+        drives = stack.get_drives()
+        assert any(dr.id == d.id for dr in drives)
+
+
+# ===========================================================================
+# Write + Read: Relationships
+# ===========================================================================
+
+
+class TestRelationships:
+    def test_save_and_get(self, stack, stack_id):
+        r = _make_relationship(stack_id)
+        rid = stack.save_relationship(r)
+        assert rid == r.id
+
+        rels = stack.get_relationships()
+        assert any(rel.id == r.id for rel in rels)
+
+    def test_filter_by_entity_id(self, stack, stack_id):
+        r1 = _make_relationship(stack_id, entity_name="alice")
+        r2 = _make_relationship(stack_id, entity_name="bob")
+        stack.save_relationship(r1)
+        stack.save_relationship(r2)
+
+        alice_rels = stack.get_relationships(entity_id="alice")
+        assert all(r.entity_name == "alice" for r in alice_rels)
+
+
+# ===========================================================================
+# Write + Read: Playbooks
+# ===========================================================================
+
+
+class TestPlaybooks:
+    def test_save_and_retrieve(self, stack, stack_id):
+        pb = Playbook(
+            id=str(uuid.uuid4()),
+            stack_id=stack_id,
+            name="Deploy",
+            description="Deploy procedure",
+            trigger_conditions=["release ready"],
+            steps=[{"action": "deploy"}],
+            failure_modes=["timeout"],
+        )
+        pid = stack.save_playbook(pb)
+        assert pid == pb.id
+
+
+# ===========================================================================
+# Write + Read: Epochs, Summaries, SelfNarratives, Suggestions
+# ===========================================================================
+
+
+class TestAdvancedTypes:
+    def test_save_epoch(self, stack, stack_id):
+        ep = Epoch(
+            id=str(uuid.uuid4()),
+            stack_id=stack_id,
+            epoch_number=1,
+            name="Beginning",
+        )
+        eid = stack.save_epoch(ep)
+        assert eid == ep.id
+
+    def test_save_summary(self, stack, stack_id):
+        s = Summary(
+            id=str(uuid.uuid4()),
+            stack_id=stack_id,
+            scope="month",
+            period_start="2025-01-01",
+            period_end="2025-01-31",
+            content="Summary of January",
+        )
+        sid = stack.save_summary(s)
+        assert sid == s.id
+
+    def test_save_self_narrative(self, stack, stack_id):
+        n = SelfNarrative(
+            id=str(uuid.uuid4()),
+            stack_id=stack_id,
+            content="I am a test entity",
+            narrative_type="identity",
+        )
+        nid = stack.save_self_narrative(n)
+        assert nid == n.id
+
+    def test_save_suggestion(self, stack, stack_id):
+        sg = MemorySuggestion(
+            id=str(uuid.uuid4()),
+            stack_id=stack_id,
+            memory_type="belief",
+            content={"statement": "Testing is good"},
+            confidence=0.7,
+            source_raw_ids=["raw-1"],
+        )
+        sid = stack.save_suggestion(sg)
+        assert sid == sg.id
+
+
+# ===========================================================================
+# Search
+# ===========================================================================
+
+
+class TestSearch:
+    def test_search_returns_protocol_results(self, stack, stack_id):
+        ep = _make_episode(stack_id, objective="unique searchable objective XYZ123")
+        stack.save_episode(ep)
+
+        results = stack.search("XYZ123")
+        # Search may or may not find it depending on indexing
+        assert isinstance(results, list)
+        for r in results:
+            assert isinstance(r, ProtocolSearchResult)
+            assert hasattr(r, "memory_type")
+            assert hasattr(r, "memory_id")
+            assert hasattr(r, "content")
+            assert hasattr(r, "score")
+
+
+# ===========================================================================
+# Working Memory (load)
+# ===========================================================================
+
+
+class TestLoad:
+    def test_load_returns_dict(self, stack, stack_id):
+        # Add some data
+        stack.save_value(_make_value(stack_id))
+        stack.save_belief(_make_belief(stack_id))
+        stack.save_episode(_make_episode(stack_id))
+
+        result = stack.load(token_budget=4000)
+        assert isinstance(result, dict)
+        assert "values" in result
+        assert "beliefs" in result
+        assert "_meta" in result
+        assert result["_meta"]["budget_total"] == 4000
+
+    def test_load_respects_budget(self, stack, stack_id):
+        # Add lots of data
+        for i in range(20):
+            stack.save_episode(_make_episode(stack_id, objective=f"Episode {i} " * 50))
+
+        result = stack.load(token_budget=MIN_TOKEN_BUDGET)
+        used = result["_meta"]["budget_used"]
+        assert used <= MIN_TOKEN_BUDGET + 100  # some slack for estimation
+
+    def test_load_empty_stack(self, stack):
+        result = stack.load()
+        assert isinstance(result, dict)
+
+
+# Minimum token budget for test reference
+MIN_TOKEN_BUDGET = 100
+
+
+# ===========================================================================
+# Detached Mode
+# ===========================================================================
+
+
+class TestDetachedMode:
+    """Stack should work without a core attached."""
+
+    def test_works_without_core(self, stack, stack_id):
+        assert stack._attached_core_id is None
+        assert stack._inference is None
+
+        # All operations should work
+        ep = _make_episode(stack_id)
+        stack.save_episode(ep)
+        episodes = stack.get_episodes()
+        assert len(episodes) >= 1
+
+        b = _make_belief(stack_id)
+        stack.save_belief(b)
+        beliefs = stack.get_beliefs()
+        assert len(beliefs) >= 1
+
+        stats = stack.get_stats()
+        assert isinstance(stats, dict)
+
+    def test_search_works_detached(self, stack, stack_id):
+        stack.save_note(_make_note(stack_id, content="detached search test"))
+        results = stack.search("detached")
+        assert isinstance(results, list)
+
+
+# ===========================================================================
+# Composition Hooks
+# ===========================================================================
+
+
+class TestCompositionHooks:
+    def test_on_attach(self, stack):
+        assert stack._attached_core_id is None
+        stack.on_attach("core-123")
+        assert stack._attached_core_id == "core-123"
+        assert stack._inference is None
+
+    def test_on_attach_with_inference(self, stack):
+        mock_inference = MagicMock(spec=InferenceService)
+        stack.on_attach("core-456", inference=mock_inference)
+        assert stack._attached_core_id == "core-456"
+        assert stack._inference is mock_inference
+
+    def test_on_detach(self, stack):
+        stack.on_attach("core-789")
+        assert stack._attached_core_id == "core-789"
+
+        stack.on_detach("core-789")
+        assert stack._attached_core_id is None
+        assert stack._inference is None
+
+    def test_on_model_changed(self, stack):
+        mock_inference = MagicMock(spec=InferenceService)
+        stack.on_attach("core-100")
+
+        stack.on_model_changed(mock_inference)
+        assert stack._inference is mock_inference
+
+        stack.on_model_changed(None)
+        assert stack._inference is None
+
+    def test_hooks_propagate_to_components(self, stack):
+        component = MagicMock(spec=StackComponentProtocol)
+        component.name = "test-comp"
+        component.required = False
+        stack.add_component(component)
+
+        mock_inference = MagicMock(spec=InferenceService)
+        stack.on_attach("core-200", inference=mock_inference)
+        component.set_inference.assert_called_with(mock_inference)
+
+        stack.on_model_changed(None)
+        component.set_inference.assert_called_with(None)
+
+        stack.on_detach("core-200")
+        component.set_inference.assert_called_with(None)
+
+
+# ===========================================================================
+# Component Registry
+# ===========================================================================
+
+
+class TestComponentRegistry:
+    def _make_component(self, name: str = "test-comp", required: bool = False):
+        comp = MagicMock(spec=StackComponentProtocol)
+        comp.name = name
+        comp.required = required
+        return comp
+
+    def test_empty_components(self, stack):
+        assert stack.components == {}
+
+    def test_add_component(self, stack):
+        comp = self._make_component("embedding")
+        stack.add_component(comp)
+
+        assert "embedding" in stack.components
+        comp.attach.assert_called_once_with(stack.stack_id, None)
+
+    def test_add_duplicate_raises(self, stack):
+        comp = self._make_component("embedding")
+        stack.add_component(comp)
+
+        with pytest.raises(ValueError, match="already registered"):
+            stack.add_component(self._make_component("embedding"))
+
+    def test_remove_component(self, stack):
+        comp = self._make_component("forgetting")
+        stack.add_component(comp)
+        assert "forgetting" in stack.components
+
+        stack.remove_component("forgetting")
+        assert "forgetting" not in stack.components
+        comp.detach.assert_called_once()
+
+    def test_remove_nonexistent_raises(self, stack):
+        with pytest.raises(ValueError, match="not found"):
+            stack.remove_component("nonexistent")
+
+    def test_remove_required_raises(self, stack):
+        comp = self._make_component("embedding", required=True)
+        stack.add_component(comp)
+
+        with pytest.raises(ValueError, match="required"):
+            stack.remove_component("embedding")
+
+    def test_get_component(self, stack):
+        comp = self._make_component("meta")
+        stack.add_component(comp)
+
+        assert stack.get_component("meta") is comp
+        assert stack.get_component("nonexistent") is None
+
+    def test_maintenance_calls_components(self, stack):
+        comp = self._make_component("sweeper")
+        comp.on_maintenance.return_value = {"swept": 5}
+        stack.add_component(comp)
+
+        results = stack.maintenance()
+        assert "sweeper" in results
+        assert results["sweeper"] == {"swept": 5}
+
+    def test_maintenance_handles_errors(self, stack):
+        comp = self._make_component("broken")
+        comp.on_maintenance.side_effect = RuntimeError("broke")
+        stack.add_component(comp)
+
+        results = stack.maintenance()
+        assert "error" in results["broken"]
+
+    def test_components_returns_copy(self, stack):
+        comp = self._make_component("test")
+        stack.add_component(comp)
+        components = stack.components
+        components["injected"] = MagicMock()
+        assert "injected" not in stack.components
+
+
+# ===========================================================================
+# Meta-Memory Operations
+# ===========================================================================
+
+
+class TestMetaMemory:
+    def test_record_access(self, stack, stack_id):
+        ep = _make_episode(stack_id)
+        stack.save_episode(ep)
+        result = stack.record_access("episode", ep.id)
+        assert result is True
+
+    def test_forget_and_recover(self, stack, stack_id):
+        ep = _make_episode(stack_id)
+        stack.save_episode(ep)
+
+        forgotten = stack.forget_memory("episode", ep.id, "test reason")
+        assert forgotten is True
+
+        # Should be excluded by default
+        episodes = stack.get_episodes(include_forgotten=False)
+        assert not any(e.id == ep.id for e in episodes)
+
+        # Include forgotten
+        all_eps = stack.get_episodes(include_forgotten=True)
+        assert any(e.id == ep.id for e in all_eps)
+
+        # Recover
+        recovered = stack.recover_memory("episode", ep.id)
+        assert recovered is True
+
+        # Should be back
+        episodes = stack.get_episodes(include_forgotten=False)
+        assert any(e.id == ep.id for e in episodes)
+
+    def test_protect_memory(self, stack, stack_id):
+        ep = _make_episode(stack_id)
+        stack.save_episode(ep)
+
+        result = stack.protect_memory("episode", ep.id, True)
+        assert result is True
+
+
+# ===========================================================================
+# Trust Layer
+# ===========================================================================
+
+
+class TestTrustLayer:
+    def test_save_and_get_assessment(self, stack, stack_id):
+        ta = TrustAssessment(
+            id=str(uuid.uuid4()),
+            stack_id=stack_id,
+            entity="alice",
+            dimensions={"general": {"score": 0.8}},
+        )
+        tid = stack.save_trust_assessment(ta)
+        assert tid == ta.id
+
+        assessments = stack.get_trust_assessments(entity_id="alice")
+        assert len(assessments) >= 1
+
+    def test_compute_trust_default(self, stack):
+        result = stack.compute_trust("unknown-entity")
+        assert result["score"] == 0.5
+        assert result["source"] == "default"
+
+    def test_compute_trust_with_assessment(self, stack, stack_id):
+        ta = TrustAssessment(
+            id=str(uuid.uuid4()),
+            stack_id=stack_id,
+            entity="bob",
+            dimensions={"general": {"score": 0.9}},
+        )
+        stack.save_trust_assessment(ta)
+
+        result = stack.compute_trust("bob")
+        assert result["score"] == 0.9
+
+
+# ===========================================================================
+# Features
+# ===========================================================================
+
+
+class TestFeatures:
+    def test_consolidate_not_enough_episodes(self, stack):
+        result = stack.consolidate()
+        assert result["consolidated"] == 0
+
+    def test_consolidate_with_episodes(self, stack, stack_id):
+        for i in range(5):
+            ep = _make_episode(
+                stack_id,
+                objective=f"Task {i}",
+                outcome="done",
+                lessons=["lesson A", "lesson B"] if i % 2 == 0 else ["lesson A"],
+            )
+            stack.save_episode(ep)
+
+        result = stack.consolidate()
+        assert result["consolidated"] >= 3
+
+    def test_apply_forgetting(self, stack, stack_id):
+        # Create some low-salience episodes
+        for i in range(3):
+            ep = _make_episode(stack_id, confidence=0.1)
+            stack.save_episode(ep)
+
+        result = stack.apply_forgetting()
+        assert isinstance(result, dict)
+        assert "forgotten" in result
+
+
+# ===========================================================================
+# Stats & Export
+# ===========================================================================
+
+
+class TestStatsExport:
+    def test_get_stats(self, stack, stack_id):
+        stack.save_episode(_make_episode(stack_id))
+        stack.save_belief(_make_belief(stack_id))
+        stats = stack.get_stats()
+        assert isinstance(stats, dict)
+        assert stats.get("episodes", 0) >= 1
+        assert stats.get("beliefs", 0) >= 1
+
+    def test_dump_markdown(self, stack, stack_id):
+        stack.save_value(_make_value(stack_id))
+        content = stack.dump(format="markdown")
+        assert "# Memory Dump for test-stack" in content
+        assert "## Values" in content
+
+    def test_dump_json(self, stack, stack_id):
+        stack.save_belief(_make_belief(stack_id))
+        content = stack.dump(format="json")
+        data = json.loads(content)
+        assert data["stack_id"] == "test-stack"
+        assert "beliefs" in data
+
+    def test_export_to_file(self, stack, stack_id, tmp_path):
+        stack.save_value(_make_value(stack_id))
+        export_path = str(tmp_path / "export.md")
+        stack.export(export_path)
+        assert Path(export_path).exists()
+        content = Path(export_path).read_text()
+        assert "Memory Dump" in content
+
+    def test_export_json_by_extension(self, stack, stack_id, tmp_path):
+        stack.save_value(_make_value(stack_id))
+        export_path = str(tmp_path / "export.json")
+        stack.export(export_path, format="markdown")
+        content = Path(export_path).read_text()
+        data = json.loads(content)
+        assert "stack_id" in data
+
+
+# ===========================================================================
+# Sync
+# ===========================================================================
+
+
+class TestSync:
+    def test_sync(self, stack):
+        result = stack.sync()
+        assert isinstance(result, ProtocolSyncResult)
+
+    def test_pull_changes(self, stack):
+        result = stack.pull_changes()
+        assert isinstance(result, ProtocolSyncResult)
+
+    def test_pending_sync_count(self, stack):
+        count = stack.get_pending_sync_count()
+        assert isinstance(count, int)
+        assert count >= 0
+
+    def test_is_online(self, stack):
+        result = stack.is_online()
+        assert isinstance(result, bool)
+
+
+# ===========================================================================
+# Raw Entries
+# ===========================================================================
+
+
+class TestRawEntries:
+    def test_save_and_get_raw(self, stack, stack_id):
+        raw = RawEntry(
+            id=str(uuid.uuid4()),
+            stack_id=stack_id,
+            blob="raw brain dump",
+            source="test",
+        )
+        rid = stack.save_raw(raw)
+        assert isinstance(rid, str)
+
+        entries = stack.get_raw()
+        assert len(entries) >= 1


### PR DESCRIPTION
## Summary
- Add `kernle/stack/` package with `SQLiteStack` class wrapping `SQLiteStorage` to implement the full `StackProtocol` from `protocols.py`
- Feature mixins (Anxiety, Consolidation, Emotions, Forgetting, Knowledge, MetaMemory, Suggestions) applied identically to how Kernle uses them
- Composition hooks (`on_attach`, `on_detach`, `on_model_changed`) propagate inference service to stack components
- Component registry infrastructure (`add_component`, `remove_component`, `get_component`, `maintenance`) ready for v0.5.0
- Budget-aware `load()` with priority-based memory selection matching Kernle's behavior
- Works fully in detached mode (no core required)

## Test plan
- [x] 61 unit tests in `tests/test_sqlite_stack.py`
- [x] CRUD for all memory types (episodes, beliefs, values, goals, notes, drives, relationships, playbooks, epochs, summaries, self-narratives, suggestions)
- [x] Search returns `ProtocolSearchResult` instances
- [x] Budget-aware `load()` respects token limits
- [x] Detached mode (no core attached) operations
- [x] Composition hooks propagate to components
- [x] Component registry add/remove/get with error handling
- [x] Meta-memory: forget, recover, protect, record_access
- [x] Trust layer: save/get assessments, compute trust
- [x] Features: consolidate, apply_forgetting
- [x] Stats, dump (markdown + JSON), export to file
- [x] Sync operations return `ProtocolSyncResult`
- [x] Full existing test suite passes (2007 passed, 1 pre-existing failure in sqlite-vec)

Closes #247