### PR TITLE
fix: entity audit fixes — version enforcement, binding, API conformance

### DIFF
--- a/tests/contracts/test_core_contract.py
+++ b/tests/contracts/test_core_contract.py
@@ -706,3 +706,35 @@ class TestRepeatAvoidRoundtrip:
         assert len(found) == 1
         assert found[0].repeat == ["good pattern"]
         assert found[0].avoid == ["bad pattern"]
+
+
+# ============================================================================
+# 11. Public API Conformance
+# ============================================================================
+
+
+class TestPublicAPIConformance:
+    """Verify public API exports and protocol conformance."""
+
+    def test_entity_exported_from_package(self):
+        """Entity should be importable from the kernle package."""
+        from kernle import Entity
+
+        assert Entity is not None
+
+    def test_entity_satisfies_core_protocol(self):
+        """Entity should satisfy CoreProtocol."""
+        from kernle import Entity
+        from kernle.protocols import CoreProtocol
+
+        entity = Entity(core_id="api-test")
+        assert isinstance(entity, CoreProtocol)
+
+    def test_version_matches_pyproject(self):
+        """Package version should match importlib.metadata."""
+        from importlib.metadata import version
+
+        import kernle
+
+        expected = version("kernle")
+        assert kernle.__version__ == expected


### PR DESCRIPTION
## Summary
- Add protocol version enforcement in `load_plugin()` — rejects plugins with higher protocol version, warns for lower (#288)
- Improve `from_binding()` to store binding metadata and discover missing plugins (#287)
- Add public API conformance tests — Entity export, CoreProtocol satisfaction, version consistency (#285, #293)
- Add plugin protocol version tests and binding metadata tests

## Test plan
- [x] Plugin with matching protocol version loads successfully
- [x] Plugin with future protocol version raises ValueError
- [x] Plugin with old protocol version loads with warning
- [x] from_binding stores _restored_binding metadata
- [x] from_binding via path roundtrip preserves metadata
- [x] Entity importable from kernle package
- [x] Entity satisfies CoreProtocol
- [x] Package version matches pyproject.toml
- [x] All existing tests pass

Closes #285, #287, #288, #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)