### PR TITLE
feat: stack component discovery and default configuration (#260)

### DIFF
--- a/kernle/stack/components/__init__.py
+++ b/kernle/stack/components/__init__.py
@@ -24,4 +24,63 @@ __all__ = [
     "KnowledgeComponent",
     "MetaMemoryComponent",
     "SuggestionComponent",
+    "get_default_components",
+    "get_minimal_components",
+    "load_components_from_discovery",
 ]
+
+# The default component set — all 8 built-in components.
+_DEFAULT_COMPONENT_CLASSES = [
+    EmbeddingComponent,
+    ForgettingComponent,
+    ConsolidationComponent,
+    EmotionalTaggingComponent,
+    AnxietyComponent,
+    SuggestionComponent,
+    MetaMemoryComponent,
+    KnowledgeComponent,
+]
+
+
+def get_default_components():
+    """Return new instances of all 8 built-in stack components.
+
+    This is the default set loaded when a stack is created without
+    an explicit component list.
+    """
+    return [cls() for cls in _DEFAULT_COMPONENT_CLASSES]
+
+
+def get_minimal_components():
+    """Return a minimal component set (embedding only).
+
+    Use this for a functional but bare stack.
+    """
+    return [EmbeddingComponent()]
+
+
+def load_components_from_discovery():
+    """Discover and instantiate all installed stack components via entry points.
+
+    Uses the ``kernle.stack_components`` entry point group. Any package
+    that registers a component class there will be discovered and
+    instantiated.
+
+    Returns:
+        List of instantiated stack component instances.
+    """
+    from kernle.discovery import discover_stack_components, load_component
+
+    discovered = discover_stack_components()
+    instances = []
+    for dc in discovered:
+        try:
+            cls = load_component(dc)
+            instances.append(cls())
+        except Exception:
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "Failed to load component '%s' from %s", dc.name, dc.qualname
+            )
+    return instances

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,14 @@ kernle-mcp = "kernle.mcp.server:main"
 [project.entry-points."kernle.models"]
 
 [project.entry-points."kernle.stack_components"]
+embedding = "kernle.stack.components.embedding:EmbeddingComponent"
+forgetting = "kernle.stack.components.forgetting:ForgettingComponent"
+consolidation = "kernle.stack.components.consolidation:ConsolidationComponent"
+emotions = "kernle.stack.components.emotions:EmotionalTaggingComponent"
+anxiety = "kernle.stack.components.anxiety:AnxietyComponent"
+suggestions = "kernle.stack.components.suggestions:SuggestionComponent"
+metamemory = "kernle.stack.components.metamemory:MetaMemoryComponent"
+knowledge = "kernle.stack.components.knowledge:KnowledgeComponent"
 
 [project.urls]
 Homepage = "https://kernle.ai"

--- a/tests/contracts/test_stack_contract.py
+++ b/tests/contracts/test_stack_contract.py
@@ -53,7 +53,7 @@ STACK_ID = "contract-test-stack"
 def stack(tmp_path):
     """Create a fresh SQLiteStack for each test."""
     db_path = tmp_path / "contract_test.db"
-    return SQLiteStack(stack_id=STACK_ID, db_path=db_path)
+    return SQLiteStack(stack_id=STACK_ID, db_path=db_path, components=[])
 
 
 def _uid() -> str:

--- a/tests/test_component_discovery.py
+++ b/tests/test_component_discovery.py
@@ -1,0 +1,352 @@
+"""Tests for stack component discovery and default configuration (#260)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from kernle.stack.components import (
+    AnxietyComponent,
+    ConsolidationComponent,
+    EmbeddingComponent,
+    EmotionalTaggingComponent,
+    ForgettingComponent,
+    KnowledgeComponent,
+    MetaMemoryComponent,
+    SuggestionComponent,
+    get_default_components,
+    get_minimal_components,
+    load_components_from_discovery,
+)
+
+# ---------------------------------------------------------------------------
+# get_default_components / get_minimal_components
+# ---------------------------------------------------------------------------
+
+
+class TestGetDefaultComponents:
+    def test_returns_8_components(self):
+        components = get_default_components()
+        assert len(components) == 8
+
+    def test_component_types(self):
+        components = get_default_components()
+        types = {type(c) for c in components}
+        expected = {
+            EmbeddingComponent,
+            ForgettingComponent,
+            ConsolidationComponent,
+            EmotionalTaggingComponent,
+            AnxietyComponent,
+            SuggestionComponent,
+            MetaMemoryComponent,
+            KnowledgeComponent,
+        }
+        assert types == expected
+
+    def test_components_are_new_instances(self):
+        """Each call returns fresh instances, not shared singletons."""
+        a = get_default_components()
+        b = get_default_components()
+        for x, y in zip(a, b):
+            assert x is not y
+
+    def test_all_have_name_attribute(self):
+        for c in get_default_components():
+            assert isinstance(c.name, str)
+            assert len(c.name) > 0
+
+    def test_embedding_is_required(self):
+        components = get_default_components()
+        embedding = [c for c in components if isinstance(c, EmbeddingComponent)]
+        assert len(embedding) == 1
+        assert embedding[0].required is True
+
+
+class TestGetMinimalComponents:
+    def test_returns_1_component(self):
+        components = get_minimal_components()
+        assert len(components) == 1
+
+    def test_is_embedding(self):
+        components = get_minimal_components()
+        assert isinstance(components[0], EmbeddingComponent)
+
+    def test_returns_new_instance(self):
+        a = get_minimal_components()
+        b = get_minimal_components()
+        assert a[0] is not b[0]
+
+
+# ---------------------------------------------------------------------------
+# load_components_from_discovery
+# ---------------------------------------------------------------------------
+
+
+class _FakeEntryPoint:
+    """Minimal stand-in for importlib.metadata.EntryPoint."""
+
+    def __init__(self, name: str, value: str, group: str):
+        self.name = name
+        self.value = value
+        self.group = group
+        self.dist = None
+
+    def load(self):
+        # Return the actual class for built-in components
+        mapping = {
+            "embedding": EmbeddingComponent,
+            "forgetting": ForgettingComponent,
+        }
+        return mapping[self.name]
+
+
+class TestLoadComponentsFromDiscovery:
+    def test_discovers_and_instantiates(self, monkeypatch):
+        """Monkeypatch importlib.metadata.entry_points to return fake eps."""
+        fake_eps = [
+            _FakeEntryPoint(
+                "embedding",
+                "kernle.stack.components.embedding:EmbeddingComponent",
+                "kernle.stack_components",
+            ),
+            _FakeEntryPoint(
+                "forgetting",
+                "kernle.stack.components.forgetting:ForgettingComponent",
+                "kernle.stack_components",
+            ),
+        ]
+
+        monkeypatch.setattr(
+            "kernle.discovery.importlib.metadata.entry_points",
+            lambda group: fake_eps,
+        )
+
+        instances = load_components_from_discovery()
+        assert len(instances) == 2
+        assert isinstance(instances[0], EmbeddingComponent)
+        assert isinstance(instances[1], ForgettingComponent)
+
+    def test_handles_load_failure_gracefully(self, monkeypatch):
+        """If one component fails to load, skip it and continue."""
+
+        class _BadEP:
+            name = "bad"
+            value = "bad.module:BadClass"
+            group = "kernle.stack_components"
+            dist = None
+
+            def load(self):
+                raise ImportError("no such module")
+
+        good_ep = _FakeEntryPoint(
+            "embedding",
+            "kernle.stack.components.embedding:EmbeddingComponent",
+            "kernle.stack_components",
+        )
+
+        monkeypatch.setattr(
+            "kernle.discovery.importlib.metadata.entry_points",
+            lambda group: [_BadEP(), good_ep],
+        )
+
+        instances = load_components_from_discovery()
+        assert len(instances) == 1
+        assert isinstance(instances[0], EmbeddingComponent)
+
+    def test_empty_when_nothing_registered(self, monkeypatch):
+        monkeypatch.setattr(
+            "kernle.discovery.importlib.metadata.entry_points",
+            lambda group: [],
+        )
+        assert load_components_from_discovery() == []
+
+
+# ---------------------------------------------------------------------------
+# SQLiteStack constructor + add_component / set_storage
+# ---------------------------------------------------------------------------
+
+
+class TestSQLiteStackComponents:
+    """Tests for SQLiteStack component auto-loading and set_storage."""
+
+    def test_constructor_loads_defaults(self, tmp_path):
+        from kernle.stack.sqlite_stack import SQLiteStack
+
+        stack = SQLiteStack("test-stack", db_path=tmp_path / "test.db")
+        assert len(stack.components) == 8
+        # Verify embedding is present
+        names = set(stack.components.keys())
+        assert "embedding-ngram" in names
+
+    def test_constructor_respects_explicit_components(self, tmp_path):
+        from kernle.stack.sqlite_stack import SQLiteStack
+
+        explicit = [EmbeddingComponent()]
+        stack = SQLiteStack(
+            "test-stack",
+            db_path=tmp_path / "test.db",
+            components=explicit,
+        )
+        assert len(stack.components) == 1
+        assert "embedding-ngram" in stack.components
+
+    def test_constructor_empty_list_loads_nothing(self, tmp_path):
+        from kernle.stack.sqlite_stack import SQLiteStack
+
+        stack = SQLiteStack(
+            "test-stack",
+            db_path=tmp_path / "test.db",
+            components=[],
+        )
+        assert len(stack.components) == 0
+
+    def test_add_component_calls_set_storage(self, tmp_path):
+        from kernle.stack.sqlite_stack import SQLiteStack
+
+        stack = SQLiteStack(
+            "test-stack",
+            db_path=tmp_path / "test.db",
+            components=[],
+        )
+        component = AnxietyComponent()
+        assert component._storage is None
+        stack.add_component(component)
+        assert component._storage is not None
+        assert component._storage is stack._storage
+
+    def test_add_component_skips_set_storage_if_missing(self, tmp_path):
+        """Components without set_storage don't cause errors."""
+        from kernle.stack.sqlite_stack import SQLiteStack
+
+        stack = SQLiteStack(
+            "test-stack",
+            db_path=tmp_path / "test.db",
+            components=[],
+        )
+
+        class BareComponent:
+            name = "bare"
+            version = "1.0.0"
+            required = False
+            needs_inference = False
+
+            def attach(self, stack_id, inference=None):
+                pass
+
+            def detach(self):
+                pass
+
+            def set_inference(self, inference):
+                pass
+
+        component = BareComponent()
+        stack.add_component(component)
+        assert "bare" in stack.components
+
+    def test_components_receive_storage_on_default_load(self, tmp_path):
+        """All default components with set_storage get storage assigned."""
+        from kernle.stack.sqlite_stack import SQLiteStack
+
+        stack = SQLiteStack("test-stack", db_path=tmp_path / "test.db")
+        for name, component in stack.components.items():
+            if hasattr(component, "_storage") and hasattr(component, "set_storage"):
+                assert (
+                    component._storage is not None
+                ), f"Component '{name}' has set_storage but _storage is None"
+
+    def test_remove_component_raises_for_required(self, tmp_path):
+        from kernle.stack.sqlite_stack import SQLiteStack
+
+        stack = SQLiteStack("test-stack", db_path=tmp_path / "test.db")
+        with pytest.raises(ValueError, match="Cannot remove required"):
+            stack.remove_component("embedding-ngram")
+
+    def test_remove_optional_component(self, tmp_path):
+        from kernle.stack.sqlite_stack import SQLiteStack
+
+        stack = SQLiteStack("test-stack", db_path=tmp_path / "test.db")
+        assert "anxiety" in stack.components
+        stack.remove_component("anxiety")
+        assert "anxiety" not in stack.components
+
+
+# ---------------------------------------------------------------------------
+# Full lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestComponentLifecycle:
+    def test_full_lifecycle(self, tmp_path):
+        """Create stack -> components auto-loaded -> maintenance -> model change."""
+        from kernle.stack.sqlite_stack import SQLiteStack
+
+        stack = SQLiteStack("lifecycle-test", db_path=tmp_path / "test.db")
+
+        # Components auto-loaded
+        assert len(stack.components) == 8
+
+        # Maintenance runs without error
+        results = stack.maintenance()
+        assert isinstance(results, dict)
+
+        # Model change propagates
+        mock_inference = MagicMock()
+        stack.on_model_changed(mock_inference)
+        for component in stack._components.values():
+            assert component._inference is mock_inference
+
+    def test_add_remove_at_runtime(self, tmp_path):
+        """Stack with minimal components can add/remove at runtime."""
+        from kernle.stack.sqlite_stack import SQLiteStack
+
+        stack = SQLiteStack(
+            "runtime-test",
+            db_path=tmp_path / "test.db",
+            components=get_minimal_components(),
+        )
+        assert len(stack.components) == 1
+
+        # Add a component at runtime
+        anxiety = AnxietyComponent()
+        stack.add_component(anxiety)
+        assert len(stack.components) == 2
+        assert "anxiety" in stack.components
+        assert anxiety._storage is stack._storage
+
+        # Remove it
+        stack.remove_component("anxiety")
+        assert len(stack.components) == 1
+        assert "anxiety" not in stack.components
+
+    def test_on_attach_propagates_inference(self, tmp_path):
+        """on_attach propagates inference to all components."""
+        from kernle.stack.sqlite_stack import SQLiteStack
+
+        stack = SQLiteStack(
+            "attach-test",
+            db_path=tmp_path / "test.db",
+            components=get_minimal_components(),
+        )
+        mock_inference = MagicMock()
+        stack.on_attach("core-1", inference=mock_inference)
+
+        for component in stack._components.values():
+            assert component._inference is mock_inference
+
+    def test_on_detach_clears_inference(self, tmp_path):
+        """on_detach clears inference on all components."""
+        from kernle.stack.sqlite_stack import SQLiteStack
+
+        stack = SQLiteStack(
+            "detach-test",
+            db_path=tmp_path / "test.db",
+            components=get_minimal_components(),
+        )
+        mock_inference = MagicMock()
+        stack.on_attach("core-1", inference=mock_inference)
+        stack.on_detach("core-1")
+
+        for component in stack._components.values():
+            assert component._inference is None

--- a/tests/test_embedding_component.py
+++ b/tests/test_embedding_component.py
@@ -311,7 +311,7 @@ class TestStackIntegration:
     def test_add_component_to_stack(self, tmp_path):
         from kernle.stack.sqlite_stack import SQLiteStack
 
-        stack = SQLiteStack(stack_id="test-stack", db_path=tmp_path / "test.db")
+        stack = SQLiteStack(stack_id="test-stack", db_path=tmp_path / "test.db", components=[])
         comp = EmbeddingComponent()
         stack.add_component(comp)
         assert "embedding-ngram" in stack.components
@@ -320,7 +320,7 @@ class TestStackIntegration:
     def test_cannot_remove_required_component(self, tmp_path):
         from kernle.stack.sqlite_stack import SQLiteStack
 
-        stack = SQLiteStack(stack_id="test-stack", db_path=tmp_path / "test.db")
+        stack = SQLiteStack(stack_id="test-stack", db_path=tmp_path / "test.db", components=[])
         comp = EmbeddingComponent()
         stack.add_component(comp)
         with pytest.raises(ValueError, match="Cannot remove required"):
@@ -329,7 +329,7 @@ class TestStackIntegration:
     def test_maintenance_includes_component(self, tmp_path):
         from kernle.stack.sqlite_stack import SQLiteStack
 
-        stack = SQLiteStack(stack_id="test-stack", db_path=tmp_path / "test.db")
+        stack = SQLiteStack(stack_id="test-stack", db_path=tmp_path / "test.db", components=[])
         comp = EmbeddingComponent()
         stack.add_component(comp)
         results = stack.maintenance()
@@ -339,7 +339,7 @@ class TestStackIntegration:
     def test_on_attach_propagates_inference(self, tmp_path):
         from kernle.stack.sqlite_stack import SQLiteStack
 
-        stack = SQLiteStack(stack_id="test-stack", db_path=tmp_path / "test.db")
+        stack = SQLiteStack(stack_id="test-stack", db_path=tmp_path / "test.db", components=[])
         comp = EmbeddingComponent()
         stack.add_component(comp)
 
@@ -350,7 +350,7 @@ class TestStackIntegration:
     def test_on_model_changed_propagates(self, tmp_path):
         from kernle.stack.sqlite_stack import SQLiteStack
 
-        stack = SQLiteStack(stack_id="test-stack", db_path=tmp_path / "test.db")
+        stack = SQLiteStack(stack_id="test-stack", db_path=tmp_path / "test.db", components=[])
         comp = EmbeddingComponent()
         stack.add_component(comp)
 
@@ -365,7 +365,7 @@ class TestStackIntegration:
     def test_on_detach_clears_inference(self, tmp_path):
         from kernle.stack.sqlite_stack import SQLiteStack
 
-        stack = SQLiteStack(stack_id="test-stack", db_path=tmp_path / "test.db")
+        stack = SQLiteStack(stack_id="test-stack", db_path=tmp_path / "test.db", components=[])
         comp = EmbeddingComponent()
         stack.add_component(comp)
 

--- a/tests/test_sqlite_stack.py
+++ b/tests/test_sqlite_stack.py
@@ -57,7 +57,7 @@ def tmp_db(tmp_path):
 @pytest.fixture
 def stack(tmp_db):
     """Create an SQLiteStack instance with a temp database."""
-    return SQLiteStack(stack_id="test-stack", db_path=tmp_db)
+    return SQLiteStack(stack_id="test-stack", db_path=tmp_db, components=[])
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- Register all 8 built-in components as `kernle.stack_components` entry points in pyproject.toml
- Add `get_default_components()`, `get_minimal_components()`, and `load_components_from_discovery()` to `kernle.stack.components`
- `SQLiteStack.__init__()` now accepts optional `components` parameter: `None` loads defaults (all 8), `[]` loads nothing, explicit list uses those
- `add_component()` now calls `set_storage()` on components that support it
- 23 new tests covering discovery, default/minimal sets, constructor behavior, set_storage propagation, and full lifecycle

## Test plan
- [x] `get_default_components()` returns 8 components with correct types and names
- [x] `get_minimal_components()` returns just EmbeddingComponent
- [x] `load_components_from_discovery()` discovers entry points (mocked)
- [x] `SQLiteStack` constructor loads defaults when no components specified
- [x] `SQLiteStack` constructor respects explicit components list
- [x] `SQLiteStack` constructor with `components=[]` loads nothing
- [x] `add_component()` calls `set_storage()` on components
- [x] Components without `set_storage` don't cause errors
- [x] Full lifecycle: create stack -> components auto-loaded -> maintenance -> model change propagation
- [x] Existing tests updated to pass `components=[]` where needed (2507 tests pass, only pre-existing sqlite-vec failure remains)

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)