### PR TITLE
feat: wire derived_from to CLI — relationship, import, value, goal

### DIFF
--- a/kernle/cli/__main__.py
+++ b/kernle/cli/__main__.py
@@ -893,23 +893,41 @@ def cmd_relation(args, k: Kernle):
         entity_type = args.type or "person"
         trust = args.trust if args.trust is not None else 0.5
         notes = validate_input(args.notes, "notes", 1000) if args.notes else None
+        derived_from = getattr(args, "derived_from", None)
 
-        _rel_id = k.relationship(name, trust_level=trust, notes=notes, entity_type=entity_type)
+        _rel_id = k.relationship(
+            name,
+            trust_level=trust,
+            notes=notes,
+            entity_type=entity_type,
+            derived_from=derived_from,
+        )
         print(f"✓ Relationship added: {name}")
         print(f"  Type: {entity_type}, Trust: {int(trust * 100)}%")
+        if derived_from:
+            print(f"  Derived from: {len(derived_from)} memories")
 
     elif args.relation_action == "update":
         name = validate_input(args.name, "name", 200)
         trust = args.trust
         notes = validate_input(args.notes, "notes", 1000) if args.notes else None
         entity_type = getattr(args, "type", None)
+        derived_from = getattr(args, "derived_from", None)
 
-        if trust is None and notes is None and entity_type is None:
-            print("✗ Provide --trust, --notes, or --type to update")
+        if trust is None and notes is None and entity_type is None and derived_from is None:
+            print("✗ Provide --trust, --notes, --type, or --derived-from to update")
             return
 
-        _rel_id = k.relationship(name, trust_level=trust, notes=notes, entity_type=entity_type)
+        _rel_id = k.relationship(
+            name,
+            trust_level=trust,
+            notes=notes,
+            entity_type=entity_type,
+            derived_from=derived_from,
+        )
         print(f"✓ Relationship updated: {name}")
+        if derived_from:
+            print(f"  Derived from: {len(derived_from)} memories")
 
     elif args.relation_action == "show":
         name = args.name
@@ -3032,6 +3050,12 @@ def main():
     )
     relation_add.add_argument("--trust", type=float, help="Trust level 0.0-1.0")
     relation_add.add_argument("--notes", "-n", help="Notes about this relationship")
+    relation_add.add_argument(
+        "--derived-from",
+        action="append",
+        dest="derived_from",
+        help="Source memory ID (repeatable)",
+    )
 
     relation_update = relation_sub.add_parser("update", help="Update a relationship")
     relation_update.add_argument("name", help="Entity name")
@@ -3039,6 +3063,12 @@ def main():
     relation_update.add_argument("--notes", "-n", help="Updated notes")
     relation_update.add_argument(
         "--type", "-t", choices=["person", "si", "organization", "system"], help="Entity type"
+    )
+    relation_update.add_argument(
+        "--derived-from",
+        action="append",
+        dest="derived_from",
+        help="Source memory ID (repeatable)",
     )
 
     relation_show = relation_sub.add_parser("show", help="Show relationship details")
@@ -4153,6 +4183,12 @@ Typical usage in a memoryFlush hook:
         action="store_false",
         dest="skip_duplicates",
         help="Import all items even if they already exist",
+    )
+    p_import.add_argument(
+        "--derived-from",
+        action="append",
+        dest="derived_from",
+        help="Source memory ID for all imported items (repeatable)",
     )
 
     # migrate - migrate from other platforms (Clawdbot, etc.)

--- a/kernle/core.py
+++ b/kernle/core.py
@@ -2953,12 +2953,14 @@ class Kernle(
         foundational: bool = False,
         context: Optional[str] = None,
         context_tags: Optional[List[str]] = None,
+        derived_from: Optional[List[str]] = None,
     ) -> str:
         """Add or affirm a value.
 
         Args:
             context: Project/scope context (e.g., 'project:api-service', 'repo:myorg/myrepo')
             context_tags: Additional context tags for filtering
+            derived_from: List of memory refs this was derived from (format: type:id)
         """
         value_id = str(uuid.uuid4())
 
@@ -2971,6 +2973,7 @@ class Kernle(
             created_at=datetime.now(timezone.utc),
             context=context,
             context_tags=context_tags,
+            derived_from=derived_from,
         )
 
         self._write_backend.save_value(value)
@@ -2984,6 +2987,7 @@ class Kernle(
         priority: str = "medium",
         context: Optional[str] = None,
         context_tags: Optional[List[str]] = None,
+        derived_from: Optional[List[str]] = None,
     ) -> str:
         """Add a goal.
 
@@ -2991,6 +2995,7 @@ class Kernle(
             goal_type: Type of goal (task, aspiration, commitment, exploration)
             context: Project/scope context (e.g., 'project:api-service', 'repo:myorg/myrepo')
             context_tags: Additional context tags for filtering
+            derived_from: List of memory refs this was derived from (format: type:id)
         """
         valid_goal_types = ("task", "aspiration", "commitment", "exploration")
         if goal_type not in valid_goal_types:
@@ -3013,6 +3018,7 @@ class Kernle(
             is_protected=is_protected,
             context=context,
             context_tags=context_tags,
+            derived_from=derived_from,
         )
 
         self._write_backend.save_goal(goal)
@@ -4836,6 +4842,7 @@ class Kernle(
         notes: Optional[str] = None,
         interaction_type: Optional[str] = None,
         entity_type: Optional[str] = None,
+        derived_from: Optional[List[str]] = None,
     ) -> str:
         """Update relationship model for another entity.
 
@@ -4845,6 +4852,7 @@ class Kernle(
             notes: Notes about the relationship
             interaction_type: Type of interaction being logged
             entity_type: Type of entity (person, agent, organization, system)
+            derived_from: Memory IDs this relationship was derived from
         """
         # Check existing
         existing = self._storage.get_relationship(other_stack_id)
@@ -4859,6 +4867,8 @@ class Kernle(
                 existing.notes = notes
             if entity_type:
                 existing.entity_type = entity_type
+            if derived_from:
+                existing.derived_from = derived_from
             existing.interaction_count += 1
             existing.last_interaction = now
             existing.version += 1
@@ -4877,6 +4887,7 @@ class Kernle(
                 interaction_count=1,
                 last_interaction=now,
                 created_at=now,
+                derived_from=derived_from,
             )
             self._write_backend.save_relationship(relationship)
             return rel_id

--- a/tests/test_cli_provenance.py
+++ b/tests/test_cli_provenance.py
@@ -1,0 +1,415 @@
+"""Tests for CLI provenance (derived_from) wiring.
+
+Verifies that derived_from is properly passed through CLI commands
+to the underlying Kernle methods.
+"""
+
+from argparse import Namespace
+from unittest.mock import MagicMock
+
+from kernle.cli.__main__ import cmd_relation
+from kernle.cli.commands.import_cmd import _import_item
+
+
+class TestRelationDerivedFrom:
+    """Test that relation add/update passes derived_from."""
+
+    def test_relation_add_with_derived_from(self, capsys):
+        """relation add passes derived_from to k.relationship()."""
+        k = MagicMock()
+        k.relationship.return_value = "rel-123"
+
+        args = Namespace(
+            relation_action="add",
+            name="Alice",
+            type="person",
+            trust=0.8,
+            notes="Met at conference",
+            derived_from=["episode:ep-abc", "note:note-def"],
+            json=False,
+        )
+
+        cmd_relation(args, k)
+
+        k.relationship.assert_called_once_with(
+            "Alice",
+            trust_level=0.8,
+            notes="Met at conference",
+            entity_type="person",
+            derived_from=["episode:ep-abc", "note:note-def"],
+        )
+        captured = capsys.readouterr()
+        assert "Relationship added: Alice" in captured.out
+        assert "Derived from: 2 memories" in captured.out
+
+    def test_relation_add_without_derived_from(self, capsys):
+        """relation add works without derived_from."""
+        k = MagicMock()
+        k.relationship.return_value = "rel-123"
+
+        args = Namespace(
+            relation_action="add",
+            name="Bob",
+            type="person",
+            trust=None,
+            notes=None,
+            json=False,
+        )
+
+        cmd_relation(args, k)
+
+        k.relationship.assert_called_once_with(
+            "Bob",
+            trust_level=0.5,
+            notes=None,
+            entity_type="person",
+            derived_from=None,
+        )
+        captured = capsys.readouterr()
+        assert "Derived from" not in captured.out
+
+    def test_relation_update_with_derived_from(self, capsys):
+        """relation update passes derived_from to k.relationship()."""
+        k = MagicMock()
+        k.relationship.return_value = "rel-123"
+
+        args = Namespace(
+            relation_action="update",
+            name="Alice",
+            trust=0.9,
+            notes=None,
+            type=None,
+            derived_from=["episode:ep-xyz"],
+            json=False,
+        )
+
+        cmd_relation(args, k)
+
+        k.relationship.assert_called_once_with(
+            "Alice",
+            trust_level=0.9,
+            notes=None,
+            entity_type=None,
+            derived_from=["episode:ep-xyz"],
+        )
+        captured = capsys.readouterr()
+        assert "Relationship updated: Alice" in captured.out
+        assert "Derived from: 1 memories" in captured.out
+
+    def test_relation_update_derived_from_only(self, capsys):
+        """relation update with only derived_from should not require other fields."""
+        k = MagicMock()
+        k.relationship.return_value = "rel-123"
+
+        args = Namespace(
+            relation_action="update",
+            name="Alice",
+            trust=None,
+            notes=None,
+            type=None,
+            derived_from=["context:imported_from_backup"],
+            json=False,
+        )
+
+        cmd_relation(args, k)
+
+        # Should not print the "Provide --trust..." error
+        k.relationship.assert_called_once()
+        captured = capsys.readouterr()
+        assert "Relationship updated" in captured.out
+
+    def test_relation_update_nothing_provided(self, capsys):
+        """relation update with no changes should show error."""
+        k = MagicMock()
+
+        args = Namespace(
+            relation_action="update",
+            name="Alice",
+            trust=None,
+            notes=None,
+            type=None,
+            derived_from=None,
+            json=False,
+        )
+
+        cmd_relation(args, k)
+
+        k.relationship.assert_not_called()
+        captured = capsys.readouterr()
+        assert "Provide --trust" in captured.out
+
+
+class TestBeliefSupersedeDerivedFrom:
+    """Test that belief supersede already handles derived_from internally."""
+
+    def test_supersede_sets_derived_from_in_core(self):
+        """The core.py supersede_belief sets derived_from=[f'belief:{old_id}']."""
+        # This tests that the core method itself sets derived_from,
+        # so the CLI doesn't need to pass it explicitly.
+        from kernle.core import Kernle
+
+        k = MagicMock(spec=Kernle)
+        # The important assertion is that core.py line ~4236 sets:
+        # derived_from=[f"belief:{old_id}"]
+        # This is tested by the core tests, not CLI tests.
+        # Here we just verify the CLI calls supersede_belief correctly.
+        k.supersede_belief.return_value = "new-belief-id"
+
+        from kernle.cli.commands.belief import cmd_belief
+
+        args = Namespace(
+            belief_action="supersede",
+            old_id="old-belief-123",
+            new_statement="Updated belief statement",
+            confidence=0.9,
+            reason="New evidence found",
+            json=False,
+        )
+
+        cmd_belief(args, k)
+
+        k.supersede_belief.assert_called_once_with(
+            old_id="old-belief-123",
+            new_statement="Updated belief statement",
+            confidence=0.9,
+            reason="New evidence found",
+        )
+
+
+class TestImportItemDerivedFrom:
+    """Test that _import_item passes derived_from to Kernle methods."""
+
+    def test_import_episode_with_derived_from(self):
+        """Import episode passes derived_from."""
+        k = MagicMock()
+        k.episode.return_value = "ep-123"
+
+        item = {
+            "type": "episode",
+            "objective": "Test objective",
+            "outcome": "Test outcome",
+        }
+
+        _import_item(item, k, derived_from=["context:imported_from_backup"])
+
+        k.episode.assert_called_once()
+        call_kwargs = k.episode.call_args[1]
+        assert call_kwargs["derived_from"] == ["context:imported_from_backup"]
+
+    def test_import_note_with_derived_from(self):
+        """Import note passes derived_from."""
+        k = MagicMock()
+        k.note.return_value = "note-123"
+
+        item = {
+            "type": "note",
+            "content": "Test note",
+        }
+
+        _import_item(item, k, derived_from=["context:csv_import"])
+
+        k.note.assert_called_once()
+        call_kwargs = k.note.call_args[1]
+        assert call_kwargs["derived_from"] == ["context:csv_import"]
+
+    def test_import_belief_with_derived_from(self):
+        """Import belief passes derived_from."""
+        k = MagicMock()
+        k.belief.return_value = "belief-123"
+
+        item = {
+            "type": "belief",
+            "statement": "Test belief",
+            "confidence": 0.8,
+        }
+
+        _import_item(item, k, derived_from=["context:json_import"])
+
+        k.belief.assert_called_once()
+        call_kwargs = k.belief.call_args[1]
+        assert call_kwargs["derived_from"] == ["context:json_import"]
+
+    def test_import_value_with_derived_from(self):
+        """Import value passes derived_from."""
+        k = MagicMock()
+        k.value.return_value = "value-123"
+
+        item = {
+            "type": "value",
+            "name": "Quality",
+            "description": "High quality work",
+        }
+
+        _import_item(item, k, derived_from=["context:migration"])
+
+        k.value.assert_called_once()
+        call_kwargs = k.value.call_args[1]
+        assert call_kwargs["derived_from"] == ["context:migration"]
+
+    def test_import_goal_with_derived_from(self):
+        """Import goal passes derived_from."""
+        k = MagicMock()
+        k.goal.return_value = "goal-123"
+
+        item = {
+            "type": "goal",
+            "description": "Test goal",
+        }
+
+        _import_item(item, k, derived_from=["context:backup_restore"])
+
+        k.goal.assert_called_once()
+        call_kwargs = k.goal.call_args[1]
+        assert call_kwargs["derived_from"] == ["context:backup_restore"]
+
+    def test_import_without_derived_from(self):
+        """Import without derived_from passes None."""
+        k = MagicMock()
+        k.episode.return_value = "ep-123"
+
+        item = {
+            "type": "episode",
+            "objective": "Test",
+            "outcome": "Done",
+        }
+
+        _import_item(item, k)
+
+        k.episode.assert_called_once()
+        call_kwargs = k.episode.call_args[1]
+        assert call_kwargs["derived_from"] is None
+
+    def test_import_raw_ignores_derived_from(self):
+        """Import raw does not pass derived_from (raw entries don't support it)."""
+        k = MagicMock()
+        k.raw.return_value = "raw-123"
+
+        item = {
+            "type": "raw",
+            "content": "Raw thought",
+            "source": "import",
+        }
+
+        _import_item(item, k, derived_from=["context:migration"])
+
+        k.raw.assert_called_once()
+        # raw() call should NOT have derived_from
+        call_kwargs = k.raw.call_args[1]
+        assert "derived_from" not in call_kwargs
+
+
+class TestCoreDerivedFrom:
+    """Test that core.py value(), goal(), and relationship() accept derived_from."""
+
+    def _make_kernle(self):
+        """Create a Kernle instance with mock storage."""
+        from kernle.storage.sqlite import SQLiteStorage
+
+        storage = MagicMock(spec=SQLiteStorage)
+        storage.get_relationship.return_value = None  # No existing relationship
+
+        from kernle import Kernle
+
+        k = Kernle(stack_id="test-agent", storage=storage)
+        return k, storage
+
+    def test_value_with_derived_from(self):
+        """Kernle.value() passes derived_from to Value dataclass."""
+        k, storage = self._make_kernle()
+
+        value_id = k.value(
+            name="Integrity",
+            statement="Act with integrity",
+            derived_from=["episode:ep-abc"],
+        )
+
+        assert value_id is not None
+        # Check that save_value was called with a Value that has derived_from set
+        storage.save_value.assert_called_once()
+        saved_value = storage.save_value.call_args[0][0]
+        assert saved_value.derived_from == ["episode:ep-abc"]
+
+    def test_value_without_derived_from(self):
+        """Kernle.value() works without derived_from."""
+        k, storage = self._make_kernle()
+
+        value_id = k.value(name="Quality", statement="High quality")
+
+        assert value_id is not None
+        storage.save_value.assert_called_once()
+        saved_value = storage.save_value.call_args[0][0]
+        assert saved_value.derived_from is None
+
+    def test_goal_with_derived_from(self):
+        """Kernle.goal() passes derived_from to Goal dataclass."""
+        k, storage = self._make_kernle()
+
+        goal_id = k.goal(
+            title="Complete migration",
+            description="Finish the data migration",
+            derived_from=["context:planning_session"],
+        )
+
+        assert goal_id is not None
+        storage.save_goal.assert_called_once()
+        saved_goal = storage.save_goal.call_args[0][0]
+        assert saved_goal.derived_from == ["context:planning_session"]
+
+    def test_goal_without_derived_from(self):
+        """Kernle.goal() works without derived_from."""
+        k, storage = self._make_kernle()
+
+        goal_id = k.goal(title="Do something")
+
+        assert goal_id is not None
+        storage.save_goal.assert_called_once()
+        saved_goal = storage.save_goal.call_args[0][0]
+        assert saved_goal.derived_from is None
+
+    def test_relationship_new_with_derived_from(self):
+        """Kernle.relationship() passes derived_from when creating new."""
+        k, storage = self._make_kernle()
+
+        rel_id = k.relationship(
+            "Alice",
+            trust_level=0.8,
+            entity_type="person",
+            derived_from=["episode:ep-meeting"],
+        )
+
+        assert rel_id is not None
+        storage.save_relationship.assert_called_once()
+        saved_rel = storage.save_relationship.call_args[0][0]
+        assert saved_rel.derived_from == ["episode:ep-meeting"]
+        assert saved_rel.entity_name == "Alice"
+
+    def test_relationship_update_with_derived_from(self):
+        """Kernle.relationship() sets derived_from on update."""
+        from datetime import datetime, timezone
+
+        from kernle.types import Relationship
+
+        k, storage = self._make_kernle()
+
+        # Mock existing relationship
+        existing = Relationship(
+            id="rel-existing",
+            stack_id="test-agent",
+            entity_name="Bob",
+            entity_type="person",
+            relationship_type="interaction",
+            sentiment=0.0,
+            interaction_count=1,
+            created_at=datetime.now(timezone.utc),
+        )
+        storage.get_relationship.return_value = existing
+
+        k.relationship(
+            "Bob",
+            trust_level=0.7,
+            derived_from=["episode:ep-collaboration"],
+        )
+
+        storage.save_relationship.assert_called_once()
+        saved_rel = storage.save_relationship.call_args[0][0]
+        assert saved_rel.derived_from == ["episode:ep-collaboration"]


### PR DESCRIPTION
## Summary
- `relation add/update` — added `--derived-from` CLI flag, wired through to `k.relationship()`
- Import commands (JSON, CSV, markdown) — added `--derived-from` global option, threaded through all formats and `_import_item()` to all memory types
- `core.py` — added `derived_from` param to `value()`, `goal()`, `relationship()` methods
- `belief supersede` — confirmed already handled internally (sets `derived_from=[f"belief:{old_id}"]`)
- `narrative update` — skipped (SelfNarrative dataclass has no derived_from field, would need schema changes)

Closes #320

## Test plan
- [x] 19 new tests in `test_cli_provenance.py`
- [x] Full suite: 2845 passed, 2 skipped
- [x] No regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>