### PR TITLE
fix: skip sqlite-vec test when extension unavailable

### DIFF
--- a/tests/test_sqlite_storage.py
+++ b/tests/test_sqlite_storage.py
@@ -57,7 +57,9 @@ class TestSQLiteStorageBasics:
         assert storage.stack_id == "test-agent"
 
     def test_sqlite_vec_available(self, storage):
-        """sqlite-vec should be available."""
+        """sqlite-vec availability depends on environment."""
+        if not storage._has_vec:
+            pytest.skip("sqlite-vec not available in this environment")
         assert storage._has_vec is True
 
     def test_embedder_default(self, storage):


### PR DESCRIPTION
## Summary
- Change `test_sqlite_vec_available` to skip gracefully when sqlite-vec extension is not installed
- Prevents false failures in environments without the optional extension

## Test plan
- [x] Test skips cleanly when sqlite-vec is unavailable
- [x] Test still passes when sqlite-vec is available
- [x] All existing storage tests pass

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)