### PR TITLE
feat: continuous strength model replaces binary forgetting (v0.9.0 PR 1/6)

### DIFF
--- a/docs-site/api-reference/sync.mdx
+++ b/docs-site/api-reference/sync.mdx
@@ -270,7 +270,7 @@ Only send fields that exist in the database schema. Unknown fields will cause si
 
 ### Episode Fields
 
-`id`, `stack_id`, `objective`, `outcome`, `lesson`, `timestamp`, `emotional_valence`, `emotional_arousal`, `emotional_tags`, `confidence`, `source_type`, `derived_from`, `source_episodes`, `context`, `context_tags`, `subject_ids`, `access_grants`, `times_accessed`, `last_accessed`, `is_protected`, `is_forgotten`
+`id`, `stack_id`, `objective`, `outcome`, `lesson`, `timestamp`, `emotional_valence`, `emotional_arousal`, `emotional_tags`, `confidence`, `source_type`, `derived_from`, `source_episodes`, `context`, `context_tags`, `subject_ids`, `access_grants`, `times_accessed`, `last_accessed`, `is_protected`, `strength`
 
 ### Belief Fields
 

--- a/docs/architecture/memory-integrity.md
+++ b/docs/architecture/memory-integrity.md
@@ -1,0 +1,140 @@
+# Memory Integrity Architecture
+
+## Overview
+
+This document maps every enforcement point in kernle's memory system —
+what is validated, where, and what gaps exist.
+
+## Enforcement Layers
+
+### Entity Layer (kernle/entity.py)
+
+**What it enforces:**
+- Active stack required for all writes (`_require_active_stack()` → `NoActiveStackError`)
+- Timestamps auto-generated (`datetime.now(timezone.utc)`)
+- Source attribution: `source_entity` set to `core:{id}` or `plugin:{name}`
+- Source type: `source_type = "direct_experience"` on all direct writes
+
+**What it passes through (no validation):**
+- `derived_from` — accepted as-is, no hierarchy check (prior to v0.9.0)
+- `confidence` — accepted as-is, no range validation
+- `intensity` — accepted as-is, no range validation
+- `priority` — accepted as-is, no range validation
+
+### Stack Layer (kernle/stack/sqlite_stack.py)
+
+**What it enforces (v0.9.0+):**
+- Stack lifecycle state (INITIALIZING → ACTIVE → MAINTENANCE)
+- Provenance validation on save (when ACTIVE):
+  - `derived_from` non-empty for types that require it
+  - Referenced type from allowed source layer
+  - Referenced memory exists in the stack
+- Component hooks (on_save, on_search, on_load, on_maintenance)
+
+**What it does NOT enforce:**
+- Content validation (accepts any string)
+- Range validation on numeric fields
+
+### Storage Layer (kernle/storage/sqlite.py)
+
+**What it enforces:**
+- `derived_from` cycle detection (via lineage.py, max depth 10)
+- `source_type` is write-once on updates
+- `derived_from` is append-only on updates (union merge)
+- Schema integrity (SQLite constraints, NOT NULL, UNIQUE)
+- Table name allowlisting (prevents SQL injection)
+
+**What it does NOT enforce:**
+- Provenance completeness
+- Hierarchy rules
+
+### Type Layer (kernle/types.py)
+
+**What it enforces:**
+- Nothing at present — no `__post_init__` validation, no range checks
+- Types are pure data containers
+
+## Memory Hierarchy
+
+```
+Raw (entry point — no provenance required)
+  ↓
+Episode / Note (must cite ≥1 raw)
+  ↓
+Belief (must cite ≥1 episode or note)
+  ↓
+Value (must cite ≥1 belief)
+
+Episode → Goal (must cite ≥1 episode or belief)
+Episode → Relationship (must cite ≥1 episode)
+Episode/Belief → Drive (must cite ≥1 episode or belief)
+```
+
+## Strength Model (v0.9.0)
+
+Replaces binary `is_forgotten` with continuous `strength: float`:
+
+| Range     | Status   | Behavior                                |
+|-----------|----------|-----------------------------------------|
+| 0.8–1.0   | Strong   | Full weight in search/load              |
+| 0.5–0.8   | Fading   | Included but reduced priority           |
+| 0.2–0.5   | Weak     | Excluded from load(), still searchable  |
+| 0.0–0.2   | Dormant  | Only via explicit `include_dormant=True` |
+| 0.0       | Forgotten| Tombstoned, only via `recover()`        |
+
+## Stack Lifecycle States
+
+```
+INITIALIZING → ACTIVE → (temporarily) MAINTENANCE → ACTIVE
+```
+
+- **INITIALIZING**: Seed writes allowed without provenance. Transitions to ACTIVE
+  on first `on_attach()`.
+- **ACTIVE**: All writes must have valid provenance (hierarchy enforced).
+- **MAINTENANCE**: Only controlled admin operations (migrate, repair).
+  Requires explicit call, returns to ACTIVE on exit.
+
+## Controlled Access Operations (v0.9.0)
+
+| Operation   | Method                              | Access        |
+|-------------|-------------------------------------|---------------|
+| Weaken      | `entity.weaken(id, amount, reason)` | SI via Entity |
+| Forget      | `entity.forget(id, reason)`         | SI via Entity |
+| Recover     | `entity.recover(id)`                | SI via Entity |
+| Consolidate | `entity.consolidate(ids, summary)`  | SI via Entity |
+| Repair      | `entity.repair(id, field, value)`   | Admin only    |
+| Migrate     | `stack.migrate(memories, source)`   | Admin only    |
+| Verify      | `entity.verify(id)`                 | SI via Entity |
+| Protect     | `entity.protect(id)`                | SI via Entity |
+
+## Audit Trail
+
+All mutation operations create entries in `memory_audit`:
+
+```sql
+CREATE TABLE memory_audit (
+    id TEXT PRIMARY KEY,
+    memory_type TEXT NOT NULL,
+    memory_id TEXT NOT NULL,
+    operation TEXT NOT NULL,
+    details TEXT,
+    actor TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+```
+
+## Gap Table
+
+| Field / Behavior | Should Be | Currently | Fixed In |
+|------------------|-----------|-----------|----------|
+| `derived_from` required | Yes (for non-raw) | Optional (None default) | v0.9.0 PR 2-3 |
+| Hierarchy enforcement | Episode needs Raw, Belief needs Episode | None | v0.9.0 PR 2-3 |
+| `confidence` range | 0.0–1.0 | Unclamped | Future |
+| `intensity` range | 0.0–1.0 | Unclamped | Future |
+| `priority` range | 0–100 | Unclamped | Future |
+| `source_entity` on Goal/Drive/Relationship | Populated | Missing | v0.9.0 PR 3 |
+| `repeat`/`avoid` on Episode | Wired | Silently dropped | v0.9.0 PR 3 |
+| Plugin value/goal/drive attribution | source=plugin:name | Missing | v0.9.0 PR 3 |
+| Stack lifecycle states | Enforced | None | v0.9.0 PR 2 |
+| Controlled access model | Named operations | Direct stack calls | v0.9.0 PR 5 |
+| Memory processing | Automated sessions | Manual | v0.9.0 PR 6 |

--- a/kernle/cli/commands/forget.py
+++ b/kernle/cli/commands/forget.py
@@ -136,11 +136,7 @@ def cmd_forget(args, k: "Kernle"):
             for i, f in enumerate(forgotten, 1):
                 print(f"{i}. [{f['type']:<10}] {f['id'][:8]}...")
                 print(f"   Summary: {f['summary'][:50]}...")
-                print(
-                    f"   Forgotten at: {f['forgotten_at'][:10] if f['forgotten_at'] else 'unknown'}"
-                )
-                if f["forgotten_reason"]:
-                    print(f"   Reason: {f['forgotten_reason'][:50]}...")
+                print(f"   Strength: {f.get('strength', 0.0)}")
                 print(f"   Created: {f['created_at']}")
                 print()
 

--- a/kernle/core.py
+++ b/kernle/core.py
@@ -5484,7 +5484,7 @@ class Kernle(
         min_occurrences = max(2, min_occurrences)
 
         episodes = self._storage.get_episodes(limit=limit)
-        episodes = [ep for ep in episodes if not ep.is_forgotten]
+        episodes = [ep for ep in episodes if ep.strength > 0.0]
 
         if len(episodes) < min_episodes:
             return {

--- a/kernle/features/consolidation.py
+++ b/kernle/features/consolidation.py
@@ -63,7 +63,7 @@ class ConsolidationMixin:
             - scaffold: formatted text scaffold for reflection
         """
         episodes = self._storage.get_episodes(limit=limit)
-        episodes = [ep for ep in episodes if not ep.is_forgotten]
+        episodes = [ep for ep in episodes if ep.strength > 0.0]
 
         if not episodes:
             return {
@@ -277,7 +277,7 @@ class ConsolidationMixin:
             - scaffold: formatted text scaffold for reflection
         """
         beliefs = self._storage.get_beliefs(limit=500, include_inactive=False)
-        beliefs = [b for b in beliefs if b.is_active and not b.is_forgotten]
+        beliefs = [b for b in beliefs if b.is_active and b.strength > 0.0]
 
         # Also get existing values for dedup checking
         values = self._storage.get_values(limit=200)
@@ -760,11 +760,11 @@ def build_epoch_closing_scaffold(kernle: "Kernle", epoch_id: str) -> Dict[str, A
     # Gather data used across multiple steps
     episodes = kernle._storage.get_episodes(limit=200)
     epoch_episodes = [
-        ep for ep in episodes if not ep.is_forgotten and getattr(ep, "epoch_id", None) == epoch_id
+        ep for ep in episodes if ep.strength > 0.0 and getattr(ep, "epoch_id", None) == epoch_id
     ]
 
     beliefs = kernle._storage.get_beliefs(limit=200, include_inactive=False)
-    active_beliefs = [b for b in beliefs if b.is_active and not b.is_forgotten]
+    active_beliefs = [b for b in beliefs if b.is_active and b.strength > 0.0]
 
     relationships = kernle._storage.get_relationships()
 

--- a/kernle/features/forgetting.py
+++ b/kernle/features/forgetting.py
@@ -104,7 +104,7 @@ class ForgettingMixin:
 
         Returns memories that are:
         - Not protected (is_protected = False)
-        - Not already forgotten (is_forgotten = False)
+        - Not already forgotten (strength > 0.0)
         - Have salience below the threshold
 
         Args:
@@ -117,33 +117,33 @@ class ForgettingMixin:
         """
         results = self._storage.get_forgetting_candidates(
             memory_types=memory_types,
-            limit=limit * 2,  # Get more to filter by threshold
+            limit=limit,
+            threshold=threshold,
         )
 
         candidates = []
         for r in results:
-            if r.score < threshold:
-                record = r.record
-                candidates.append(
-                    {
-                        "type": r.record_type,
-                        "id": record.id,
-                        "salience": round(r.score, 4),
-                        "summary": self._get_memory_summary(r.record_type, record),
-                        "confidence": getattr(record, "confidence", 0.8),
-                        "times_accessed": getattr(record, "times_accessed", 0),
-                        "last_accessed": (
-                            getattr(record, "last_accessed").isoformat()
-                            if getattr(record, "last_accessed", None)
-                            else None
-                        ),
-                        "created_at": (
-                            getattr(record, "created_at").strftime("%Y-%m-%d")
-                            if getattr(record, "created_at", None)
-                            else "unknown"
-                        ),
-                    }
-                )
+            record = r.record
+            candidates.append(
+                {
+                    "type": r.record_type,
+                    "id": record.id,
+                    "salience": round(r.score, 4),
+                    "summary": self._get_memory_summary(r.record_type, record),
+                    "confidence": getattr(record, "confidence", 0.8),
+                    "times_accessed": getattr(record, "times_accessed", 0),
+                    "last_accessed": (
+                        getattr(record, "last_accessed").isoformat()
+                        if getattr(record, "last_accessed", None)
+                        else None
+                    ),
+                    "created_at": (
+                        getattr(record, "created_at").strftime("%Y-%m-%d")
+                        if getattr(record, "created_at", None)
+                        else "unknown"
+                    ),
+                }
+            )
 
         return candidates[:limit]
 
@@ -279,12 +279,7 @@ class ForgettingMixin:
                     "type": r.record_type,
                     "id": record.id,
                     "summary": self._get_memory_summary(r.record_type, record),
-                    "forgotten_at": (
-                        getattr(record, "forgotten_at").isoformat()
-                        if getattr(record, "forgotten_at", None)
-                        else None
-                    ),
-                    "forgotten_reason": getattr(record, "forgotten_reason", None),
+                    "strength": getattr(record, "strength", 0.0),
                     "created_at": (
                         getattr(record, "created_at").strftime("%Y-%m-%d")
                         if getattr(record, "created_at", None)

--- a/kernle/protocols.py
+++ b/kernle/protocols.py
@@ -106,6 +106,22 @@ class StorageError(KernleError):
     pass
 
 
+class ProvenanceError(KernleError):
+    """Raised when provenance validation fails.
+
+    E.g., creating a belief without citing an episode/note,
+    or citing a raw directly as a belief source.
+    """
+
+    pass
+
+
+class MaintenanceModeError(KernleError):
+    """Raised when an operation requires maintenance mode but the stack is not in it."""
+
+    pass
+
+
 # =============================================================================
 # SHARED TYPES
 # =============================================================================
@@ -127,6 +143,14 @@ class StorageError(KernleError):
 # - relationship.trust_level is typically the latest compute_trust() result
 #   for that entity. The stack may update it automatically or on request.
 # =============================================================================
+
+
+class StackState(str, Enum):
+    """Lifecycle state for a memory stack."""
+
+    INITIALIZING = "initializing"  # Seed writes allowed without provenance
+    ACTIVE = "active"  # All writes require valid provenance
+    MAINTENANCE = "maintenance"  # Only controlled admin operations
 
 
 class MemoryType(str, Enum):

--- a/kernle/stack/components/consolidation.py
+++ b/kernle/stack/components/consolidation.py
@@ -114,7 +114,7 @@ class ConsolidationComponent:
         lesson_domain_map: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
 
         for ep in episodes:
-            if ep.is_forgotten:
+            if ep.strength == 0.0:
                 continue
             tags = set(ep.tags or [])
             ctx_tags = getattr(ep, "context_tags", None) or []

--- a/kernle/stack/sqlite_stack.py
+++ b/kernle/stack/sqlite_stack.py
@@ -351,7 +351,7 @@ class SQLiteStack(
     ) -> List[Episode]:
         episodes = self._backend.get_episodes(limit=limit, tags=tags)
         if not include_forgotten:
-            episodes = [e for e in episodes if not e.is_forgotten]
+            episodes = [e for e in episodes if e.strength > 0.0]
         return episodes
 
     def get_beliefs(
@@ -369,7 +369,7 @@ class SQLiteStack(
         if min_confidence is not None:
             beliefs = [b for b in beliefs if b.confidence >= min_confidence]
         if not include_forgotten:
-            beliefs = [b for b in beliefs if not b.is_forgotten]
+            beliefs = [b for b in beliefs if b.strength > 0.0]
         return beliefs
 
     def get_values(
@@ -381,7 +381,7 @@ class SQLiteStack(
     ) -> List[Value]:
         values = self._backend.get_values(limit=limit)
         if not include_forgotten:
-            values = [v for v in values if not v.is_forgotten]
+            values = [v for v in values if v.strength > 0.0]
         return values
 
     def get_goals(
@@ -394,7 +394,7 @@ class SQLiteStack(
     ) -> List[Goal]:
         goals = self._backend.get_goals(status=status, limit=limit)
         if not include_forgotten:
-            goals = [g for g in goals if not g.is_forgotten]
+            goals = [g for g in goals if g.strength > 0.0]
         return goals
 
     def get_notes(
@@ -407,7 +407,7 @@ class SQLiteStack(
     ) -> List[Note]:
         notes = self._backend.get_notes(limit=limit, note_type=note_type)
         if not include_forgotten:
-            notes = [n for n in notes if not n.is_forgotten]
+            notes = [n for n in notes if n.strength > 0.0]
         return notes
 
     def get_drives(self, *, include_expired: bool = False) -> List[Drive]:

--- a/kernle/storage/base.py
+++ b/kernle/storage/base.py
@@ -952,17 +952,20 @@ class Storage(Protocol):
         self,
         memory_types: Optional[List[str]] = None,
         limit: int = 100,
+        threshold: float = 0.5,
     ) -> List[SearchResult]:
         """Get memories that are candidates for forgetting.
 
         Returns memories that are:
         - Not protected
-        - Not already forgotten
-        - Sorted by salience (lowest first)
+        - Not already forgotten (strength > 0.0)
+        - Below the strength threshold
+        - Sorted by strength (lowest first)
 
         Args:
             memory_types: Filter by memory type
             limit: Maximum results
+            threshold: Strength threshold (memories below this are candidates)
 
         Returns:
             List of candidate memories with computed salience scores

--- a/kernle/types.py
+++ b/kernle/types.py
@@ -241,13 +241,13 @@ class Episode:
     last_verified: Optional[datetime] = None
     verification_count: int = 0
     confidence_history: Optional[List[Dict[str, Any]]] = None
-    # Forgetting fields
+    # Strength and access fields
+    strength: float = 1.0  # 0.0 (forgotten) to 1.0 (strong) — replaces binary is_forgotten
     times_accessed: int = 0  # Number of times this memory was retrieved
     last_accessed: Optional[datetime] = None  # When last accessed/retrieved
     is_protected: bool = False  # Never decay (core identity memories)
-    is_forgotten: bool = False  # Tombstoned, not deleted
-    forgotten_at: Optional[datetime] = None  # When it was forgotten
-    forgotten_reason: Optional[str] = None  # Why it was forgotten
+    # Processing state
+    processed: bool = False  # Whether this episode has been processed for promotion
     # Context/scope fields for project-specific memories
     context: Optional[str] = None  # e.g., "project:api-service", "repo:myorg/myrepo"
     context_tags: Optional[List[str]] = None  # Additional context tags for filtering
@@ -287,13 +287,11 @@ class Belief:
     superseded_by: Optional[str] = None  # ID of belief that replaced this
     times_reinforced: int = 0  # How many times confirmed
     is_active: bool = True  # False if superseded/archived
-    # Forgetting fields
+    # Strength and access fields
+    strength: float = 1.0  # 0.0 (forgotten) to 1.0 (strong)
     times_accessed: int = 0
     last_accessed: Optional[datetime] = None
     is_protected: bool = False
-    is_forgotten: bool = False
-    forgotten_at: Optional[datetime] = None
-    forgotten_reason: Optional[str] = None
     # Context/scope fields for project-specific memories
     context: Optional[str] = None  # e.g., "project:api-service", "repo:myorg/myrepo"
     context_tags: Optional[List[str]] = None  # Additional context tags for filtering
@@ -333,13 +331,11 @@ class Value:
     last_verified: Optional[datetime] = None
     verification_count: int = 0
     confidence_history: Optional[List[Dict[str, Any]]] = None
-    # Forgetting fields
+    # Strength and access fields
+    strength: float = 1.0  # 0.0 (forgotten) to 1.0 (strong)
     times_accessed: int = 0
     last_accessed: Optional[datetime] = None
     is_protected: bool = True  # Values are protected by default
-    is_forgotten: bool = False
-    forgotten_at: Optional[datetime] = None
-    forgotten_reason: Optional[str] = None
     # Context/scope fields for project-specific memories
     context: Optional[str] = None
     context_tags: Optional[List[str]] = None
@@ -376,13 +372,11 @@ class Goal:
     last_verified: Optional[datetime] = None
     verification_count: int = 0
     confidence_history: Optional[List[Dict[str, Any]]] = None
-    # Forgetting fields
+    # Strength and access fields
+    strength: float = 1.0  # 0.0 (forgotten) to 1.0 (strong)
     times_accessed: int = 0
     last_accessed: Optional[datetime] = None
     is_protected: bool = False
-    is_forgotten: bool = False
-    forgotten_at: Optional[datetime] = None
-    forgotten_reason: Optional[str] = None
     # Context/scope fields for project-specific memories
     context: Optional[str] = None
     context_tags: Optional[List[str]] = None
@@ -420,13 +414,13 @@ class Note:
     last_verified: Optional[datetime] = None
     verification_count: int = 0
     confidence_history: Optional[List[Dict[str, Any]]] = None
-    # Forgetting fields
+    # Strength and access fields
+    strength: float = 1.0  # 0.0 (forgotten) to 1.0 (strong)
     times_accessed: int = 0
     last_accessed: Optional[datetime] = None
     is_protected: bool = False
-    is_forgotten: bool = False
-    forgotten_at: Optional[datetime] = None
-    forgotten_reason: Optional[str] = None
+    # Processing state
+    processed: bool = False  # Whether this note has been processed for promotion
     # Context/scope fields for project-specific memories
     context: Optional[str] = None  # e.g., "project:api-service", "repo:myorg/myrepo"
     context_tags: Optional[List[str]] = None  # Additional context tags for filtering
@@ -462,13 +456,11 @@ class Drive:
     last_verified: Optional[datetime] = None
     verification_count: int = 0
     confidence_history: Optional[List[Dict[str, Any]]] = None
-    # Forgetting fields
+    # Strength and access fields
+    strength: float = 1.0  # 0.0 (forgotten) to 1.0 (strong)
     times_accessed: int = 0
     last_accessed: Optional[datetime] = None
     is_protected: bool = True  # Drives are protected by default
-    is_forgotten: bool = False
-    forgotten_at: Optional[datetime] = None
-    forgotten_reason: Optional[str] = None
     # Context/scope fields for project-specific memories
     context: Optional[str] = None
     context_tags: Optional[List[str]] = None
@@ -507,13 +499,11 @@ class Relationship:
     last_verified: Optional[datetime] = None
     verification_count: int = 0
     confidence_history: Optional[List[Dict[str, Any]]] = None
-    # Forgetting fields
+    # Strength and access fields
+    strength: float = 1.0  # 0.0 (forgotten) to 1.0 (strong)
     times_accessed: int = 0
     last_accessed: Optional[datetime] = None
     is_protected: bool = False
-    is_forgotten: bool = False
-    forgotten_at: Optional[datetime] = None
-    forgotten_reason: Optional[str] = None
     # Context/scope fields for project-specific memories
     context: Optional[str] = None
     context_tags: Optional[List[str]] = None

--- a/tests/contracts/test_stack_contract.py
+++ b/tests/contracts/test_stack_contract.py
@@ -620,7 +620,7 @@ class TestMetaMemoryOps:
         all_eps = stack.get_episodes(include_forgotten=True)
         forgotten = [e for e in all_eps if e.id == ep.id]
         assert len(forgotten) == 1
-        assert forgotten[0].is_forgotten is True
+        assert forgotten[0].strength == 0.0
 
         # Recover
         recovered = stack.recover_memory("episode", ep.id)
@@ -629,7 +629,7 @@ class TestMetaMemoryOps:
         episodes_after = stack.get_episodes()
         found_after = [e for e in episodes_after if e.id == ep.id]
         assert len(found_after) == 1
-        assert found_after[0].is_forgotten is False
+        assert found_after[0].strength > 0.0
 
     def test_protect_memory(self, stack):
         b = _make_belief()

--- a/tests/test_cli_forget.py
+++ b/tests/test_cli_forget.py
@@ -283,8 +283,7 @@ class TestCmdForgetList:
                 "type": "episode",
                 "id": "abc123",
                 "summary": "Forgotten episode",
-                "forgotten_at": "2026-01-28T00:00:00Z",
-                "forgotten_reason": "Low salience",
+                "strength": 0.0,
                 "created_at": "2026-01-01",
             }
         ]

--- a/tests/test_consolidation_scaffold.py
+++ b/tests/test_consolidation_scaffold.py
@@ -24,7 +24,7 @@ def _make_episode(
 ):
     """Create a mock episode with sensible defaults."""
     ep = MagicMock()
-    ep.is_forgotten = False
+    ep.strength = 1.0
     ep.objective = objective
     ep.outcome = outcome
     ep.outcome_type = outcome_type

--- a/tests/test_diagnostic_sessions.py
+++ b/tests/test_diagnostic_sessions.py
@@ -806,7 +806,7 @@ class TestSchemaVersion:
     def test_schema_version_is_22(self):
         from kernle.storage.sqlite import SCHEMA_VERSION
 
-        assert SCHEMA_VERSION == 23
+        assert SCHEMA_VERSION == 24
 
     def test_tables_in_allowed_list(self):
         from kernle.storage.sqlite import ALLOWED_TABLES

--- a/tests/test_fractal_summarization.py
+++ b/tests/test_fractal_summarization.py
@@ -386,4 +386,4 @@ class TestSchemaVersion:
     def test_schema_version_updated(self):
         from kernle.storage.sqlite import SCHEMA_VERSION
 
-        assert SCHEMA_VERSION == 23
+        assert SCHEMA_VERSION == 24

--- a/tests/test_postgres_storage.py
+++ b/tests/test_postgres_storage.py
@@ -1035,9 +1035,7 @@ class TestSupabaseForgetting:
                 "objective": "Test episode",
                 "outcome": "Success",
                 "is_protected": False,
-                "is_forgotten": False,
-                "forgotten_at": None,
-                "forgotten_reason": None,
+                "strength": 1.0,
                 "created_at": datetime.now(timezone.utc).isoformat(),
             }
         )
@@ -1046,9 +1044,7 @@ class TestSupabaseForgetting:
         assert result is True
 
         updated = db["episodes"][0]
-        assert updated["is_forgotten"] is True
-        assert updated["forgotten_reason"] == "Low salience"
-        assert updated["forgotten_at"] is not None
+        assert updated["strength"] == 0.0
 
     def test_forget_protected_memory_fails(self, supabase_storage):
         """Test that protected memories cannot be forgotten."""
@@ -1062,7 +1058,7 @@ class TestSupabaseForgetting:
                 "objective": "Protected episode",
                 "outcome": "Success",
                 "is_protected": True,
-                "is_forgotten": False,
+                "strength": 1.0,
                 "created_at": datetime.now(timezone.utc).isoformat(),
             }
         )
@@ -1071,7 +1067,7 @@ class TestSupabaseForgetting:
         assert result is False
 
         updated = db["episodes"][0]
-        assert updated["is_forgotten"] is False
+        assert updated["strength"] == 1.0
 
     def test_forget_already_forgotten_fails(self, supabase_storage):
         """Test that already forgotten memories return False."""
@@ -1085,8 +1081,7 @@ class TestSupabaseForgetting:
                 "objective": "Already forgotten",
                 "outcome": "Success",
                 "is_protected": False,
-                "is_forgotten": True,
-                "forgotten_at": datetime.now(timezone.utc).isoformat(),
+                "strength": 0.0,
                 "created_at": datetime.now(timezone.utc).isoformat(),
             }
         )
@@ -1105,9 +1100,7 @@ class TestSupabaseForgetting:
                 "stack_id": "test_agent",
                 "objective": "Forgotten episode",
                 "outcome": "Success",
-                "is_forgotten": True,
-                "forgotten_at": datetime.now(timezone.utc).isoformat(),
-                "forgotten_reason": "Test",
+                "strength": 0.0,
                 "created_at": datetime.now(timezone.utc).isoformat(),
             }
         )
@@ -1116,9 +1109,7 @@ class TestSupabaseForgetting:
         assert result is True
 
         updated = db["episodes"][0]
-        assert updated["is_forgotten"] is False
-        assert updated["forgotten_at"] is None
-        assert updated["forgotten_reason"] is None
+        assert updated["strength"] > 0.0
 
     def test_recover_not_forgotten_fails(self, supabase_storage):
         """Test that recovering non-forgotten memory returns False."""
@@ -1131,7 +1122,7 @@ class TestSupabaseForgetting:
                 "stack_id": "test_agent",
                 "objective": "Normal episode",
                 "outcome": "Success",
-                "is_forgotten": False,
+                "strength": 1.0,
                 "created_at": datetime.now(timezone.utc).isoformat(),
             }
         )
@@ -1199,7 +1190,7 @@ class TestSupabaseForgetting:
                 "times_accessed": 0,
                 "last_accessed": None,
                 "is_protected": False,
-                "is_forgotten": False,
+                "strength": 1.0,
                 "created_at": old_date,
             }
         )
@@ -1214,7 +1205,7 @@ class TestSupabaseForgetting:
                 "confidence": 0.3,
                 "times_accessed": 0,
                 "is_protected": True,
-                "is_forgotten": False,
+                "strength": 1.0,
                 "created_at": old_date,
             }
         )
@@ -1229,7 +1220,7 @@ class TestSupabaseForgetting:
                 "confidence": 0.3,
                 "times_accessed": 0,
                 "is_protected": False,
-                "is_forgotten": True,
+                "strength": 0.0,
                 "created_at": old_date,
             }
         )
@@ -1258,7 +1249,7 @@ class TestSupabaseForgetting:
                 "times_accessed": 10,
                 "last_accessed": now,
                 "is_protected": False,
-                "is_forgotten": False,
+                "strength": 1.0,
                 "created_at": now,
             }
         )
@@ -1274,7 +1265,7 @@ class TestSupabaseForgetting:
                 "times_accessed": 0,
                 "last_accessed": None,
                 "is_protected": False,
-                "is_forgotten": False,
+                "strength": 1.0,
                 "created_at": now,
             }
         )
@@ -1300,9 +1291,7 @@ class TestSupabaseForgetting:
                 "stack_id": "test_agent",
                 "objective": "Forgotten 1",
                 "outcome": "Old",
-                "is_forgotten": True,
-                "forgotten_at": now,
-                "forgotten_reason": "Low salience",
+                "strength": 0.0,
                 "created_at": now,
             }
         )
@@ -1313,9 +1302,7 @@ class TestSupabaseForgetting:
                 "stack_id": "test_agent",
                 "objective": "Forgotten 2",
                 "outcome": "Old",
-                "is_forgotten": True,
-                "forgotten_at": now,
-                "forgotten_reason": "Manual",
+                "strength": 0.0,
                 "created_at": now,
             }
         )
@@ -1327,7 +1314,7 @@ class TestSupabaseForgetting:
                 "stack_id": "test_agent",
                 "objective": "Active",
                 "outcome": "Current",
-                "is_forgotten": False,
+                "strength": 1.0,
                 "created_at": now,
             }
         )
@@ -1350,7 +1337,7 @@ class TestSupabaseForgetting:
                 "stack_id": "test_agent",
                 "objective": "Active",
                 "outcome": "Current",
-                "is_forgotten": False,
+                "strength": 1.0,
                 "created_at": datetime.now(timezone.utc).isoformat(),
             }
         )
@@ -1371,7 +1358,7 @@ class TestSupabaseForgetting:
                 "belief_type": "fact",
                 "confidence": 0.5,
                 "is_protected": False,
-                "is_forgotten": False,
+                "strength": 1.0,
                 "is_active": True,
                 "created_at": datetime.now(timezone.utc).isoformat(),
             }
@@ -1381,7 +1368,7 @@ class TestSupabaseForgetting:
         assert result is True
 
         updated = db["beliefs"][0]
-        assert updated["is_forgotten"] is True
+        assert updated["strength"] == 0.0
 
     def test_forget_note_uses_stack_id(self, supabase_storage):
         """Test that forgetting notes uses stack_id correctly."""
@@ -1395,7 +1382,7 @@ class TestSupabaseForgetting:
                 "content": "Test note",
                 "source": "curated",
                 "is_protected": False,
-                "is_forgotten": False,
+                "strength": 1.0,
                 "metadata": {},
                 "created_at": datetime.now(timezone.utc).isoformat(),
             }
@@ -1405,4 +1392,4 @@ class TestSupabaseForgetting:
         assert result is True
 
         updated = db["notes"][0]
-        assert updated["is_forgotten"] is True
+        assert updated["strength"] == 0.0

--- a/tests/test_self_narrative.py
+++ b/tests/test_self_narrative.py
@@ -301,4 +301,4 @@ class TestSchemaVersion:
     def test_schema_version_updated(self):
         from kernle.storage.sqlite import SCHEMA_VERSION
 
-        assert SCHEMA_VERSION == 23
+        assert SCHEMA_VERSION == 24

--- a/tests/test_stack_components.py
+++ b/tests/test_stack_components.py
@@ -67,7 +67,7 @@ def _make_mock_episode(
     outcome_type: str = "success",
     lessons: Optional[List[str]] = None,
     tags: Optional[List[str]] = None,
-    is_forgotten: bool = False,
+    strength: float = 1.0,
     emotional_valence: float = 0.0,
     emotional_arousal: float = 0.0,
     emotional_tags: Optional[List[str]] = None,
@@ -81,7 +81,7 @@ def _make_mock_episode(
     ep.outcome_type = outcome_type
     ep.lessons = lessons or []
     ep.tags = tags or []
-    ep.is_forgotten = is_forgotten
+    ep.strength = strength
     ep.emotional_valence = emotional_valence
     ep.emotional_arousal = emotional_arousal
     ep.emotional_tags = emotional_tags or []

--- a/tests/test_two_tier_consolidation.py
+++ b/tests/test_two_tier_consolidation.py
@@ -29,7 +29,7 @@ def _make_episode(
 ):
     ep = MagicMock()
     ep.id = id
-    ep.is_forgotten = False
+    ep.strength = 1.0
     ep.objective = objective
     ep.outcome = outcome
     ep.outcome_type = outcome_type
@@ -72,7 +72,7 @@ def _make_belief(id="b-001", statement="Test belief", confidence=0.8):
     b.statement = statement
     b.confidence = confidence
     b.is_active = True
-    b.is_forgotten = False
+    b.strength = 1.0
     b.times_reinforced = 0
     b.superseded_by = None
     b.source_domain = None


### PR DESCRIPTION
## Summary

- Replace `is_forgotten: bool`, `forgotten_at`, `forgotten_reason` with `strength: float` (0.0-1.0) across all 7 memory types (Episode, Belief, Value, Goal, Note, Drive, Relationship)
- Add `processed: bool` field to Episode and Note for future memory processing pipeline
- Add `ProvenanceError`, `MaintenanceModeError` exceptions and `StackState` enum to protocols (foundations for PR 2)
- Add `memory_audit` and `processing_config` tables to SQLite schema (foundations for PR 5-6)
- Schema migration v24 converts existing `is_forgotten=1` records to `strength=0.0`
- Update all storage backends (SQLite + Postgres), stack, components, features, CLI, and tests
- Create architecture audit doc: `docs/architecture/memory-integrity.md`

## Strength model

| Range | Status | Behavior |
|-------|--------|----------|
| 0.8-1.0 | Strong | Full weight in search/load |
| 0.5-0.8 | Fading | Included but reduced priority |
| 0.2-0.5 | Weak | Excluded from load(), still searchable |
| 0.0-0.2 | Dormant | Only via explicit `include_dormant=True` |
| 0.0 | Forgotten | Tombstoned, only via `recover()` |

## Files changed (24)

- `kernle/types.py` — Remove 3 fields, add `strength` + `processed`
- `kernle/protocols.py` — Add exceptions + StackState enum
- `kernle/storage/sqlite.py` — Schema DDL, save/update/row-mapping, forget/recover
- `kernle/storage/postgres.py` — Save/row-mapping methods
- `kernle/storage/base.py` — Update protocol signature
- `kernle/stack/sqlite_stack.py` — Strength-based filtering
- `kernle/stack/components/consolidation.py` — Strength check
- `kernle/features/forgetting.py` — Strength-based candidates
- `kernle/features/consolidation.py` — Strength checks
- `kernle/core.py` — Strength check
- `kernle/cli/commands/forget.py` — Display strength
- `migrations/001_initial_schema.sql` — Postgres schema
- `docs/architecture/memory-integrity.md` — NEW audit doc
- 11 test files updated

## Test plan

- [x] Full test suite: 2587 passed, 0 failures, 2 skipped
- [x] Grep verification: zero remaining `is_forgotten`/`forgotten_at`/`forgotten_reason` in code (only in comments and migration logic)
- [x] Pre-commit hooks pass (ruff, black, secrets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)