### PR TITLE
fix: plugin bypass spoofable + strict mode auto-attach

### DIFF
--- a/kernle/core.py
+++ b/kernle/core.py
@@ -532,6 +532,10 @@ class Kernle(
             )
             if hasattr(self, "_entity"):
                 self._entity.attach_stack(self._stack, alias="default", set_active=True)
+            elif self._strict:
+                # Strict mode: auto-attach so stack transitions to ACTIVE
+                # (without Entity, on_attach is the only way to leave INITIALIZING)
+                self._stack.on_attach(self.stack_id)
         return self._stack
 
     @property


### PR DESCRIPTION
## Summary

Fixes two P1 issues from codex's updated audit (HEAD 050d2cf):

### P1 #1: Plugin provenance bypass spoofable
- `_validate_provenance()` trusted any `source_entity="plugin:..."` — any direct caller could spoof this
- **Fix**: SQLiteStack now maintains a `_registered_plugins` set. Only plugins registered via `register_plugin()` are trusted
- Entity wires this automatically: `load_plugin()` registers, `unload_plugin()` unregisters, `attach_stack()` registers all already-loaded plugins

### P1 #2: Strict mode didn't auto-attach
- `Kernle(strict=True)` routed writes to the stack, but the stack stayed in `INITIALIZING` (which skips all provenance)
- **Fix**: `Kernle.stack` property now calls `on_attach()` when `strict=True`, transitioning to `ACTIVE` immediately

## Test plan

- [x] 91 provenance tests pass (+5 new: spoofable bypass, unregister revocation, auto-attach, enforced rejection)
- [x] Full suite: 2825 passed, 2 skipped, 0 failures
- [x] Unregistered `plugin:unknown_plugin` rejected with ProvenanceError
- [x] `unregister_plugin()` revokes bypass for that plugin
- [x] Strict mode stack auto-attaches to ACTIVE state
- [x] Strict + enforce_provenance rejects belief without derived_from

🤖 Generated with [Claude Code](https://claude.com/claude-code)