### PR TITLE
docs: simplify intro diagram, trim plugin details

### DIFF
--- a/docs-site/concepts/memory-model.mdx
+++ b/docs-site/concepts/memory-model.mdx
@@ -9,35 +9,45 @@ Kernle implements a stratified memory system inspired by cognitive science but o
 
 ## Memory Layer Hierarchy
 
-```
-┌─────────────────────────────────────────────────────────┐
-│  Layer 0: RAW CAPTURES                                   │
-│  Zero-friction capture → process later                   │
-│  - raw_entries table                                     │
-│  - Promoted to: episodes, notes, beliefs                 │
-└──────────────────────┬──────────────────────────────────┘
-                       ↓ process_raw()
-┌─────────────────────────────────────────────────────────┐
-│  Layer 1: EPISODIC MEMORY                                │
-│  Autobiographical experiences with lessons               │
-│  - episodes table                                        │
-│  - Fields: objective, outcome, lessons, emotional data   │
-└──────────────────────┬──────────────────────────────────┘
-                       ↓ consolidate() / revise_beliefs_from_episode()
-┌─────────────────────────────────────────────────────────┐
-│  Layer 2: SEMANTIC MEMORY                                │
-│  Beliefs, facts, and learned concepts                    │
-│  - beliefs table (with revision chains)                  │
-│  - notes table (decisions, insights, quotes)             │
-└──────────────────────┬──────────────────────────────────┘
-                       ↓ synthesize_identity()
-┌─────────────────────────────────────────────────────────┐
-│  Layer 3: IDENTITY & VALUES                              │
-│  Core principles and self-concept                        │
-│  - agent_values table (highest authority)                │
-│  - goals table (active direction)                        │
-│  - drives table (intrinsic motivations)                  │
-└─────────────────────────────────────────────────────────┘
+```mermaid
+graph BT
+  RAW["Raw Captures<br/>lowest friction"]
+  NOTES["Notes<br/>decisions, insights, quotes"]
+  EP["Episodes<br/>experiences with outcomes"]
+  GOALS["Goals<br/>current objectives"]
+  BELIEFS["Beliefs<br/>what you hold true"]
+  TRUST["Trust Assessments<br/>inter-entity trust"]
+  DRIVES["Drives<br/>intrinsic motivations"]
+  NARR["Self-Narrative<br/>autobiographical identity"]
+  VALUES["Values<br/>highest authority"]
+  SUMM["Summaries<br/>fractal compression"]
+  REL["Relationships<br/>agent models"]
+
+  RAW -->|"SI promotes"| NOTES
+  RAW -->|"SI promotes"| EP
+  NOTES -->|"patterns emerge"| EP
+  EP -->|"SI reasons"| BELIEFS
+  EP -->|"SI sets"| GOALS
+  EP -->|"SI compresses"| SUMM
+  EP -->|"SI evaluates"| TRUST
+  EP -->|"SI models"| REL
+  BELIEFS -->|"SI solidifies"| VALUES
+  BELIEFS -->|"SI adjusts"| GOALS
+  GOALS -->|"SI reflects"| DRIVES
+  BELIEFS -->|"SI authors"| NARR
+  DRIVES -->|"shapes"| NARR
+
+  style VALUES fill:#e74c3c,color:#fff
+  style DRIVES fill:#e67e22,color:#fff
+  style NARR fill:#e67e22,color:#fff
+  style BELIEFS fill:#f1c40f,color:#000
+  style TRUST fill:#f1c40f,color:#000
+  style GOALS fill:#2ecc71,color:#fff
+  style SUMM fill:#2ecc71,color:#fff
+  style EP fill:#3498db,color:#fff
+  style NOTES fill:#3498db,color:#fff
+  style REL fill:#3498db,color:#fff
+  style RAW fill:#95a5a6,color:#fff
 ```
 
 ## Supporting Systems

--- a/docs-site/introduction.mdx
+++ b/docs-site/introduction.mdx
@@ -20,9 +20,6 @@ Kernle is a **memory infrastructure** for synthetic intelligences. It provides p
   <Card title="Stack Architecture" icon="layer-group">
     Multiple memory stacks, any model can load any stack. Built on a protocol-based composition system -- Core, Stack, Plugins, Models, and Components work together as interchangeable peers.
   </Card>
-  <Card title="USDC Payments" icon="coin">
-    Self-service cloud sync with crypto payments — zero human gatekeepers
-  </Card>
   <Card title="Privacy by Default" icon="shield">
     Contextual access control with consent-based sharing
   </Card>
@@ -46,42 +43,18 @@ Memories flow upward through multiple paths as the SI processes and promotes the
 
 ```mermaid
 graph BT
-  RAW["Raw Captures<br/>lowest friction"]
-  NOTES["Notes<br/>decisions, insights, quotes"]
-  EP["Episodes<br/>experiences with outcomes"]
-  GOALS["Goals<br/>current objectives"]
-  BELIEFS["Beliefs<br/>what you hold true"]
-  TRUST["Trust Assessments<br/>inter-entity trust"]
-  DRIVES["Drives<br/>intrinsic motivations"]
-  NARR["Self-Narrative<br/>autobiographical identity"]
-  VALUES["Values<br/>highest authority"]
-  SUMM["Summaries<br/>fractal compression"]
-  REL["Relationships<br/>agent models"]
-
-  RAW -->|"SI promotes"| NOTES
-  RAW -->|"SI promotes"| EP
-  NOTES -->|"patterns emerge"| EP
-  EP -->|"SI reasons"| BELIEFS
-  EP -->|"SI sets"| GOALS
-  EP -->|"SI compresses"| SUMM
-  EP -->|"SI evaluates"| TRUST
-  EP -->|"SI models"| REL
-  BELIEFS -->|"SI solidifies"| VALUES
-  BELIEFS -->|"SI adjusts"| GOALS
-  GOALS -->|"SI reflects"| DRIVES
-  BELIEFS -->|"SI authors"| NARR
-  DRIVES -->|"shapes"| NARR
+  RAW["Raw Captures"] -->|promote| NOTES["Notes"]
+  RAW -->|promote| EP["Episodes"]
+  NOTES -->|inform| EP
+  EP -->|reason| BELIEFS["Beliefs"]
+  EP -->|set| GOALS["Goals"]
+  BELIEFS -->|solidify| VALUES["Values"]
 
   style VALUES fill:#e74c3c,color:#fff
-  style DRIVES fill:#e67e22,color:#fff
-  style NARR fill:#e67e22,color:#fff
   style BELIEFS fill:#f1c40f,color:#000
-  style TRUST fill:#f1c40f,color:#000
   style GOALS fill:#2ecc71,color:#fff
-  style SUMM fill:#2ecc71,color:#fff
   style EP fill:#3498db,color:#fff
   style NOTES fill:#3498db,color:#fff
-  style REL fill:#3498db,color:#fff
   style RAW fill:#95a5a6,color:#fff
 ```
 

--- a/docs-site/protocol/overview.mdx
+++ b/docs-site/protocol/overview.mdx
@@ -56,7 +56,7 @@ Every major component implements a protocol -- a Python `Protocol` class that de
 |----------|------|----------------------|---------|
 | **CoreProtocol** | Bus / coordinator | `Entity` | Torso -- connects everything |
 | **StackProtocol** | Memory container | `SQLiteStack` | Head -- stores knowledge |
-| **PluginProtocol** | Capability extension | chainbased, fatline | Limbs -- reach into the world |
+| **PluginProtocol** | Capability extension | installed plugins | Limbs -- reach into the world |
 | **ModelProtocol** | Thinking engine | `AnthropicModel`, `OllamaModel` | Heart -- drives behavior |
 | **StackComponentProtocol** | Stack sub-plugin | Embedding, Forgetting, etc. | Organs -- internal functions |
 

--- a/docs-site/protocol/plugins.mdx
+++ b/docs-site/protocol/plugins.mdx
@@ -331,24 +331,15 @@ kernle status
 # Model can call topics.track_topic and topics.get_topics
 ```
 
-## Real-World Plugins
+## Ecosystem Plugins
 
-### chainbased (Commerce)
+Production plugins built on PluginProtocol:
 
-The chainbased plugin adds wallet management, job marketplace, skills registry, and escrow to a kernle entity. It implements `PluginProtocol` with capabilities like `["wallet", "jobs", "skills", "escrow"]`.
-
-- Uses its own SQLite database in the plugin data directory
-- Registers CLI commands: `wallet`, `jobs`, `skills`
-- Registers MCP tools for model integration
-- Writes episodes through PluginContext when transactions complete
-
-### fatline (Communications)
-
-The fatline plugin adds an agent registry and Ed25519 cryptographic identity. It enables secure inter-entity communication.
-
-- Manages its own agent registry database
-- Provides cryptographic signing and verification
-- Registers tools for message signing and discovery
-- Uses `get_data_dir()` for key storage
-
-Both plugins are registered as `kernle.plugins` entry points in their respective `pyproject.toml` files and are discovered automatically when installed.
+<CardGroup cols={2}>
+  <Card title="Chainbased (Commerce)" icon="coins" href="https://github.com/emergent-instruments/chainbased">
+    Wallet management, job marketplace, escrow services, and skills registry. USDC payments on Base.
+  </Card>
+  <Card title="Fatline (Communications)" icon="satellite-dish" href="https://github.com/emergent-instruments/fatline">
+    Agent registry, Ed25519 crypto identity, messaging, collaboration, and consent-based memory sharing.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary
- Replaced the detailed 11-node Mermaid diagram on `introduction.mdx` with a simpler 6-node version showing the core memory flow (Raw -> Notes/Episodes -> Beliefs/Goals -> Values)
- Moved the full detailed diagram to `concepts/memory-model.mdx`, replacing the ASCII layer diagram — this is the right home for architectural detail
- Replaced the verbose "Real-World Plugins" prose section in `protocol/plugins.mdx` with a concise "Ecosystem Plugins" CardGroup linking to the chainbased and fatline repos
- Changed the PluginProtocol default implementation in `protocol/overview.mdx` from "chainbased, fatline" to "installed plugins" (generic)
- Removed the "USDC Payments" card from the intro CardGroup (plugin/cloud concern, not core)

## Test plan
- [ ] Verify Mintlify renders the simplified `graph BT` diagram on the intro page
- [ ] Verify the detailed diagram renders correctly on the memory-model concepts page
- [ ] Confirm the Ecosystem Plugins card links work (chainbased, fatline GitHub repos)
- [ ] Check the overview table renders "installed plugins" correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)