### PR TITLE
feat: wire inference to consolidation + emotion components, add Belief.processed

### DIFF
--- a/kernle/stack/sqlite_stack.py
+++ b/kernle/stack/sqlite_stack.py
@@ -984,6 +984,10 @@ class SQLiteStack(
         """Mark a note as processed."""
         return self._backend.mark_note_processed(note_id)
 
+    def mark_belief_processed(self, belief_id: str) -> bool:
+        """Mark a belief as processed."""
+        return self._backend.mark_belief_processed(belief_id)
+
     # ---- Stack Settings ----
 
     def get_stack_setting(self, key: str) -> Optional[str]:

--- a/kernle/types.py
+++ b/kernle/types.py
@@ -301,6 +301,8 @@ class Belief:
     subject_ids: Optional[List[str]] = None  # Who/what is this about
     access_grants: Optional[List[str]] = None  # Who can see this (empty = private to self)
     consent_grants: Optional[List[str]] = None  # Who authorized sharing
+    # Processing state
+    processed: bool = False  # Whether this belief has been processed for promotion
     # Belief scope and domain metadata (KEP v3)
     belief_scope: str = "world"  # 'self' | 'world' | 'relational'
     source_domain: Optional[str] = None  # "coding", "communication", etc.


### PR DESCRIPTION
## Summary
- **EmotionalTaggingComponent**: calls `inference.infer()` for richer emotion detection when available, falls back to keyword-based detection
- **ConsolidationComponent**: calls `inference.infer()` for theme synthesis during maintenance when available, falls back to keyword counting
- **Belief.processed**: added `processed: bool` field to Belief dataclass + DB schema + `mark_belief_processed()` method, completing the processing lifecycle tracking for all promotable types
- All inference calls wrapped in try/except for graceful degradation — components never fail if inference is unavailable or returns garbage

Closes #322

## Test plan
- [x] 18 new tests (7 emotion inference, 4 consolidation inference, 5 belief processed, 2 integration)
- [x] Full suite: 2842 passed
- [x] No regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>