### PR TITLE
Migrate CLI to use Entity for status and plugin discovery (#255)

### DIFF
--- a/tests/test_cli_entity.py
+++ b/tests/test_cli_entity.py
@@ -1,0 +1,115 @@
+"""Tests for CLI Entity integration (v0.4.0).
+
+Verifies that the CLI status command shows composition info
+and that plugin discovery + CLI registration works without
+breaking existing CLI commands.
+"""
+
+import io
+from contextlib import redirect_stdout
+
+import pytest
+
+from kernle.core import Kernle
+from kernle.storage import SQLiteStorage
+
+
+@pytest.fixture
+def kernle_cli(tmp_path):
+    """Kernle instance for CLI tests."""
+    db_path = tmp_path / "cli_test.db"
+    storage = SQLiteStorage(stack_id="test_cli_entity", db_path=db_path)
+    k = Kernle(
+        stack_id="test_cli_entity",
+        storage=storage,
+        checkpoint_dir=tmp_path / "cp",
+    )
+    yield k
+    storage.close()
+
+
+def capture_status(k):
+    """Run cmd_status and capture stdout."""
+    from kernle.cli.__main__ import cmd_status
+
+    class FakeArgs:
+        pass
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        cmd_status(FakeArgs(), k)
+    return buf.getvalue()
+
+
+class TestStatusComposition:
+    """Tests for the enhanced status command with composition info."""
+
+    def test_status_shows_composition_section(self, kernle_cli):
+        output = capture_status(kernle_cli)
+        assert "Composition (v0.4.0)" in output
+
+    def test_status_shows_core_id(self, kernle_cli):
+        output = capture_status(kernle_cli)
+        assert "Core ID:" in output
+        assert "test_cli_entity" in output
+
+    def test_status_shows_stack_info(self, kernle_cli):
+        output = capture_status(kernle_cli)
+        assert "Stack:" in output
+        assert "schema v" in output
+
+    def test_status_shows_plugins_line(self, kernle_cli):
+        output = capture_status(kernle_cli)
+        assert "Plugins:" in output or "Plugin:" in output
+
+    def test_status_shows_model_line(self, kernle_cli):
+        output = capture_status(kernle_cli)
+        assert "Model:" in output
+
+    def test_status_still_shows_memory_counts(self, kernle_cli):
+        """Existing status output is preserved."""
+        output = capture_status(kernle_cli)
+        assert "Memory Status for" in output
+        assert "Values:" in output
+        assert "Beliefs:" in output
+        assert "Goals:" in output
+        assert "Episodes:" in output
+        assert "Checkpoint:" in output
+
+    def test_status_stack_detached_when_entity_not_accessed_first(self, kernle_cli):
+        """If entity is not accessed before stack, shows 'detached'."""
+        # Access stack first (without entity), then status
+        # This tests the fallback path in cmd_status
+        output = capture_status(kernle_cli)
+        # Entity is accessed first in cmd_status, so stack auto-attaches.
+        # The output should show the stack as attached (active).
+        assert "(active)" in output or "detached" in output
+
+
+class TestStatusWithAutoAttach:
+    """Verify auto-attach behavior in status command."""
+
+    def test_entity_accessed_first_attaches_stack(self, kernle_cli):
+        """Accessing entity then stack auto-attaches."""
+        output = capture_status(kernle_cli)
+        # Entity is created first in cmd_status, then stack is checked
+        # via entity.stacks — if stack was accessed through Kernle.stack
+        # and entity existed, it should be auto-attached.
+        assert "test_cli_entity" in output
+        assert "schema v" in output
+
+
+class TestPluginDiscovery:
+    """Tests for plugin discovery in CLI."""
+
+    def test_discover_plugins_called_in_status(self, kernle_cli):
+        """Status command calls entity.discover_plugins()."""
+        output = capture_status(kernle_cli)
+        # Even with no plugins installed, the line should appear
+        assert "Plugins:" in output or "Plugin:" in output
+
+    def test_no_plugins_shows_none(self, kernle_cli):
+        """When no plugins are installed, shows '(none)' or count."""
+        output = capture_status(kernle_cli)
+        # With no plugins installed, should show "discovered, 0 loaded" or "(none)"
+        assert "(none)" in output or "0 loaded" in output


### PR DESCRIPTION
## Summary
- Enhances `kernle status` to show v0.4.0 composition info: core_id, active stack (with schema version), discovered/loaded plugins, and bound model
- Adds plugin discovery before arg parsing so installed plugins can register CLI subcommands via `plugin.register_cli(subparsers)`
- Uses the compat layer from PR #273 (`k.entity` / `k.stack`) — auto-attaches stack when entity is accessed first

## Changes
- `kernle/cli/__main__.py`: Updated `cmd_status()` with composition section (+40 lines), added plugin discovery block before `parse_args` (+13 lines)
- `tests/test_cli_entity.py`: New test file with 10 tests covering status output, auto-attach behavior, and plugin discovery

## Backward Compatibility
- All existing CLI commands work unchanged
- 2110 tests pass (10 new + 2100 existing), only pre-existing sqlite-vec failure

## Example Output
```
Memory Status for my_agent
========================================
Values:     3
Beliefs:    5
Goals:      1 active
Episodes:   12
Raw:        4
Checkpoint: Yes

Composition (v0.4.0)
----------------------------------------
Core ID:    my_agent
Stack:      my_agent [default] (active) (schema v23)
Plugins:    (none)
Model:      (none)
```

## Test Plan
- [x] 10 new tests in `tests/test_cli_entity.py`
- [x] Full test suite: 2110 passed, 1 skipped, 1 pre-existing failure

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)