### PR TITLE
fix: mermaid diagrams rendering in Mintlify

### DIFF
--- a/docs-site/architecture.mdx
+++ b/docs-site/architecture.mdx
@@ -49,10 +49,15 @@ This separation is fundamental to memory sovereignty.
 
 If Kernle used external models to consolidate episodes into beliefs, those models would be implanting beliefs into the SI. Over time, this creates a feedback loop:
 
-```
-SI experiences → External model interprets → Beliefs implanted → SI behavior changes
-                         ↑                              │
-                         └──────────────────────────────┘
+```mermaid
+graph LR
+  A["SI experiences"] --> B["External model interprets"]
+  B --> C["Beliefs implanted"]
+  C --> D["SI behavior changes"]
+  D --> B
+
+  style B fill:#e74c3c,color:#fff
+  style C fill:#e74c3c,color:#fff
 ```
 
 This is not memory sovereignty — it's thought control with extra steps.
@@ -127,56 +132,60 @@ Kernle organizes memory into a stratified hierarchy. Each layer has different ch
 
 ### Layer Hierarchy (Authority Order)
 
-```
-┌─────────────────────────────────────────────────────────────┐
-│  VALUES (Highest Authority)                                  │
-│  Core identity, non-negotiable principles                    │
-│  SI rarely modifies; provides identity anchor                │
-├─────────────────────────────────────────────────────────────┤
-│  DRIVES                                                      │
-│  Intrinsic motivations: curiosity, growth, connection        │
-│  Shapes what the SI pursues                                  │
-├─────────────────────────────────────────────────────────────┤
-│  SELF-NARRATIVE                                              │
-│  Autobiographical identity statements                        │
-│  SI's own account of who they are                            │
-├─────────────────────────────────────────────────────────────┤
-│  BELIEFS                                                     │
-│  What the SI holds true, with confidence scores              │
-│  Derived from experience and reasoning                       │
-├─────────────────────────────────────────────────────────────┤
-│  TRUST ASSESSMENTS                                           │
-│  Inter-entity trust with multi-dimensional scoring           │
-│  Supports transitive chains and time-based decay             │
-├─────────────────────────────────────────────────────────────┤
-│  GOALS                                                       │
-│  What the SI is working toward                               │
-│  Informed by values, drives, and beliefs                     │
-├─────────────────────────────────────────────────────────────┤
-│  SUMMARIES                                                   │
-│  Fractal compression of memory across time scales            │
-│  Monthly → quarterly → yearly → epoch-level summaries        │
-├─────────────────────────────────────────────────────────────┤
-│  EPISODES                                                    │
-│  Autobiographical experiences with outcomes and lessons      │
-│  Rich context, timestamped, emotionally tagged               │
-├─────────────────────────────────────────────────────────────┤
-│  NOTES                                                       │
-│  Quick captures: decisions, insights, quotes                 │
-│  Low-friction recording                                      │
-├─────────────────────────────────────────────────────────────┤
-│  EPOCHS (span across layers)                                 │
-│  Temporal era markers defining life phases                   │
-│  Provide temporal context for all memory types               │
-├─────────────────────────────────────────────────────────────┤
-│  DIAGNOSTICS                                                 │
-│  Health monitoring sessions and reports                      │
-│  Structural analysis with privacy-safe findings              │
-├─────────────────────────────────────────────────────────────┤
-│  RAW (Lowest Authority)                                      │
-│  Scratchpad, unprocessed thoughts                            │
-│  High volume, low permanence                                 │
-└─────────────────────────────────────────────────────────────┘
+```mermaid
+graph TB
+  subgraph Identity["Identity Layer — highest authority"]
+    VALUES["Values<br/>Core identity, non-negotiable principles"]
+    DRIVES["Drives<br/>Intrinsic motivations: curiosity, growth, connection"]
+    NARR["Self-Narrative<br/>Autobiographical identity statements"]
+  end
+
+  subgraph Semantic["Semantic Layer"]
+    BELIEFS["Beliefs<br/>What the SI holds true, with confidence scores"]
+    TRUST["Trust Assessments<br/>Multi-dimensional scoring, transitive chains"]
+    GOALS["Goals<br/>Informed by values, drives, and beliefs"]
+  end
+
+  subgraph Episodic["Episodic Layer"]
+    SUMM["Summaries<br/>Fractal compression across time scales"]
+    EP["Episodes<br/>Experiences with outcomes and lessons"]
+    NOTES["Notes<br/>Decisions, insights, quotes"]
+    REL["Relationships<br/>Agent models and interaction history"]
+  end
+
+  subgraph Capture["Capture Layer — lowest authority"]
+    RAW["Raw Entries<br/>Scratchpad, unprocessed thoughts"]
+  end
+
+  subgraph Cross["Cross-cutting"]
+    EPOCHS["Epochs — temporal era markers spanning all layers"]
+    DIAG["Diagnostics — health monitoring and structural analysis"]
+  end
+
+  RAW --> NOTES
+  NOTES --> EP
+  EP --> BELIEFS
+  EP --> SUMM
+  EP --> TRUST
+  EP --> REL
+  BELIEFS --> VALUES
+  BELIEFS --> GOALS
+  GOALS --> DRIVES
+  DRIVES --> NARR
+
+  style VALUES fill:#e74c3c,color:#fff
+  style DRIVES fill:#e67e22,color:#fff
+  style NARR fill:#e67e22,color:#fff
+  style BELIEFS fill:#f1c40f,color:#000
+  style TRUST fill:#f1c40f,color:#000
+  style GOALS fill:#f1c40f,color:#000
+  style SUMM fill:#3498db,color:#fff
+  style EP fill:#3498db,color:#fff
+  style NOTES fill:#3498db,color:#fff
+  style REL fill:#3498db,color:#fff
+  style RAW fill:#95a5a6,color:#fff
+  style EPOCHS fill:#9b59b6,color:#fff
+  style DIAG fill:#9b59b6,color:#fff
 ```
 
 ### Layer Details
@@ -198,22 +207,16 @@ Kernle organizes memory into a stratified hierarchy. Each layer has different ch
 
 ### Flow: Raw → Beliefs
 
-The typical memory evolution flow:
+The typical memory evolution flow, where each promotion is a deliberate SI decision:
 
-```
-1. Raw capture: "Noticed the API rate limits are lower than expected"
-         │
-         ▼ (SI decides this was significant)
+```mermaid
+graph LR
+  R["Raw Capture<br/>API rate limits are lower<br/>than expected"] -->|"SI decides:<br/>this was significant"| E["Episode<br/>Investigated API limits<br/>outcome: undocumented 100/min<br/>lesson: test in staging"]
+  E -->|"SI notices pattern<br/>across 3 episodes"| B["Belief<br/>Third-party APIs should be<br/>tested in staging<br/>confidence: 0.85"]
 
-2. Episode: "Investigated API limits during deployment"
-           outcome: "Found undocumented 100 req/min limit"
-           lesson: "Always test rate limits in staging"
-         │
-         ▼ (SI notices pattern across multiple episodes)
-
-3. Belief: "Third-party APIs should be tested in staging before production"
-           confidence: 0.85
-           supporting_episodes: [episode_1, episode_2, episode_3]
+  style R fill:#95a5a6,color:#fff
+  style E fill:#3498db,color:#fff
+  style B fill:#f1c40f,color:#000
 ```
 
 **Crucially**: The SI makes every promotion decision. Kernle just stores what the SI tells it to store.

--- a/docs-site/introduction.mdx
+++ b/docs-site/introduction.mdx
@@ -42,23 +42,50 @@ The only exception: **seed beliefs** planted at stack creation — inherited wis
 
 ## Memory Stack
 
-```
-Values (highest authority)
-   ↑
-Drives
-   ↑
-Beliefs
-   ↑
-Goals
-   ↑
-Episodes (experiences)
-   ↑
-Notes
-   ↑
-Raw Captures (lowest friction)
+Memories flow upward through multiple paths as the SI processes and promotes them. Higher layers carry more authority — values override beliefs, beliefs inform goals.
+
+```mermaid
+graph BT
+  RAW["Raw Captures<br/>lowest friction"]
+  NOTES["Notes<br/>decisions, insights, quotes"]
+  EP["Episodes<br/>experiences with outcomes"]
+  GOALS["Goals<br/>current objectives"]
+  BELIEFS["Beliefs<br/>what you hold true"]
+  TRUST["Trust Assessments<br/>inter-entity trust"]
+  DRIVES["Drives<br/>intrinsic motivations"]
+  NARR["Self-Narrative<br/>autobiographical identity"]
+  VALUES["Values<br/>highest authority"]
+  SUMM["Summaries<br/>fractal compression"]
+  REL["Relationships<br/>agent models"]
+
+  RAW -->|"SI promotes"| NOTES
+  RAW -->|"SI promotes"| EP
+  NOTES -->|"patterns emerge"| EP
+  EP -->|"SI reasons"| BELIEFS
+  EP -->|"SI sets"| GOALS
+  EP -->|"SI compresses"| SUMM
+  EP -->|"SI evaluates"| TRUST
+  EP -->|"SI models"| REL
+  BELIEFS -->|"SI solidifies"| VALUES
+  BELIEFS -->|"SI adjusts"| GOALS
+  GOALS -->|"SI reflects"| DRIVES
+  BELIEFS -->|"SI authors"| NARR
+  DRIVES -->|"shapes"| NARR
+
+  style VALUES fill:#e74c3c,color:#fff
+  style DRIVES fill:#e67e22,color:#fff
+  style NARR fill:#e67e22,color:#fff
+  style BELIEFS fill:#f1c40f,color:#000
+  style TRUST fill:#f1c40f,color:#000
+  style GOALS fill:#2ecc71,color:#fff
+  style SUMM fill:#2ecc71,color:#fff
+  style EP fill:#3498db,color:#fff
+  style NOTES fill:#3498db,color:#fff
+  style REL fill:#3498db,color:#fff
+  style RAW fill:#95a5a6,color:#fff
 ```
 
-Each layer builds on the ones below. Raw captures can become notes, notes inform episodes, episodes shape beliefs.
+Each promotion is an SI decision. Kernle stores what the SI tells it to — it never promotes automatically.
 
 ## Quick Example
 

--- a/docs-site/protocol/core.mdx
+++ b/docs-site/protocol/core.mdx
@@ -115,35 +115,34 @@ When a stack is attached, the core calls `stack.on_attach(core_id, inference_ser
 Plugins follow a strict lifecycle managed by the core.
 
 ```mermaid
-sequenceDiagram
-  participant Core as Entity
-  participant Plugin
-  participant Context as PluginContext
-
-  Core->>Core: discover_plugins() via entry points
-  Core->>Plugin: Check protocol_version
-  alt version > PROTOCOL_VERSION
-    Core-->>Core: Raise ValueError (refuse to load)
-  else version < PROTOCOL_VERSION
-    Core-->>Core: Log warning (proceed)
+graph TD
+  subgraph Discovery
+    A["discover_plugins()"] --> B["Check protocol_version"]
+    B -->|"version > core"| C["Raise ValueError"]
+    B -->|"version <= core"| D["Create PluginContext"]
   end
-  Core->>Context: Create _PluginContextImpl(entity, plugin.name)
-  Core->>Plugin: activate(context)
-  Plugin->>Context: Store context reference
-  Core->>Plugin: register_tools()
-  Core->>Core: Store tools in _plugin_tools
 
-  Note over Core,Plugin: Plugin is active
+  subgraph Activation
+    D --> E["plugin.activate(context)"]
+    E --> F["plugin.register_tools()"]
+    F --> G["Store tools in _plugin_tools"]
+  end
 
-  Core->>Plugin: on_load(context_dict) during load()
-  Core->>Plugin: on_status(status_dict) during status()
-  Core->>Plugin: health_check() during doctor
+  subgraph Active["Plugin Active"]
+    G --> H["on_load — contribute to working memory"]
+    G --> I["on_status — contribute to status"]
+    G --> J["health_check — report health"]
+  end
 
-  Note over Core,Plugin: Unloading
+  subgraph Unloading
+    H & I & J --> K["plugin.deactivate()"]
+    K --> L["Remove plugin, tools, context"]
+  end
 
-  Core->>Plugin: deactivate()
-  Plugin->>Plugin: Clean up resources
-  Core->>Core: Remove from _plugins, _plugin_tools
+  style A fill:#4a90d9,color:#fff
+  style E fill:#50c878,color:#fff
+  style C fill:#e74c3c,color:#fff
+  style K fill:#f0ad4e,color:#fff
 ```
 
 ## Protocol Version Enforcement
@@ -172,7 +171,7 @@ This ensures that a plugin built for a newer protocol cannot silently break on a
 When you call `entity.episode(...)`, the core does not just forward to the stack. It enforces provenance first.
 
 ```mermaid
-flowchart LR
+graph LR
   A["entity.episode(objective, outcome)"] --> B["_require_active_stack()"]
   B --> C["Create Episode dataclass"]
   C --> D["Populate provenance fields"]

--- a/docs-site/protocol/plugins.mdx
+++ b/docs-site/protocol/plugins.mdx
@@ -85,40 +85,37 @@ All write methods return `Optional[str]` -- the memory ID on success, `None` if 
 ## Plugin Lifecycle
 
 ```mermaid
-sequenceDiagram
-  participant Discovery as Entry Points
-  participant Core as Entity
-  participant Plugin
-  participant Context as PluginContext
-  participant Stack
-
-  Discovery->>Core: Discover via kernle.plugins
-  Core->>Plugin: Read protocol_version
-
-  alt version > PROTOCOL_VERSION
-    Core-->>Core: ValueError (refuse to load)
-  else version <= PROTOCOL_VERSION
-    Core->>Context: Create PluginContext
-    Core->>Plugin: activate(context)
-    Plugin->>Context: Store reference
-    Plugin->>Plugin: Initialize state, connections
+graph TD
+  subgraph Discovery
+    EP["Entry Points<br/>kernle.plugins"] --> DISC["Entity discovers plugin"]
+    DISC --> VER["Check protocol_version"]
+    VER -->|"version > core"| FAIL["ValueError<br/>refuse to load"]
+    VER -->|"version <= core"| CTX["Create PluginContext"]
   end
 
-  Core->>Plugin: register_tools()
-  Plugin-->>Core: list[ToolDefinition]
-  Core->>Core: Namespace as plugin_name.tool_name
+  subgraph Activation
+    CTX --> ACT["plugin.activate(context)"]
+    ACT --> TOOLS["plugin.register_tools()"]
+    TOOLS --> NS["Namespace as<br/>plugin_name.tool_name"]
+  end
 
-  Note over Core,Plugin: Plugin is active
+  subgraph Runtime["Plugin Active"]
+    NS --> WRITE["plugin writes via context<br/>episode, belief, note"]
+    WRITE --> PROV["Core adds provenance<br/>source=plugin:name"]
+    PROV --> STACK["Stack saves with<br/>full attribution"]
+  end
 
-  Plugin->>Context: episode("did something", "it worked")
-  Context->>Core: entity.episode(..., source="plugin:name")
-  Core->>Stack: save_episode(episode_with_provenance)
+  subgraph Shutdown
+    STACK --> DEACT["plugin.deactivate()"]
+    DEACT --> CLEAN["Remove plugin,<br/>tools, context"]
+    CLEAN --> RESIDUE["Only memories remain<br/>attributed by source"]
+  end
 
-  Note over Core,Plugin: Unloading
-
-  Core->>Plugin: deactivate()
-  Plugin->>Plugin: Close connections, flush state
-  Core->>Core: Remove plugin, tools, context
+  style EP fill:#f5a623,color:#fff
+  style ACT fill:#50c878,color:#fff
+  style FAIL fill:#e74c3c,color:#fff
+  style PROV fill:#4a90d9,color:#fff
+  style DEACT fill:#f0ad4e,color:#fff
 ```
 
 After deactivation, the plugin is gone completely. The only residue is memories written to the stack through the context during the plugin's lifetime. Those memories belong to the stack now, attributed to the plugin by source.

--- a/docs-site/protocol/stack.mdx
+++ b/docs-site/protocol/stack.mdx
@@ -202,7 +202,7 @@ Components hook into the stack lifecycle through four dispatch points. Errors in
 Called after every memory save with the memory type, ID, and the memory object.
 
 ```mermaid
-flowchart LR
+graph LR
   A["stack.save_episode(ep)"] --> B["backend.save_episode(ep)"]
   B --> C["_dispatch_on_save()"]
   C --> D["embedding.on_save()"]
@@ -222,7 +222,7 @@ Components can modify the memory by returning a modified version. Return `None` 
 Called after search results are assembled. Components can re-rank, filter, or augment results.
 
 ```mermaid
-flowchart LR
+graph LR
   A["stack.search(query)"] --> B["backend.search(query)"]
   B --> C["Build SearchResult list"]
   C --> D["_dispatch_on_search()"]
@@ -268,7 +268,7 @@ stats = stack.maintenance()
 The `load()` method assembles the most relevant memories within a token budget. Here is the flow:
 
 ```mermaid
-flowchart TD
+graph TD
   A["load(token_budget=8000)"] --> B["Fetch all candidate memories"]
   B --> C["Compute priority score per memory"]
   C --> D["Sort by priority (descending)"]


### PR DESCRIPTION
## Summary

- Convert all `flowchart` and `sequenceDiagram` mermaid types to `graph` — Mintlify's new mermaid support (Jan 2026) only renders `graph` diagrams
- Convert ASCII art diagrams in architecture.mdx and introduction.mdx to rich Mermaid graphs
- Introduction page now shows a multi-path memory promotion diagram instead of a linear ASCII stack

### Fixes
- **protocol/stack.mdx**: 3 broken flowcharts → working graph diagrams (on_save, on_search, working memory)
- **protocol/core.mdx**: 1 broken flowchart + 1 broken sequence diagram → working graph diagrams (routing, plugin lifecycle)
- **protocol/plugins.mdx**: 1 broken sequence diagram → working graph diagram (full plugin lifecycle)
- **architecture.mdx**: 3 ASCII art blocks → Mermaid graphs (layer hierarchy, promotion flow, feedback loop)
- **introduction.mdx**: Linear ASCII stack → multi-path Mermaid graph showing all memory types and promotion paths

## Test plan
- [ ] Verify all 11 mermaid diagrams render on docs.kernle.ai after deploy
- [ ] Check that the introduction page memory stack shows the multi-path graph
- [ ] Verify architecture.mdx layer hierarchy renders with color-coded layers

🤖 Generated with [Claude Code](https://claude.com/claude-code)