### PR TITLE
Add InferenceService and EmbeddingComponent (#257, #258)

### DIFF
--- a/kernle/entity.py
+++ b/kernle/entity.py
@@ -827,6 +827,13 @@ class Entity:
     # ---- Internal Helpers ----
 
     def _get_inference_service(self) -> Optional[InferenceService]:
-        # Full InferenceService implementation deferred to v0.5.0.
-        # For now, return None. Stacks degrade gracefully without it.
-        return None
+        """Create an InferenceService wrapping the current model.
+
+        Returns None if no model is bound. Stacks and components
+        degrade gracefully without it.
+        """
+        if self._model is None:
+            return None
+        from kernle.inference import create_inference_service
+
+        return create_inference_service(self._model)

--- a/kernle/inference.py
+++ b/kernle/inference.py
@@ -1,0 +1,60 @@
+"""InferenceService — narrow model access for stack components.
+
+Wraps a ModelProtocol into the InferenceService interface that stack
+components use. Components never see ModelProtocol directly — they
+get this thin wrapper which provides infer(), embed(), and embed_batch().
+
+When no model-level embedding is available, falls back to the local
+hash-based embedder from storage/embeddings.py.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from kernle.protocols import InferenceService, ModelMessage, ModelProtocol
+from kernle.storage.embeddings import HashEmbedder
+
+
+class _InferenceServiceImpl:
+    """Concrete InferenceService wrapping a ModelProtocol.
+
+    Delegates infer() to model.generate() and provides local
+    hash-based embeddings as the default embed() implementation.
+    """
+
+    def __init__(self, model: ModelProtocol) -> None:
+        self._model = model
+        self._embedder = HashEmbedder()
+
+    def infer(self, prompt: str, *, system: Optional[str] = None) -> str:
+        """Generate text by routing to the bound model."""
+        messages = [ModelMessage(role="user", content=prompt)]
+        response = self._model.generate(messages, system=system)
+        return response.content
+
+    def embed(self, text: str) -> list[float]:
+        """Embed text using the local hash embedder."""
+        return self._embedder.embed(text)
+
+    def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        """Batch embed using the local hash embedder."""
+        return self._embedder.embed_batch(texts)
+
+    @property
+    def embedding_dimension(self) -> int:
+        """Dimension of vectors produced by embed()."""
+        return self._embedder.dimension
+
+    @property
+    def embedding_provider_id(self) -> str:
+        """Stable ID for the current embedding source."""
+        return "ngram-v1"
+
+
+def create_inference_service(model: ModelProtocol) -> InferenceService:
+    """Create an InferenceService wrapping a model.
+
+    This is the factory function Entity uses when set_model() is called.
+    """
+    return _InferenceServiceImpl(model)  # type: ignore[return-value]

--- a/kernle/stack/components/__init__.py
+++ b/kernle/stack/components/__init__.py
@@ -1,0 +1,11 @@
+"""kernle.stack.components - Stack sub-components.
+
+Components extend what the stack can do. They hook into the stack's
+lifecycle: memory saves, loads, searches, and periodic maintenance.
+
+Discovery via entry point: kernle.stack_components
+"""
+
+from kernle.stack.components.embedding import EmbeddingComponent
+
+__all__ = ["EmbeddingComponent"]

--- a/kernle/stack/components/embedding.py
+++ b/kernle/stack/components/embedding.py
@@ -1,0 +1,155 @@
+"""EmbeddingComponent - required stack component for semantic search.
+
+Wraps the hash-based embedder from storage/embeddings.py and conforms
+to StackComponentProtocol. When an InferenceService is available with
+embed() support, the component can optionally delegate to that instead
+of the local n-gram embedder.
+
+This is the first stack component and serves as the reference
+implementation for the StackComponentProtocol lifecycle.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from kernle.protocols import InferenceService, SearchResult
+from kernle.storage.embeddings import HashEmbedder
+
+logger = logging.getLogger(__name__)
+
+
+class EmbeddingComponent:
+    """Required stack component providing embedding for semantic search.
+
+    Works without inference (local n-gram hash embedder). When inference
+    is available, can optionally use model-based embeddings for higher
+    quality search.
+
+    Conforms to StackComponentProtocol.
+    """
+
+    def __init__(self) -> None:
+        self._stack_id: Optional[str] = None
+        self._inference: Optional[InferenceService] = None
+        self._embedder = HashEmbedder()
+
+    # ---- StackComponentProtocol properties ----
+
+    @property
+    def name(self) -> str:
+        return "embedding-ngram"
+
+    @property
+    def version(self) -> str:
+        return "1.0.0"
+
+    @property
+    def required(self) -> bool:
+        return True
+
+    @property
+    def needs_inference(self) -> bool:
+        return False
+
+    # ---- Lifecycle ----
+
+    def attach(
+        self,
+        stack_id: str,
+        inference: Optional[InferenceService] = None,
+    ) -> None:
+        """Called when the component is added to a stack."""
+        self._stack_id = stack_id
+        self._inference = inference
+
+    def detach(self) -> None:
+        """Called when the component is removed from a stack."""
+        self._stack_id = None
+        self._inference = None
+
+    def set_inference(self, inference: Optional[InferenceService]) -> None:
+        """Update the inference service when the model changes."""
+        self._inference = inference
+
+    # ---- Lifecycle Hooks ----
+
+    def on_save(self, memory_type: str, memory_id: str, memory: Any) -> Any:
+        """Generate embedding for saved memory.
+
+        The actual embedding storage is handled by the SQLiteStorage
+        backend via _save_embedding(). This hook is a notification
+        point for when the component system takes over embedding
+        management from the backend.
+
+        Returns None (no modification to the memory).
+        """
+        return None
+
+    def on_search(
+        self,
+        query: str,
+        results: list[SearchResult],
+    ) -> list[SearchResult]:
+        """Post-process search results.
+
+        Currently a pass-through. When the component fully owns
+        embedding, this would re-rank results by semantic similarity.
+        """
+        return results
+
+    def on_load(self, context: dict[str, Any]) -> None:
+        """No-op for embeddings during load assembly."""
+        return None
+
+    def on_maintenance(self) -> dict[str, Any]:
+        """Re-index stale embeddings.
+
+        Returns stats about what was done. Currently reports
+        component status; full re-indexing deferred to when the
+        component owns the embedding lifecycle.
+        """
+        return {
+            "provider": self.embedding_provider_id,
+            "dimension": self.embedding_dimension,
+            "has_inference": self._inference is not None,
+        }
+
+    # ---- Embedding Interface ----
+
+    def embed(self, text: str) -> list[float]:
+        """Embed text using the best available provider.
+
+        If inference is available and provides embeddings, uses that.
+        Otherwise falls back to the local hash embedder.
+        """
+        if self._inference is not None:
+            try:
+                return self._inference.embed(text)
+            except Exception:
+                logger.debug("Inference embed failed, falling back to local")
+        return self._embedder.embed(text)
+
+    def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        """Batch embed texts."""
+        if self._inference is not None:
+            try:
+                return self._inference.embed_batch(texts)
+            except Exception:
+                logger.debug("Inference embed_batch failed, falling back to local")
+        return self._embedder.embed_batch(texts)
+
+    @property
+    def embedding_dimension(self) -> int:
+        """Dimension of vectors produced by embed()."""
+        if self._inference is not None:
+            return self._inference.embedding_dimension
+        return self._embedder.dimension
+
+    @property
+    def embedding_provider_id(self) -> str:
+        """Stable ID for the current embedding source."""
+        if self._inference is not None:
+            return self._inference.embedding_provider_id
+        return "ngram-v1"

--- a/tests/contracts/test_core_contract.py
+++ b/tests/contracts/test_core_contract.py
@@ -562,8 +562,11 @@ class TestModelBinding:
         entity.set_model(model)
 
         # Stack should have been notified via on_model_changed
-        # Since _get_inference_service returns None, inference is None
-        assert stack._inference is None  # Expected until v0.5.0
+        # with a real InferenceService wrapping the model (v0.5.0)
+        from kernle.protocols import InferenceService
+
+        assert stack._inference is not None
+        assert isinstance(stack._inference, InferenceService)
 
 
 # ============================================================================

--- a/tests/test_embedding_component.py
+++ b/tests/test_embedding_component.py
@@ -1,0 +1,375 @@
+"""Tests for EmbeddingComponent (StackComponentProtocol implementation)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from kernle.protocols import InferenceService, SearchResult, StackComponentProtocol
+from kernle.stack.components.embedding import EmbeddingComponent
+from kernle.storage.embeddings import HASH_EMBEDDING_DIM
+
+# ---- Fixtures ----
+
+
+def _make_mock_inference(embed_result=None, dimension=384, provider_id="test-embed"):
+    """Create a mock InferenceService."""
+    inference = MagicMock(spec=InferenceService)
+    inference.embedding_dimension = dimension
+    inference.embedding_provider_id = provider_id
+    if embed_result is not None:
+        inference.embed.return_value = embed_result
+        inference.embed_batch.return_value = [embed_result]
+    else:
+        inference.embed.return_value = [0.1] * dimension
+        inference.embed_batch.return_value = [[0.1] * dimension]
+    return inference
+
+
+# ---- Protocol Conformance ----
+
+
+class TestProtocolConformance:
+    """Test that EmbeddingComponent conforms to StackComponentProtocol."""
+
+    def test_is_stack_component(self):
+        comp = EmbeddingComponent()
+        assert isinstance(comp, StackComponentProtocol)
+
+    def test_name_property(self):
+        comp = EmbeddingComponent()
+        assert comp.name == "embedding-ngram"
+
+    def test_version_property(self):
+        comp = EmbeddingComponent()
+        assert comp.version == "1.0.0"
+
+    def test_required_is_true(self):
+        comp = EmbeddingComponent()
+        assert comp.required is True
+
+    def test_needs_inference_is_false(self):
+        comp = EmbeddingComponent()
+        assert comp.needs_inference is False
+
+
+# ---- Lifecycle ----
+
+
+class TestLifecycle:
+    """Test attach/detach/set_inference lifecycle."""
+
+    def test_attach_sets_stack_id(self):
+        comp = EmbeddingComponent()
+        comp.attach("stack-1")
+        assert comp._stack_id == "stack-1"
+
+    def test_attach_sets_inference(self):
+        comp = EmbeddingComponent()
+        inference = _make_mock_inference()
+        comp.attach("stack-1", inference=inference)
+        assert comp._inference is inference
+
+    def test_attach_without_inference(self):
+        comp = EmbeddingComponent()
+        comp.attach("stack-1")
+        assert comp._inference is None
+
+    def test_detach_clears_state(self):
+        comp = EmbeddingComponent()
+        comp.attach("stack-1", inference=_make_mock_inference())
+        comp.detach()
+        assert comp._stack_id is None
+        assert comp._inference is None
+
+    def test_set_inference_updates(self):
+        comp = EmbeddingComponent()
+        comp.attach("stack-1")
+        inference = _make_mock_inference()
+        comp.set_inference(inference)
+        assert comp._inference is inference
+
+    def test_set_inference_to_none(self):
+        comp = EmbeddingComponent()
+        comp.attach("stack-1", inference=_make_mock_inference())
+        comp.set_inference(None)
+        assert comp._inference is None
+
+
+# ---- Hooks ----
+
+
+class TestOnSave:
+    """Test on_save hook."""
+
+    def test_on_save_returns_none(self):
+        comp = EmbeddingComponent()
+        comp.attach("stack-1")
+        result = comp.on_save("episode", "ep-1", {"objective": "test"})
+        assert result is None
+
+
+class TestOnSearch:
+    """Test on_search hook."""
+
+    def test_on_search_returns_results_unchanged(self):
+        comp = EmbeddingComponent()
+        comp.attach("stack-1")
+        results = [
+            SearchResult(
+                memory_type="episode",
+                memory_id="ep-1",
+                content="test",
+                score=0.9,
+            ),
+            SearchResult(
+                memory_type="belief",
+                memory_id="b-1",
+                content="belief",
+                score=0.7,
+            ),
+        ]
+        out = comp.on_search("query", results)
+        assert out is results
+        assert len(out) == 2
+
+    def test_on_search_empty_results(self):
+        comp = EmbeddingComponent()
+        comp.attach("stack-1")
+        out = comp.on_search("query", [])
+        assert out == []
+
+
+class TestOnLoad:
+    """Test on_load hook."""
+
+    def test_on_load_returns_none(self):
+        comp = EmbeddingComponent()
+        comp.attach("stack-1")
+        result = comp.on_load({"values": []})
+        assert result is None
+
+
+class TestOnMaintenance:
+    """Test on_maintenance hook."""
+
+    def test_on_maintenance_returns_stats(self):
+        comp = EmbeddingComponent()
+        comp.attach("stack-1")
+        stats = comp.on_maintenance()
+        assert isinstance(stats, dict)
+        assert stats["provider"] == "ngram-v1"
+        assert stats["dimension"] == HASH_EMBEDDING_DIM
+        assert stats["has_inference"] is False
+
+    def test_on_maintenance_with_inference(self):
+        comp = EmbeddingComponent()
+        inference = _make_mock_inference(provider_id="model-embed-v1")
+        comp.attach("stack-1", inference=inference)
+        stats = comp.on_maintenance()
+        assert stats["has_inference"] is True
+        assert stats["provider"] == "model-embed-v1"
+
+
+# ---- Embedding Interface ----
+
+
+class TestEmbed:
+    """Test embed() method."""
+
+    def test_embed_without_inference_uses_local(self):
+        comp = EmbeddingComponent()
+        comp.attach("stack-1")
+        result = comp.embed("hello world")
+        assert isinstance(result, list)
+        assert len(result) == HASH_EMBEDDING_DIM
+
+    def test_embed_is_deterministic(self):
+        comp = EmbeddingComponent()
+        comp.attach("stack-1")
+        r1 = comp.embed("hello world")
+        r2 = comp.embed("hello world")
+        assert r1 == r2
+
+    def test_embed_with_inference_delegates(self):
+        comp = EmbeddingComponent()
+        expected = [0.5] * 384
+        inference = _make_mock_inference(embed_result=expected)
+        comp.attach("stack-1", inference=inference)
+        result = comp.embed("hello world")
+        assert result == expected
+        inference.embed.assert_called_once_with("hello world")
+
+    def test_embed_falls_back_on_inference_failure(self):
+        comp = EmbeddingComponent()
+        inference = _make_mock_inference()
+        inference.embed.side_effect = RuntimeError("model down")
+        comp.attach("stack-1", inference=inference)
+        result = comp.embed("hello world")
+        # Should still get a valid embedding from local fallback
+        assert isinstance(result, list)
+        assert len(result) == HASH_EMBEDDING_DIM
+
+
+class TestEmbedBatch:
+    """Test embed_batch() method."""
+
+    def test_embed_batch_without_inference(self):
+        comp = EmbeddingComponent()
+        comp.attach("stack-1")
+        results = comp.embed_batch(["hello", "world"])
+        assert len(results) == 2
+        assert all(len(r) == HASH_EMBEDDING_DIM for r in results)
+
+    def test_embed_batch_with_inference_delegates(self):
+        comp = EmbeddingComponent()
+        expected = [[0.5] * 384, [0.6] * 384]
+        inference = _make_mock_inference()
+        inference.embed_batch.return_value = expected
+        comp.attach("stack-1", inference=inference)
+        result = comp.embed_batch(["hello", "world"])
+        assert result == expected
+
+    def test_embed_batch_falls_back_on_inference_failure(self):
+        comp = EmbeddingComponent()
+        inference = _make_mock_inference()
+        inference.embed_batch.side_effect = RuntimeError("model down")
+        comp.attach("stack-1", inference=inference)
+        results = comp.embed_batch(["hello", "world"])
+        assert len(results) == 2
+        assert all(len(r) == HASH_EMBEDDING_DIM for r in results)
+
+    def test_embed_batch_empty_list(self):
+        comp = EmbeddingComponent()
+        comp.attach("stack-1")
+        results = comp.embed_batch([])
+        assert results == []
+
+
+# ---- Properties ----
+
+
+class TestProperties:
+    """Test embedding_dimension and embedding_provider_id."""
+
+    def test_dimension_without_inference(self):
+        comp = EmbeddingComponent()
+        assert comp.embedding_dimension == HASH_EMBEDDING_DIM
+
+    def test_dimension_with_inference(self):
+        comp = EmbeddingComponent()
+        inference = _make_mock_inference(dimension=768)
+        comp.attach("stack-1", inference=inference)
+        assert comp.embedding_dimension == 768
+
+    def test_provider_id_without_inference(self):
+        comp = EmbeddingComponent()
+        assert comp.embedding_provider_id == "ngram-v1"
+
+    def test_provider_id_with_inference(self):
+        comp = EmbeddingComponent()
+        inference = _make_mock_inference(provider_id="sentence-transformers/all-MiniLM-L6-v2")
+        comp.attach("stack-1", inference=inference)
+        assert comp.embedding_provider_id == "sentence-transformers/all-MiniLM-L6-v2"
+
+
+# ---- Graceful Degradation ----
+
+
+class TestGracefulDegradation:
+    """Test that the component works correctly without inference."""
+
+    def test_works_without_attach(self):
+        """Embedding works even before attach (standalone use)."""
+        comp = EmbeddingComponent()
+        result = comp.embed("hello")
+        assert isinstance(result, list)
+        assert len(result) == HASH_EMBEDDING_DIM
+
+    def test_works_after_detach(self):
+        comp = EmbeddingComponent()
+        comp.attach("stack-1", inference=_make_mock_inference())
+        comp.detach()
+        result = comp.embed("hello")
+        assert isinstance(result, list)
+        assert len(result) == HASH_EMBEDDING_DIM
+
+    def test_works_after_inference_removed(self):
+        comp = EmbeddingComponent()
+        comp.attach("stack-1", inference=_make_mock_inference())
+        comp.set_inference(None)
+        result = comp.embed("hello")
+        assert isinstance(result, list)
+        assert len(result) == HASH_EMBEDDING_DIM
+
+
+# ---- Stack Integration ----
+
+
+class TestStackIntegration:
+    """Test EmbeddingComponent with SQLiteStack's component system."""
+
+    def test_add_component_to_stack(self, tmp_path):
+        from kernle.stack.sqlite_stack import SQLiteStack
+
+        stack = SQLiteStack(stack_id="test-stack", db_path=tmp_path / "test.db")
+        comp = EmbeddingComponent()
+        stack.add_component(comp)
+        assert "embedding-ngram" in stack.components
+        assert stack.get_component("embedding-ngram") is comp
+
+    def test_cannot_remove_required_component(self, tmp_path):
+        from kernle.stack.sqlite_stack import SQLiteStack
+
+        stack = SQLiteStack(stack_id="test-stack", db_path=tmp_path / "test.db")
+        comp = EmbeddingComponent()
+        stack.add_component(comp)
+        with pytest.raises(ValueError, match="Cannot remove required"):
+            stack.remove_component("embedding-ngram")
+
+    def test_maintenance_includes_component(self, tmp_path):
+        from kernle.stack.sqlite_stack import SQLiteStack
+
+        stack = SQLiteStack(stack_id="test-stack", db_path=tmp_path / "test.db")
+        comp = EmbeddingComponent()
+        stack.add_component(comp)
+        results = stack.maintenance()
+        assert "embedding-ngram" in results
+        assert results["embedding-ngram"]["provider"] == "ngram-v1"
+
+    def test_on_attach_propagates_inference(self, tmp_path):
+        from kernle.stack.sqlite_stack import SQLiteStack
+
+        stack = SQLiteStack(stack_id="test-stack", db_path=tmp_path / "test.db")
+        comp = EmbeddingComponent()
+        stack.add_component(comp)
+
+        inference = _make_mock_inference()
+        stack.on_attach("core-1", inference=inference)
+        assert comp._inference is inference
+
+    def test_on_model_changed_propagates(self, tmp_path):
+        from kernle.stack.sqlite_stack import SQLiteStack
+
+        stack = SQLiteStack(stack_id="test-stack", db_path=tmp_path / "test.db")
+        comp = EmbeddingComponent()
+        stack.add_component(comp)
+
+        inference1 = _make_mock_inference(provider_id="v1")
+        stack.on_attach("core-1", inference=inference1)
+        assert comp._inference is inference1
+
+        inference2 = _make_mock_inference(provider_id="v2")
+        stack.on_model_changed(inference2)
+        assert comp._inference is inference2
+
+    def test_on_detach_clears_inference(self, tmp_path):
+        from kernle.stack.sqlite_stack import SQLiteStack
+
+        stack = SQLiteStack(stack_id="test-stack", db_path=tmp_path / "test.db")
+        comp = EmbeddingComponent()
+        stack.add_component(comp)
+
+        inference = _make_mock_inference()
+        stack.on_attach("core-1", inference=inference)
+        stack.on_detach("core-1")
+        assert comp._inference is None

--- a/tests/test_inference_service.py
+++ b/tests/test_inference_service.py
@@ -1,0 +1,270 @@
+"""Tests for InferenceService implementation."""
+
+from unittest.mock import MagicMock
+
+from kernle.inference import _InferenceServiceImpl, create_inference_service
+from kernle.protocols import (
+    InferenceService,
+    ModelCapabilities,
+    ModelProtocol,
+    ModelResponse,
+)
+from kernle.storage.embeddings import HASH_EMBEDDING_DIM
+
+# ---- Fixtures ----
+
+
+def _make_mock_model(model_id="test-model", response_text="Hello world"):
+    """Create a mock ModelProtocol."""
+    model = MagicMock(spec=ModelProtocol)
+    model.model_id = model_id
+    model.capabilities = ModelCapabilities(
+        model_id=model_id,
+        provider="test",
+        context_window=4096,
+    )
+    model.generate.return_value = ModelResponse(content=response_text)
+    return model
+
+
+# ---- InferenceService Protocol Conformance ----
+
+
+class TestInferenceServiceProtocol:
+    """Test that _InferenceServiceImpl conforms to InferenceService."""
+
+    def test_is_inference_service(self):
+        model = _make_mock_model()
+        svc = _InferenceServiceImpl(model)
+        assert isinstance(svc, InferenceService)
+
+    def test_has_infer_method(self):
+        model = _make_mock_model()
+        svc = _InferenceServiceImpl(model)
+        assert callable(svc.infer)
+
+    def test_has_embed_method(self):
+        model = _make_mock_model()
+        svc = _InferenceServiceImpl(model)
+        assert callable(svc.embed)
+
+    def test_has_embed_batch_method(self):
+        model = _make_mock_model()
+        svc = _InferenceServiceImpl(model)
+        assert callable(svc.embed_batch)
+
+    def test_has_embedding_dimension_property(self):
+        model = _make_mock_model()
+        svc = _InferenceServiceImpl(model)
+        assert isinstance(svc.embedding_dimension, int)
+
+    def test_has_embedding_provider_id_property(self):
+        model = _make_mock_model()
+        svc = _InferenceServiceImpl(model)
+        assert isinstance(svc.embedding_provider_id, str)
+
+
+# ---- Infer ----
+
+
+class TestInfer:
+    """Test infer() delegates to model.generate()."""
+
+    def test_infer_returns_string(self):
+        model = _make_mock_model(response_text="The answer is 42")
+        svc = _InferenceServiceImpl(model)
+        result = svc.infer("What is the answer?")
+        assert result == "The answer is 42"
+
+    def test_infer_calls_generate_with_user_message(self):
+        model = _make_mock_model()
+        svc = _InferenceServiceImpl(model)
+        svc.infer("Hello")
+        model.generate.assert_called_once()
+        args, kwargs = model.generate.call_args
+        messages = args[0]
+        assert len(messages) == 1
+        assert messages[0].role == "user"
+        assert messages[0].content == "Hello"
+
+    def test_infer_passes_system_prompt(self):
+        model = _make_mock_model()
+        svc = _InferenceServiceImpl(model)
+        svc.infer("Hello", system="You are helpful")
+        _, kwargs = model.generate.call_args
+        assert kwargs["system"] == "You are helpful"
+
+    def test_infer_without_system_prompt(self):
+        model = _make_mock_model()
+        svc = _InferenceServiceImpl(model)
+        svc.infer("Hello")
+        _, kwargs = model.generate.call_args
+        assert kwargs["system"] is None
+
+    def test_infer_returns_empty_for_empty_response(self):
+        model = _make_mock_model(response_text="")
+        svc = _InferenceServiceImpl(model)
+        result = svc.infer("Hello")
+        assert result == ""
+
+
+# ---- Embed ----
+
+
+class TestEmbed:
+    """Test embed() uses local hash embedder."""
+
+    def test_embed_returns_float_list(self):
+        model = _make_mock_model()
+        svc = _InferenceServiceImpl(model)
+        result = svc.embed("hello world")
+        assert isinstance(result, list)
+        assert all(isinstance(x, float) for x in result)
+
+    def test_embed_returns_correct_dimension(self):
+        model = _make_mock_model()
+        svc = _InferenceServiceImpl(model)
+        result = svc.embed("hello world")
+        assert len(result) == HASH_EMBEDDING_DIM
+
+    def test_embed_is_deterministic(self):
+        model = _make_mock_model()
+        svc = _InferenceServiceImpl(model)
+        r1 = svc.embed("hello world")
+        r2 = svc.embed("hello world")
+        assert r1 == r2
+
+    def test_embed_different_text_different_vectors(self):
+        model = _make_mock_model()
+        svc = _InferenceServiceImpl(model)
+        r1 = svc.embed("hello world")
+        r2 = svc.embed("completely different text")
+        assert r1 != r2
+
+    def test_embed_does_not_call_model(self):
+        model = _make_mock_model()
+        svc = _InferenceServiceImpl(model)
+        svc.embed("hello world")
+        model.generate.assert_not_called()
+
+
+# ---- Embed Batch ----
+
+
+class TestEmbedBatch:
+    """Test embed_batch()."""
+
+    def test_embed_batch_returns_list_of_lists(self):
+        model = _make_mock_model()
+        svc = _InferenceServiceImpl(model)
+        results = svc.embed_batch(["hello", "world"])
+        assert len(results) == 2
+        assert all(isinstance(r, list) for r in results)
+
+    def test_embed_batch_consistent_with_embed(self):
+        model = _make_mock_model()
+        svc = _InferenceServiceImpl(model)
+        single = svc.embed("hello")
+        batch = svc.embed_batch(["hello"])
+        assert single == batch[0]
+
+    def test_embed_batch_empty_list(self):
+        model = _make_mock_model()
+        svc = _InferenceServiceImpl(model)
+        results = svc.embed_batch([])
+        assert results == []
+
+
+# ---- Properties ----
+
+
+class TestProperties:
+    """Test embedding_dimension and embedding_provider_id."""
+
+    def test_embedding_dimension_is_hash_dim(self):
+        model = _make_mock_model()
+        svc = _InferenceServiceImpl(model)
+        assert svc.embedding_dimension == HASH_EMBEDDING_DIM
+
+    def test_embedding_provider_id_is_ngram(self):
+        model = _make_mock_model()
+        svc = _InferenceServiceImpl(model)
+        assert svc.embedding_provider_id == "ngram-v1"
+
+
+# ---- Factory Function ----
+
+
+class TestCreateInferenceService:
+    """Test the create_inference_service factory."""
+
+    def test_returns_inference_service(self):
+        model = _make_mock_model()
+        svc = create_inference_service(model)
+        assert isinstance(svc, InferenceService)
+
+    def test_factory_wraps_model(self):
+        model = _make_mock_model(response_text="factory test")
+        svc = create_inference_service(model)
+        result = svc.infer("test")
+        assert result == "factory test"
+
+
+# ---- Entity Integration ----
+
+
+class TestEntityIntegration:
+    """Test that Entity._get_inference_service() returns a real service."""
+
+    def test_entity_returns_none_without_model(self):
+        from kernle.entity import Entity
+
+        entity = Entity(core_id="test-core")
+        assert entity._get_inference_service() is None
+
+    def test_entity_returns_service_with_model(self):
+        from kernle.entity import Entity
+
+        entity = Entity(core_id="test-core")
+        model = _make_mock_model()
+        entity._model = model
+        svc = entity._get_inference_service()
+        assert svc is not None
+        assert isinstance(svc, InferenceService)
+
+    def test_set_model_propagates_inference_to_stacks(self):
+        from kernle.entity import Entity
+
+        entity = Entity(core_id="test-core")
+        mock_stack = MagicMock()
+        mock_stack.stack_id = "stack-1"
+        mock_stack.schema_version = 1
+        mock_stack.get_stats.return_value = {}
+        entity.attach_stack(mock_stack, alias="main")
+
+        model = _make_mock_model()
+        entity.set_model(model)
+
+        # on_attach is called with None inference (no model at attach time)
+        # then on_model_changed is called with real inference
+        mock_stack.on_model_changed.assert_called_once()
+        inference_arg = mock_stack.on_model_changed.call_args[0][0]
+        assert isinstance(inference_arg, InferenceService)
+
+    def test_attach_stack_passes_inference_when_model_exists(self):
+        from kernle.entity import Entity
+
+        entity = Entity(core_id="test-core")
+        model = _make_mock_model()
+        entity._model = model
+
+        mock_stack = MagicMock()
+        mock_stack.stack_id = "stack-1"
+        mock_stack.schema_version = 1
+        mock_stack.get_stats.return_value = {}
+        entity.attach_stack(mock_stack, alias="main")
+
+        # on_attach should receive the inference service
+        mock_stack.on_attach.assert_called_once()
+        _, inference_arg = mock_stack.on_attach.call_args[0]
+        assert isinstance(inference_arg, InferenceService)


### PR DESCRIPTION
## Summary
- Implement `_InferenceServiceImpl` in `kernle/inference.py` wrapping `ModelProtocol` into the narrow `InferenceService` interface that stack components use. `infer()` delegates to `model.generate()`, `embed()`/`embed_batch()` use the local hash embedder.
- Wire up `Entity._get_inference_service()` to create a real `InferenceService` when a model is bound, propagating it to all attached stacks via `on_model_changed()` and `on_attach()`.
- Add `EmbeddingComponent` in `kernle/stack/components/embedding.py` as the first `StackComponentProtocol` implementation. Required component that wraps the hash-based embedder with graceful fallback when inference is unavailable.
- Update contract test `test_set_model_notifies_stacks` to expect a real `InferenceService` instead of `None`.

## Test plan
- [x] 65 new tests across `test_inference_service.py` and `test_embedding_component.py`
- [x] Protocol conformance: `isinstance(svc, InferenceService)` and `isinstance(comp, StackComponentProtocol)`
- [x] InferenceService: infer delegates to model, embed uses local hash, batch consistency, system prompt pass-through
- [x] EmbeddingComponent: lifecycle (attach/detach/set_inference), all hooks, embedding delegation to inference, fallback on failure, graceful degradation without inference
- [x] Stack integration: add_component, cannot remove required, maintenance stats, inference propagation via on_attach/on_model_changed/on_detach
- [x] Entity integration: returns None without model, returns real service with model, propagates to stacks
- [x] Full suite: 2337 passed (2 pre-existing failures: sqlite-vec availability, unrelated)

Closes #257, closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)