### PR TITLE
Add Kernle compatibility layer with Entity and SQLiteStack (#253)

### DIFF
--- a/tests/test_compat_layer.py
+++ b/tests/test_compat_layer.py
@@ -1,0 +1,169 @@
+"""Tests for the Kernle compatibility layer (v0.4.0).
+
+Verifies that the Kernle class exposes Entity and SQLiteStack
+via lazy properties, while preserving full backward compatibility
+with the existing _storage-based code paths.
+"""
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from kernle.core import Kernle
+from kernle.entity import Entity
+from kernle.stack.sqlite_stack import SQLiteStack
+from kernle.storage import SQLiteStorage
+from kernle.storage.base import Note
+
+
+@pytest.fixture
+def kernle_sqlite(tmp_path):
+    """Kernle instance backed by SQLite for compat-layer tests."""
+    db_path = tmp_path / "compat_test.db"
+    storage = SQLiteStorage(stack_id="compat_agent", db_path=db_path)
+    k = Kernle(stack_id="compat_agent", storage=storage, checkpoint_dir=tmp_path / "cp")
+    yield k
+    storage.close()
+
+
+class TestEntityProperty:
+    """Tests for Kernle.entity lazy property."""
+
+    def test_entity_returns_entity_instance(self, kernle_sqlite):
+        e = kernle_sqlite.entity
+        assert isinstance(e, Entity)
+
+    def test_entity_core_id_matches_stack_id(self, kernle_sqlite):
+        e = kernle_sqlite.entity
+        assert e.core_id == kernle_sqlite.stack_id
+
+    def test_entity_is_lazily_created(self, kernle_sqlite):
+        assert not hasattr(kernle_sqlite, "_entity")
+        _ = kernle_sqlite.entity
+        assert hasattr(kernle_sqlite, "_entity")
+
+    def test_entity_is_cached(self, kernle_sqlite):
+        e1 = kernle_sqlite.entity
+        e2 = kernle_sqlite.entity
+        assert e1 is e2
+
+
+class TestStackProperty:
+    """Tests for Kernle.stack lazy property."""
+
+    def test_stack_returns_sqlite_stack(self, kernle_sqlite):
+        s = kernle_sqlite.stack
+        assert isinstance(s, SQLiteStack)
+
+    def test_stack_uses_same_db_path(self, kernle_sqlite):
+        s = kernle_sqlite.stack
+        assert s._backend.db_path == kernle_sqlite._storage.db_path
+
+    def test_stack_is_lazily_created(self, kernle_sqlite):
+        assert not hasattr(kernle_sqlite, "_stack")
+        _ = kernle_sqlite.stack
+        assert hasattr(kernle_sqlite, "_stack")
+
+    def test_stack_is_cached(self, kernle_sqlite):
+        s1 = kernle_sqlite.stack
+        s2 = kernle_sqlite.stack
+        assert s1 is s2
+
+    def test_stack_returns_none_for_non_sqlite(self, tmp_path):
+        """If the storage is not SQLite, .stack returns None."""
+        from unittest.mock import MagicMock
+
+        mock_storage = MagicMock()
+        mock_storage.is_online.return_value = False
+        mock_storage.get_pending_sync_count.return_value = 0
+
+        k = Kernle(stack_id="mock_agent", storage=mock_storage, checkpoint_dir=tmp_path / "cp")
+        assert k.stack is None
+
+
+class TestEntityStackIntegration:
+    """Tests for entity + stack working together."""
+
+    def test_entity_then_stack_attaches_automatically(self, kernle_sqlite):
+        """Accessing .entity first, then .stack, auto-attaches the stack."""
+        e = kernle_sqlite.entity
+        s = kernle_sqlite.stack
+        assert e.active_stack is s
+
+    def test_stack_then_entity_does_not_auto_attach(self, kernle_sqlite):
+        """Accessing .stack first, then .entity, does NOT auto-attach."""
+        _ = kernle_sqlite.stack  # noqa: F841 - trigger lazy creation
+        e = kernle_sqlite.entity
+        # Stack was created before entity, so no auto-attach happened
+        assert e.active_stack is None
+
+    def test_manual_attach_after_both_created(self, kernle_sqlite):
+        """User can manually attach stack to entity."""
+        s = kernle_sqlite.stack
+        e = kernle_sqlite.entity
+        e.attach_stack(s, alias="default", set_active=True)
+        assert e.active_stack is s
+
+    def test_entity_can_write_through_stack(self, kernle_sqlite):
+        """Full round-trip: entity writes to stack, data visible in storage."""
+        _ = kernle_sqlite.entity  # create entity first
+        _ = kernle_sqlite.stack  # auto-attaches
+
+        ep_id = kernle_sqlite.entity.episode(
+            objective="Test compat layer",
+            outcome="Verified round-trip works",
+        )
+        assert ep_id is not None
+
+        # The episode should be retrievable from the stack
+        episodes = kernle_sqlite.stack.get_episodes(limit=10)
+        assert any(ep.id == ep_id for ep in episodes)
+
+
+class TestBackwardCompatibility:
+    """Verify that existing code paths are not affected."""
+
+    def test_storage_property_still_works(self, kernle_sqlite):
+        assert kernle_sqlite.storage is kernle_sqlite._storage
+
+    def test_internal_storage_unaffected(self, kernle_sqlite):
+        """Internal _storage attribute still works for all operations."""
+        note = Note(
+            id=str(uuid.uuid4()),
+            stack_id="compat_agent",
+            content="test note",
+            note_type="observation",
+            created_at=datetime.now(timezone.utc),
+        )
+        note_id = kernle_sqlite._storage.save_note(note)
+        assert note_id is not None
+        notes = kernle_sqlite._storage.get_notes()
+        assert len(notes) >= 1
+
+    def test_existing_methods_work(self, kernle_sqlite):
+        """Core methods that use self._storage still work."""
+        ep_id = kernle_sqlite.episode(
+            objective="Test backward compat",
+            outcome="Methods still work",
+        )
+        assert ep_id is not None
+
+    def test_entity_and_stack_do_not_interfere_with_storage(self, kernle_sqlite):
+        """Creating entity/stack doesn't break _storage operations."""
+        # Create entity and stack
+        _ = kernle_sqlite.entity
+        _ = kernle_sqlite.stack
+
+        # _storage should still work fine
+        note = Note(
+            id=str(uuid.uuid4()),
+            stack_id="compat_agent",
+            content="after entity/stack creation",
+            note_type="observation",
+            created_at=datetime.now(timezone.utc),
+        )
+        note_id = kernle_sqlite._storage.save_note(note)
+        assert note_id is not None
+        notes = kernle_sqlite._storage.get_notes()
+        assert any(n.content == "after entity/stack creation" for n in notes)


### PR DESCRIPTION
## Summary
- Adds lazy `.entity` and `.stack` properties to the `Kernle` class, exposing the new v0.4.0 architecture (Entity/CoreProtocol and SQLiteStack/StackProtocol) alongside existing `_storage`-based code
- Properties are lazily initialized on first access — zero overhead if not used
- When `.entity` is accessed before `.stack`, the stack is automatically attached as the active stack on the entity
- `.stack` returns `None` gracefully when the underlying storage is not SQLite-based
- Marks `.storage` property docstring as deprecated (no runtime warning yet, to avoid breaking existing callers)

## Backward Compatibility
- **All 2100 existing tests pass without modification** (only pre-existing `sqlite-vec` failure)
- No changes to `self._storage` usage — all 160+ internal references remain untouched
- No changes to mixin `_storage` access (50+ references across 7 feature files)
- Purely additive: no existing methods, attributes, or behavior modified

## Test Plan
- [x] 17 new tests in `tests/test_compat_layer.py` covering:
  - Entity property: creation, caching, core_id matching, lazy initialization
  - Stack property: creation, caching, db_path sharing, non-SQLite fallback
  - Integration: auto-attach order, manual attach, round-trip write/read
  - Backward compat: storage property, internal _storage, existing methods, non-interference
- [x] Full test suite: 2100 passed, 1 skipped, 1 pre-existing failure

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)