### PR TITLE
feat: add memory processing MCP tools and CLI command

### DIFF
--- a/kernle/cli/__main__.py
+++ b/kernle/cli/__main__.py
@@ -39,6 +39,7 @@ from kernle.cli.commands import (
     cmd_meta,
     cmd_narrative,
     cmd_playbook,
+    cmd_process,
     cmd_promote,
     cmd_raw,
     cmd_stats,
@@ -3473,6 +3474,37 @@ def main():
     # mcp
     subparsers.add_parser("mcp", help="Start MCP server (stdio transport)")
 
+    # process (memory processing)
+    p_process = subparsers.add_parser(
+        "process", help="Run memory processing (model-driven promotion)"
+    )
+    process_sub = p_process.add_subparsers(dest="process_action", required=True)
+
+    process_run = process_sub.add_parser("run", help="Run memory processing")
+    process_run.add_argument(
+        "--transition",
+        "-t",
+        choices=[
+            "raw_to_episode",
+            "raw_to_note",
+            "episode_to_belief",
+            "episode_to_goal",
+            "episode_to_relationship",
+            "belief_to_value",
+            "episode_to_drive",
+        ],
+        help="Specific transition to process (omit to check all)",
+    )
+    process_run.add_argument(
+        "--force", "-f", action="store_true", help="Process even if thresholds aren't met"
+    )
+    process_run.add_argument("--json", "-j", action="store_true", help="Output as JSON")
+
+    process_status = process_sub.add_parser(
+        "status", help="Show unprocessed counts and trigger status"
+    )
+    process_status.add_argument("--json", "-j", action="store_true", help="Output as JSON")
+
     # raw (raw memory entries)
     p_raw = subparsers.add_parser("raw", help="Raw memory capture and management")
     # Arguments for default action (kernle raw "content" without subcommand)
@@ -4528,6 +4560,8 @@ Beliefs already present in the agent's memory will be skipped.
             cmd_narrative(args, k)
         elif args.command == "playbook":
             cmd_playbook(args, k)
+        elif args.command == "process":
+            cmd_process(args, k)
         elif args.command == "raw":
             cmd_raw(args, k)
         elif args.command == "suggestions":

--- a/kernle/cli/commands/__init__.py
+++ b/kernle/cli/commands/__init__.py
@@ -20,6 +20,7 @@ from kernle.cli.commands.init import cmd_init as cmd_init_md
 from kernle.cli.commands.meta import cmd_meta
 from kernle.cli.commands.narrative import cmd_narrative
 from kernle.cli.commands.playbook import cmd_playbook
+from kernle.cli.commands.process import cmd_process
 from kernle.cli.commands.raw import cmd_raw, resolve_raw_id
 from kernle.cli.commands.stats import cmd_stats
 from kernle.cli.commands.subscription import cmd_subscription
@@ -44,6 +45,7 @@ __all__ = [
     "cmd_meta",
     "cmd_narrative",
     "cmd_playbook",
+    "cmd_process",
     "cmd_raw",
     "cmd_stats",
     "cmd_suggestions",

--- a/kernle/cli/commands/process.py
+++ b/kernle/cli/commands/process.py
@@ -1,0 +1,137 @@
+"""Memory processing commands for Kernle CLI."""
+
+import json
+from typing import TYPE_CHECKING
+
+from kernle.processing import DEFAULT_LAYER_CONFIGS, VALID_TRANSITIONS
+
+if TYPE_CHECKING:
+    from kernle import Kernle
+
+
+def cmd_process(args, k: "Kernle"):
+    """Handle process subcommands."""
+    if args.process_action == "run":
+        transition = getattr(args, "transition", None)
+        force = getattr(args, "force", False)
+
+        if transition and transition not in VALID_TRANSITIONS:
+            print(f"Invalid transition: {transition}")
+            print(f"Valid transitions: {', '.join(sorted(VALID_TRANSITIONS))}")
+            return
+
+        try:
+            results = k.process(transition=transition, force=force)
+        except RuntimeError as e:
+            print(f"Error: {e}")
+            print("Memory processing requires a bound model. Use entity.set_model() first.")
+            return
+
+        if not results:
+            print("No processing triggered.")
+            if not force:
+                print("Thresholds not met -- use --force to process anyway.")
+            else:
+                print("No unprocessed memories found.")
+            return
+
+        if getattr(args, "json", False):
+            output = []
+            for r in results:
+                output.append(
+                    {
+                        "transition": r.layer_transition,
+                        "source_count": r.source_count,
+                        "created": r.created,
+                        "errors": r.errors,
+                        "skipped": r.skipped,
+                        "skip_reason": r.skip_reason,
+                    }
+                )
+            print(json.dumps(output, indent=2, default=str))
+        else:
+            print(f"Processing complete ({len(results)} transition(s)):\n")
+            for r in results:
+                if r.skipped:
+                    print(f"  {r.layer_transition}: skipped ({r.skip_reason})")
+                else:
+                    print(
+                        f"  {r.layer_transition}: "
+                        f"{r.source_count} sources -> {len(r.created)} created"
+                    )
+                    for c in r.created:
+                        print(f"    + {c['type']}:{c['id'][:8]}...")
+                    for err in r.errors:
+                        print(f"    ! {err}")
+
+    elif args.process_action == "status":
+        try:
+            storage = k._storage
+
+            # Raw entries
+            unprocessed_raw = storage.list_raw(processed=False, limit=1000)
+            raw_count = len(unprocessed_raw)
+
+            # Episodes
+            episodes = storage.get_episodes(limit=1000)
+            unprocessed_eps = [e for e in episodes if not e.processed]
+
+            # Beliefs
+            beliefs = storage.get_beliefs(limit=1000)
+            unprocessed_beliefs = [b for b in beliefs if not getattr(b, "processed", False)]
+
+            if getattr(args, "json", False):
+                trigger_checks = {}
+                source_counts = {
+                    "raw_to_episode": raw_count,
+                    "raw_to_note": raw_count,
+                    "episode_to_belief": len(unprocessed_eps),
+                    "episode_to_goal": len(unprocessed_eps),
+                    "episode_to_relationship": len(unprocessed_eps),
+                    "episode_to_drive": len(unprocessed_eps),
+                    "belief_to_value": len(unprocessed_beliefs),
+                }
+                for transition, count in source_counts.items():
+                    cfg = DEFAULT_LAYER_CONFIGS.get(transition)
+                    if cfg:
+                        trigger_checks[transition] = {
+                            "unprocessed": count,
+                            "threshold": cfg.quantity_threshold,
+                            "would_fire": count >= cfg.quantity_threshold,
+                        }
+                output = {
+                    "unprocessed_raw": raw_count,
+                    "unprocessed_episodes": len(unprocessed_eps),
+                    "unprocessed_beliefs": len(unprocessed_beliefs),
+                    "triggers": trigger_checks,
+                }
+                print(json.dumps(output, indent=2))
+            else:
+                print("Memory Processing Status")
+                print("=" * 40)
+                print(f"Unprocessed raw entries:  {raw_count}")
+                print(f"Unprocessed episodes:    {len(unprocessed_eps)}")
+                print(f"Unprocessed beliefs:     {len(unprocessed_beliefs)}")
+                print()
+                print("Trigger Status:")
+                trigger_data = {
+                    "raw_to_episode": raw_count,
+                    "raw_to_note": raw_count,
+                    "episode_to_belief": len(unprocessed_eps),
+                    "episode_to_goal": len(unprocessed_eps),
+                    "episode_to_relationship": len(unprocessed_eps),
+                    "episode_to_drive": len(unprocessed_eps),
+                    "belief_to_value": len(unprocessed_beliefs),
+                }
+                for transition, count in trigger_data.items():
+                    cfg = DEFAULT_LAYER_CONFIGS.get(transition)
+                    if cfg:
+                        would_fire = count >= cfg.quantity_threshold
+                        status = "READY" if would_fire else "waiting"
+                        print(f"  {transition}: {count}/{cfg.quantity_threshold} ({status})")
+
+        except Exception as e:
+            print(f"Error gathering status: {e}")
+
+    else:
+        print("Usage: kernle process {run|status}")

--- a/kernle/core.py
+++ b/kernle/core.py
@@ -1786,6 +1786,25 @@ class Kernle(
             for e in entries
         ]
 
+    def process(self, transition=None, force=False):
+        """Run memory processing. Requires a bound model.
+
+        Promotes memories up the hierarchy using the bound model:
+        raw -> episode/note, episode -> belief/goal/relationship/drive,
+        belief -> value.
+
+        Args:
+            transition: Specific layer transition to process (None = check all)
+            force: Process even if triggers aren't met
+
+        Returns:
+            List of ProcessingResult for each transition that ran
+        """
+        entity = self.entity
+        if entity is None:
+            raise RuntimeError("process() requires Entity (use SQLite storage)")
+        return entity.process(transition=transition, force=force)
+
     def process_raw(
         self,
         raw_id: str,

--- a/tests/test_process_triggers.py
+++ b/tests/test_process_triggers.py
@@ -1,0 +1,559 @@
+"""Tests for memory processing MCP tools, CLI commands, and Kernle.process() delegation."""
+
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+
+from kernle.mcp.server import (
+    TOOLS,
+    call_tool,
+    validate_tool_input,
+)
+from kernle.processing import VALID_TRANSITIONS
+from kernle.storage.sqlite import SQLiteStorage
+
+
+@pytest.fixture
+def kernle_instance(tmp_path):
+    """Create a real Kernle instance with SQLite storage."""
+    from kernle import Kernle
+
+    db_path = tmp_path / "test.db"
+    storage = SQLiteStorage(stack_id="test-process", db_path=db_path)
+    k = Kernle(stack_id="test-process", storage=storage)
+    yield k
+    storage.close()
+
+
+# =============================================================================
+# Kernle.process() delegation tests
+# =============================================================================
+
+
+class TestKernleProcess:
+    """Test Kernle.process() delegates to Entity.process()."""
+
+    def test_process_delegates_to_entity(self, kernle_instance):
+        """Kernle.process() should delegate to entity.process()."""
+        k = kernle_instance
+
+        mock_entity = Mock()
+        mock_entity.process.return_value = []
+        k._entity = mock_entity
+
+        result = k.process(transition="raw_to_episode", force=True)
+        mock_entity.process.assert_called_once_with(transition="raw_to_episode", force=True)
+        assert result == []
+
+    def test_process_no_args_delegates_defaults(self, kernle_instance):
+        """Kernle.process() with no args passes defaults."""
+        k = kernle_instance
+
+        mock_entity = Mock()
+        mock_entity.process.return_value = []
+        k._entity = mock_entity
+
+        k.process()
+        mock_entity.process.assert_called_once_with(transition=None, force=False)
+
+    def test_process_propagates_runtime_error(self, kernle_instance):
+        """Kernle.process() propagates RuntimeError from entity."""
+        k = kernle_instance
+
+        mock_entity = Mock()
+        mock_entity.process.side_effect = RuntimeError(
+            "No model bound \u2014 processing requires inference"
+        )
+        k._entity = mock_entity
+
+        with pytest.raises(RuntimeError, match="No model bound"):
+            k.process()
+
+
+# =============================================================================
+# MCP tool definition tests
+# =============================================================================
+
+
+class TestMCPProcessToolDefinitions:
+    """Test that memory_process and memory_process_status tools are defined."""
+
+    def test_memory_process_tool_exists(self):
+        """memory_process tool should be in TOOLS list."""
+        tool_names = {t.name for t in TOOLS}
+        assert "memory_process" in tool_names
+
+    def test_memory_process_status_tool_exists(self):
+        """memory_process_status tool should be in TOOLS list."""
+        tool_names = {t.name for t in TOOLS}
+        assert "memory_process_status" in tool_names
+
+    def test_memory_process_schema(self):
+        """memory_process tool should have correct input schema."""
+        tool = next(t for t in TOOLS if t.name == "memory_process")
+        schema = tool.inputSchema
+        assert schema["type"] == "object"
+        props = schema["properties"]
+        assert "transition" in props
+        assert "force" in props
+        assert "enum" in props["transition"]
+        assert set(props["transition"]["enum"]) == VALID_TRANSITIONS
+
+    def test_memory_process_status_schema(self):
+        """memory_process_status tool should have minimal schema."""
+        tool = next(t for t in TOOLS if t.name == "memory_process_status")
+        schema = tool.inputSchema
+        assert schema["type"] == "object"
+
+
+# =============================================================================
+# MCP validation tests
+# =============================================================================
+
+
+class TestMCPProcessValidation:
+    """Test validate_tool_input for process tools."""
+
+    def test_validate_process_no_args(self):
+        """Validate memory_process with no arguments."""
+        result = validate_tool_input("memory_process", {})
+        assert result["transition"] is None
+        assert result["force"] is False
+
+    def test_validate_process_with_transition(self):
+        """Validate memory_process with valid transition."""
+        result = validate_tool_input("memory_process", {"transition": "raw_to_episode"})
+        assert result["transition"] == "raw_to_episode"
+
+    def test_validate_process_invalid_transition(self):
+        """Validate memory_process rejects invalid transition."""
+        with pytest.raises(ValueError, match="Invalid transition"):
+            validate_tool_input("memory_process", {"transition": "invalid_thing"})
+
+    def test_validate_process_with_force(self):
+        """Validate memory_process with force flag."""
+        result = validate_tool_input("memory_process", {"force": True})
+        assert result["force"] is True
+
+    def test_validate_process_force_non_bool(self):
+        """Non-bool force defaults to False."""
+        result = validate_tool_input("memory_process", {"force": "yes"})
+        assert result["force"] is False
+
+    def test_validate_process_status(self):
+        """Validate memory_process_status with no args."""
+        result = validate_tool_input("memory_process_status", {})
+        assert result == {}
+
+
+# =============================================================================
+# MCP handler tests
+# =============================================================================
+
+
+@pytest.fixture
+def mock_kernle_for_process():
+    """Create mock Kernle for process tool tests."""
+    mock = Mock()
+    mock._storage = Mock()
+
+    # Set up storage mock returns
+    mock._storage.list_raw.return_value = []
+    mock._storage.get_episodes.return_value = []
+    mock._storage.get_beliefs.return_value = []
+
+    return mock
+
+
+@pytest.fixture
+def patched_kernle_process(mock_kernle_for_process):
+    """Patch get_kernle to return process mock."""
+    with patch("kernle.mcp.server.get_kernle", return_value=mock_kernle_for_process):
+        yield mock_kernle_for_process
+
+
+class TestMCPProcessHandler:
+    """Test memory_process MCP tool handler."""
+
+    @pytest.mark.asyncio
+    async def test_process_no_model_returns_error(self, patched_kernle_process):
+        """memory_process with no model bound returns informative error."""
+        patched_kernle_process.process.side_effect = RuntimeError("No model bound")
+
+        result = await call_tool("memory_process", {})
+
+        assert len(result) == 1
+        assert "requires a bound model" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_process_no_triggers(self, patched_kernle_process):
+        """memory_process with no triggers met returns message."""
+        patched_kernle_process.process.return_value = []
+
+        result = await call_tool("memory_process", {})
+
+        assert len(result) == 1
+        assert "No processing triggered" in result[0].text
+        assert "force=true" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_process_force_no_sources(self, patched_kernle_process):
+        """memory_process with force but no sources."""
+        patched_kernle_process.process.return_value = []
+
+        result = await call_tool("memory_process", {"force": True})
+
+        assert len(result) == 1
+        assert "No processing triggered" in result[0].text
+        assert "No unprocessed memories found" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_process_successful(self, patched_kernle_process):
+        """memory_process returns formatted results on success."""
+        from kernle.processing import ProcessingResult
+
+        mock_result = ProcessingResult(
+            layer_transition="raw_to_episode",
+            source_count=3,
+            created=[
+                {"type": "episode", "id": "ep-12345678-abcd"},
+                {"type": "episode", "id": "ep-87654321-dcba"},
+            ],
+        )
+        patched_kernle_process.process.return_value = [mock_result]
+
+        result = await call_tool("memory_process", {"force": True})
+
+        assert len(result) == 1
+        text = result[0].text
+        assert "Processing complete" in text
+        assert "raw_to_episode" in text
+        assert "3 sources" in text
+        assert "2 created" in text
+
+    @pytest.mark.asyncio
+    async def test_process_with_errors(self, patched_kernle_process):
+        """memory_process includes errors in output."""
+        from kernle.processing import ProcessingResult
+
+        mock_result = ProcessingResult(
+            layer_transition="raw_to_episode",
+            source_count=5,
+            errors=["Inference failed: connection timeout"],
+        )
+        patched_kernle_process.process.return_value = [mock_result]
+
+        result = await call_tool("memory_process", {"force": True})
+
+        text = result[0].text
+        assert "Error: Inference failed" in text
+
+    @pytest.mark.asyncio
+    async def test_process_skipped(self, patched_kernle_process):
+        """memory_process shows skip reason."""
+        from kernle.processing import ProcessingResult
+
+        mock_result = ProcessingResult(
+            layer_transition="raw_to_note",
+            source_count=0,
+            skipped=True,
+            skip_reason="No unprocessed sources",
+        )
+        patched_kernle_process.process.return_value = [mock_result]
+
+        result = await call_tool("memory_process", {"force": True})
+
+        text = result[0].text
+        assert "skipped" in text
+        assert "No unprocessed sources" in text
+
+
+class TestMCPProcessStatusHandler:
+    """Test memory_process_status MCP tool handler."""
+
+    @pytest.mark.asyncio
+    async def test_status_empty(self, patched_kernle_process):
+        """memory_process_status with no unprocessed memories."""
+        result = await call_tool("memory_process_status", {})
+
+        assert len(result) == 1
+        text = result[0].text
+        assert "Memory Processing Status" in text
+        assert "Unprocessed raw entries: 0" in text
+        assert "Unprocessed episodes: 0" in text
+
+    @pytest.mark.asyncio
+    async def test_status_with_unprocessed(self, patched_kernle_process):
+        """memory_process_status shows counts and trigger readiness."""
+        # Create mock unprocessed items
+        raw_entries = [Mock() for _ in range(15)]
+        patched_kernle_process._storage.list_raw.return_value = raw_entries
+
+        ep_processed = Mock()
+        ep_processed.processed = True
+        ep_unprocessed = Mock()
+        ep_unprocessed.processed = False
+        patched_kernle_process._storage.get_episodes.return_value = [
+            ep_processed,
+            ep_unprocessed,
+            ep_unprocessed,
+            ep_unprocessed,
+            ep_unprocessed,
+            ep_unprocessed,
+        ]
+
+        result = await call_tool("memory_process_status", {})
+
+        text = result[0].text
+        assert "Unprocessed raw entries: 15" in text
+        assert "Unprocessed episodes: 5" in text
+        assert "READY" in text  # raw_to_episode should be ready at 15 >= 10
+
+
+# =============================================================================
+# CLI command tests
+# =============================================================================
+
+
+class TestCLIProcessCommand:
+    """Test CLI process command registration and execution."""
+
+    def test_process_command_registered(self):
+        """process command should be importable from commands."""
+        from kernle.cli.commands import cmd_process
+
+        assert callable(cmd_process)
+
+    def test_process_run_no_model(self, kernle_instance, capsys):
+        """kernle process run with no model shows error."""
+        from kernle.cli.commands.process import cmd_process
+
+        k = kernle_instance
+
+        mock_entity = Mock()
+        mock_entity.process.side_effect = RuntimeError(
+            "No model bound \u2014 processing requires inference"
+        )
+        k._entity = mock_entity
+
+        args = Mock()
+        args.process_action = "run"
+        args.transition = None
+        args.force = False
+        args.json = False
+
+        cmd_process(args, k)
+
+        captured = capsys.readouterr()
+        assert "requires a bound model" in captured.out
+
+    def test_process_run_success(self, kernle_instance, capsys):
+        """kernle process run with successful processing."""
+        from kernle.cli.commands.process import cmd_process
+        from kernle.processing import ProcessingResult
+
+        k = kernle_instance
+
+        mock_result = ProcessingResult(
+            layer_transition="raw_to_episode",
+            source_count=3,
+            created=[{"type": "episode", "id": "ep-12345678"}],
+        )
+        mock_entity = Mock()
+        mock_entity.process.return_value = [mock_result]
+        k._entity = mock_entity
+
+        args = Mock()
+        args.process_action = "run"
+        args.transition = "raw_to_episode"
+        args.force = True
+        args.json = False
+
+        cmd_process(args, k)
+
+        captured = capsys.readouterr()
+        assert "Processing complete" in captured.out
+        assert "raw_to_episode" in captured.out
+        assert "ep-12345" in captured.out
+
+    def test_process_run_json_output(self, kernle_instance, capsys):
+        """kernle process run --json outputs JSON."""
+        from kernle.cli.commands.process import cmd_process
+        from kernle.processing import ProcessingResult
+
+        k = kernle_instance
+
+        mock_result = ProcessingResult(
+            layer_transition="raw_to_note",
+            source_count=2,
+            created=[{"type": "note", "id": "note-abc123"}],
+        )
+        mock_entity = Mock()
+        mock_entity.process.return_value = [mock_result]
+        k._entity = mock_entity
+
+        args = Mock()
+        args.process_action = "run"
+        args.transition = None
+        args.force = True
+        args.json = True
+
+        cmd_process(args, k)
+
+        captured = capsys.readouterr()
+        output = json.loads(captured.out)
+        assert isinstance(output, list)
+        assert output[0]["transition"] == "raw_to_note"
+        assert output[0]["source_count"] == 2
+
+    def test_process_status(self, kernle_instance, capsys):
+        """kernle process status shows counts."""
+        from kernle.cli.commands.process import cmd_process
+
+        k = kernle_instance
+
+        # Mock storage methods
+        k._storage.list_raw = Mock(return_value=[Mock() for _ in range(5)])
+
+        ep = Mock()
+        ep.processed = False
+        k._storage.get_episodes = Mock(return_value=[ep, ep])
+
+        belief = Mock()
+        belief.processed = False
+        k._storage.get_beliefs = Mock(return_value=[belief])
+
+        args = Mock()
+        args.process_action = "status"
+        args.json = False
+
+        cmd_process(args, k)
+
+        captured = capsys.readouterr()
+        assert "Unprocessed raw entries:" in captured.out
+        assert "5" in captured.out
+        assert "Trigger Status:" in captured.out
+
+    def test_process_status_json(self, kernle_instance, capsys):
+        """kernle process status --json outputs JSON."""
+        from kernle.cli.commands.process import cmd_process
+
+        k = kernle_instance
+
+        k._storage.list_raw = Mock(return_value=[])
+        k._storage.get_episodes = Mock(return_value=[])
+        k._storage.get_beliefs = Mock(return_value=[])
+
+        args = Mock()
+        args.process_action = "status"
+        args.json = True
+
+        cmd_process(args, k)
+
+        captured = capsys.readouterr()
+        output = json.loads(captured.out)
+        assert "unprocessed_raw" in output
+        assert "unprocessed_episodes" in output
+        assert "triggers" in output
+
+    def test_process_invalid_transition(self, kernle_instance, capsys):
+        """kernle process run with invalid transition shows error."""
+        from kernle.cli.commands.process import cmd_process
+
+        k = kernle_instance
+
+        args = Mock()
+        args.process_action = "run"
+        args.transition = "invalid_transition"
+        args.force = False
+        args.json = False
+
+        cmd_process(args, k)
+
+        captured = capsys.readouterr()
+        assert "Invalid transition" in captured.out
+
+    def test_process_no_triggers_without_force(self, kernle_instance, capsys):
+        """kernle process run without triggers hints about --force."""
+        from kernle.cli.commands.process import cmd_process
+
+        k = kernle_instance
+
+        mock_entity = Mock()
+        mock_entity.process.return_value = []
+        k._entity = mock_entity
+
+        args = Mock()
+        args.process_action = "run"
+        args.transition = None
+        args.force = False
+        args.json = False
+
+        cmd_process(args, k)
+
+        captured = capsys.readouterr()
+        assert "--force" in captured.out
+
+
+# =============================================================================
+# Default config persistence test
+# =============================================================================
+
+
+class TestDefaultConfigPersistence:
+    """Test that Entity.process() loads saved configs."""
+
+    def test_entity_process_loads_saved_config(self):
+        """Entity.process() loads config from stack."""
+        from kernle.entity import Entity
+
+        entity = Entity(core_id="test-config")
+
+        # Mock stack with saved config
+        mock_stack = Mock()
+        mock_stack.get_processing_config.return_value = [
+            {
+                "layer_transition": "raw_to_episode",
+                "enabled": True,
+                "quantity_threshold": 20,
+                "batch_size": 5,
+            }
+        ]
+
+        # Mock inference
+        mock_inference = Mock()
+
+        entity._get_inference_service = Mock(return_value=mock_inference)
+        entity._require_active_stack = Mock(return_value=mock_stack)
+
+        # entity.process will create MemoryProcessor and load config
+        # Since we mock everything, it should complete without error
+        with patch("kernle.processing.MemoryProcessor") as mock_processor_cls:
+            instance = mock_processor_cls.return_value
+            instance.process.return_value = []
+
+            entity.process(force=True)
+
+            # Verify MemoryProcessor was created and config was loaded
+            mock_processor_cls.assert_called_once()
+            # Verify update_config was called with the saved config
+            instance.update_config.assert_called_once()
+            call_args = instance.update_config.call_args
+            assert call_args[0][0] == "raw_to_episode"
+            lc = call_args[0][1]
+            assert lc.quantity_threshold == 20
+            assert lc.batch_size == 5
+
+    def test_entity_process_no_model_raises(self):
+        """Entity.process() raises RuntimeError without model."""
+        from kernle.entity import Entity
+
+        entity = Entity(core_id="test-no-model")
+
+        mock_stack = Mock()
+        entity._require_active_stack = Mock(return_value=mock_stack)
+        entity._get_inference_service = Mock(return_value=None)
+
+        with pytest.raises(RuntimeError, match="No model bound"):
+            entity.process()


### PR DESCRIPTION
## Summary
- Adds `memory_process` and `memory_process_status` MCP tools for triggering and monitoring memory processing sessions
- Adds `kernle process run [--transition] [--force] [--json]` and `kernle process status [--json]` CLI commands
- Adds `Kernle.process()` delegation method to the compat layer
- 31 new tests covering MCP tools, CLI commands, and integration

Closes #328

## Test plan
- [x] MCP `memory_process` tool triggers processing with optional transition filter
- [x] MCP `memory_process_status` tool returns unprocessed counts per layer
- [x] CLI `process run` executes processing and reports results
- [x] CLI `process status` shows layer-by-layer unprocessed counts
- [x] JSON output mode for both CLI commands
- [x] Force flag bypasses threshold checks
- [x] All 2939 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)