### PR TITLE
fix: enforce_provenance setting takes effect immediately

### DIFF
--- a/kernle/stack/sqlite_stack.py
+++ b/kernle/stack/sqlite_stack.py
@@ -991,8 +991,13 @@ class SQLiteStack(
         return self._backend.get_stack_setting(key)
 
     def set_stack_setting(self, key: str, value: str) -> None:
-        """Set a stack setting (upsert)."""
+        """Set a stack setting (upsert). Updates in-memory state for known keys."""
         self._backend.set_stack_setting(key, value)
+        # Sync in-memory flags so changes take effect immediately
+        if key == "enforce_provenance":
+            self._enforce_provenance = value == "true"
+        elif key == "stack_state" and value in StackState.__members__:
+            self._state = StackState[value]
 
     def get_all_stack_settings(self) -> Dict[str, str]:
         """Get all stack settings as a dict."""


### PR DESCRIPTION
## Summary

`set_stack_setting("enforce_provenance", "true")` now updates the in-memory `_enforce_provenance` flag immediately, instead of requiring a stack restart.

Also syncs `stack_state` on write for consistency.

Codex P1: setting was only loaded at init (`__init__` line 190), but `set_stack_setting()` only wrote to DB.

## Test plan

- [x] New test: enable provenance → reject → disable → allow (live toggle)
- [x] 92 provenance tests pass, 2826 total

🤖 Generated with [Claude Code](https://claude.com/claude-code)