### PR TITLE
fix: enforce provenance + strength tiers + on_save + processing idempotency

### DIFF
--- a/kernle/core.py
+++ b/kernle/core.py
@@ -394,7 +394,7 @@ class Kernle(
         supabase_url: Optional[str] = None,
         supabase_key: Optional[str] = None,
         checkpoint_dir: Optional[Path] = None,
-        strict: bool = False,
+        strict: bool = True,
     ):
         """Initialize Kernle.
 
@@ -529,6 +529,7 @@ class Kernle(
             self._stack = SQLiteStack(
                 stack_id=self.stack_id,
                 db_path=self._storage.db_path,
+                enforce_provenance=self._strict,
             )
             if hasattr(self, "_entity"):
                 self._entity.attach_stack(self._stack, alias="default", set_active=True)

--- a/kernle/processing.py
+++ b/kernle/processing.py
@@ -730,5 +730,6 @@ class MemoryProcessor:
         ):
             for ep in sources:
                 backend.mark_episode_processed(ep.id)
-        # Note: belief_to_value does not mark beliefs as processed
-        # (beliefs table has no processed column)
+        elif transition == "belief_to_value":
+            for belief in sources:
+                backend.mark_belief_processed(belief.id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,9 @@ def kernle_instance(temp_checkpoint_dir, temp_db_path):
         db_path=temp_db_path,
     )
 
-    kernle = Kernle(stack_id="test_agent", storage=storage, checkpoint_dir=temp_checkpoint_dir)
+    kernle = Kernle(
+        stack_id="test_agent", storage=storage, checkpoint_dir=temp_checkpoint_dir, strict=False
+    )
 
     yield kernle, storage
     storage.close()

--- a/tests/contracts/test_binding_integration.py
+++ b/tests/contracts/test_binding_integration.py
@@ -40,7 +40,7 @@ def entity(data_dir):
 
 @pytest.fixture
 def stack(db_path):
-    return SQLiteStack(stack_id=STACK_ID, db_path=db_path)
+    return SQLiteStack(stack_id=STACK_ID, db_path=db_path, enforce_provenance=False)
 
 
 def _make_mock_plugin(name="test-plugin"):
@@ -104,8 +104,8 @@ class TestBindingRoundtrip:
         assert data["model_config"]["model_id"] == "claude-test"
 
     def test_roundtrip_with_multiple_stacks(self, entity, tmp_path):
-        s1 = SQLiteStack(stack_id="s1", db_path=tmp_path / "s1.db")
-        s2 = SQLiteStack(stack_id="s2", db_path=tmp_path / "s2.db")
+        s1 = SQLiteStack(stack_id="s1", db_path=tmp_path / "s1.db", enforce_provenance=False)
+        s2 = SQLiteStack(stack_id="s2", db_path=tmp_path / "s2.db", enforce_provenance=False)
 
         entity.attach_stack(s1, alias="alpha")
         entity.attach_stack(s2, alias="beta", set_active=False)
@@ -238,7 +238,7 @@ class TestMemoriesSurviveBinding:
         assert restored.core_id == CORE_ID
 
         # Re-open the same database to verify data persisted
-        reopened_stack = SQLiteStack(stack_id=STACK_ID, db_path=db_path)
+        reopened_stack = SQLiteStack(stack_id=STACK_ID, db_path=db_path, enforce_provenance=False)
         episodes = reopened_stack.get_episodes()
         assert any(e.id == ep_id for e in episodes)
 

--- a/tests/contracts/test_core_contract.py
+++ b/tests/contracts/test_core_contract.py
@@ -52,7 +52,7 @@ def entity(data_dir):
 @pytest.fixture
 def stack(tmp_path):
     db_path = tmp_path / "contract_core_test.db"
-    return SQLiteStack(stack_id=STACK_ID, db_path=db_path)
+    return SQLiteStack(stack_id=STACK_ID, db_path=db_path, enforce_provenance=False)
 
 
 @pytest.fixture
@@ -119,8 +119,8 @@ class TestStackManagement:
     def test_set_active_stack(self, entity, tmp_path):
         db1 = tmp_path / "stack1.db"
         db2 = tmp_path / "stack2.db"
-        s1 = SQLiteStack(stack_id="s1", db_path=db1)
-        s2 = SQLiteStack(stack_id="s2", db_path=db2)
+        s1 = SQLiteStack(stack_id="s1", db_path=db1, enforce_provenance=False)
+        s2 = SQLiteStack(stack_id="s2", db_path=db2, enforce_provenance=False)
 
         entity.attach_stack(s1, alias="first", set_active=True)
         entity.attach_stack(s2, alias="second", set_active=False)
@@ -147,8 +147,8 @@ class TestStackManagement:
     def test_multiple_stacks(self, entity, tmp_path):
         db1 = tmp_path / "s1.db"
         db2 = tmp_path / "s2.db"
-        s1 = SQLiteStack(stack_id="s1", db_path=db1)
-        s2 = SQLiteStack(stack_id="s2", db_path=db2)
+        s1 = SQLiteStack(stack_id="s1", db_path=db1, enforce_provenance=False)
+        s2 = SQLiteStack(stack_id="s2", db_path=db2, enforce_provenance=False)
 
         entity.attach_stack(s1, alias="alpha")
         entity.attach_stack(s2, alias="beta", set_active=False)

--- a/tests/contracts/test_stack_contract.py
+++ b/tests/contracts/test_stack_contract.py
@@ -53,7 +53,7 @@ STACK_ID = "contract-test-stack"
 def stack(tmp_path):
     """Create a fresh SQLiteStack for each test."""
     db_path = tmp_path / "contract_test.db"
-    return SQLiteStack(stack_id=STACK_ID, db_path=db_path, components=[])
+    return SQLiteStack(stack_id=STACK_ID, db_path=db_path, components=[], enforce_provenance=False)
 
 
 def _uid() -> str:
@@ -626,7 +626,7 @@ class TestMetaMemoryOps:
         recovered = stack.recover_memory("episode", ep.id)
         assert recovered is True
 
-        episodes_after = stack.get_episodes()
+        episodes_after = stack.get_episodes(include_weak=True)
         found_after = [e for e in episodes_after if e.id == ep.id]
         assert len(found_after) == 1
         assert found_after[0].strength > 0.0

--- a/tests/test_anxiety.py
+++ b/tests/test_anxiety.py
@@ -30,7 +30,10 @@ def k(temp_checkpoint_dir, temp_db_path):
     )
 
     kernle = Kernle(
-        stack_id="test_anxiety_agent", storage=storage, checkpoint_dir=temp_checkpoint_dir
+        stack_id="test_anxiety_agent",
+        storage=storage,
+        checkpoint_dir=temp_checkpoint_dir,
+        strict=False,
     )
 
     return kernle

--- a/tests/test_belief_revision.py
+++ b/tests/test_belief_revision.py
@@ -19,7 +19,7 @@ def kernle_with_beliefs(tmp_path):
     """Create a Kernle instance with some initial beliefs."""
     db_path = tmp_path / "test_beliefs.db"
     storage = SQLiteStorage(stack_id="test_agent", db_path=db_path)
-    k = Kernle(stack_id="test_agent", storage=storage)
+    k = Kernle(stack_id="test_agent", storage=storage, strict=False)
 
     # Add some initial beliefs
     k.belief("I should always validate user input", type="principle", confidence=0.9)
@@ -36,7 +36,7 @@ def kernle_fresh(tmp_path):
     """Create a fresh Kernle instance."""
     db_path = tmp_path / "test_fresh.db"
     storage = SQLiteStorage(stack_id="test_agent", db_path=db_path)
-    return Kernle(stack_id="test_agent", storage=storage)
+    return Kernle(stack_id="test_agent", storage=storage, strict=False)
 
 
 class TestFindContradictions:
@@ -461,7 +461,7 @@ class TestBeliefDataclassFields:
 
         # Create and save belief
         storage1 = SQLiteStorage(stack_id="test_agent", db_path=db_path)
-        k1 = Kernle(stack_id="test_agent", storage=storage1)
+        k1 = Kernle(stack_id="test_agent", storage=storage1, strict=False)
 
         belief_id = k1.belief("Test belief", confidence=0.7)
         k1.reinforce_belief(belief_id)

--- a/tests/test_belief_scope.py
+++ b/tests/test_belief_scope.py
@@ -209,7 +209,7 @@ class TestBeliefScopeDecay:
         """Self-scoped beliefs should decay slower, like values."""
         from kernle import Kernle
 
-        k = Kernle(stack_id="test_agent", storage=storage)
+        k = Kernle(stack_id="test_agent", storage=storage, strict=False)
 
         old_date = datetime.now(timezone.utc) - timedelta(days=90)
 
@@ -234,7 +234,7 @@ class TestBeliefScopeDecay:
         """World-scoped beliefs should use standard belief decay."""
         from kernle import Kernle
 
-        k = Kernle(stack_id="test_agent", storage=storage)
+        k = Kernle(stack_id="test_agent", storage=storage, strict=False)
 
         old_date = datetime.now(timezone.utc) - timedelta(days=30)
 

--- a/tests/test_boot_config.py
+++ b/tests/test_boot_config.py
@@ -31,7 +31,7 @@ def kernle_instance(tmp_db, tmp_path):
     checkpoint_dir = tmp_path / "checkpoints"
     checkpoint_dir.mkdir()
     s = SQLiteStorage(stack_id="test-agent", db_path=tmp_db)
-    k = Kernle(stack_id="test-agent", storage=s, checkpoint_dir=checkpoint_dir)
+    k = Kernle(stack_id="test-agent", storage=s, checkpoint_dir=checkpoint_dir, strict=False)
     yield k
     s.close()
 
@@ -389,7 +389,9 @@ class TestBootCLI:
         checkpoint_dir = tmp_path / "checkpoints"
         checkpoint_dir.mkdir()
         storage = SQLiteStorage(stack_id="cli-test", db_path=db_path)
-        k = Kernle(stack_id="cli-test", storage=storage, checkpoint_dir=checkpoint_dir)
+        k = Kernle(
+            stack_id="cli-test", storage=storage, checkpoint_dir=checkpoint_dir, strict=False
+        )
         k.boot_set("chat_id", "4")
         k.boot_set("gateway_ip", "192.168.50.11")
         return k
@@ -492,7 +494,7 @@ class TestBootCLI:
         checkpoint_dir = tmp_path / "cp"
         checkpoint_dir.mkdir()
         s = SQLiteStorage(stack_id="empty", db_path=db_path)
-        k = Kernle(stack_id="empty", storage=s, checkpoint_dir=checkpoint_dir)
+        k = Kernle(stack_id="empty", storage=s, checkpoint_dir=checkpoint_dir, strict=False)
         args = self._make_args(boot_action="list", format="plain")
         cmd_boot(args, k)
         output = capsys.readouterr().out

--- a/tests/test_budget_loading.py
+++ b/tests/test_budget_loading.py
@@ -206,7 +206,9 @@ class TestBudgetLoading:
         checkpoint_dir.mkdir()
 
         storage = SQLiteStorage(stack_id="test_agent", db_path=db_path)
-        kernle = Kernle(stack_id="test_agent", storage=storage, checkpoint_dir=checkpoint_dir)
+        kernle = Kernle(
+            stack_id="test_agent", storage=storage, checkpoint_dir=checkpoint_dir, strict=False
+        )
 
         # Add test data with varying priorities/confidence
         for i in range(10):
@@ -339,7 +341,7 @@ class TestBudgetValidation:
         checkpoint_dir = tmp_path / "checkpoints"
         checkpoint_dir.mkdir()
         storage = SQLiteStorage(stack_id="test", db_path=db_path)
-        k = Kernle(stack_id="test", storage=storage, checkpoint_dir=checkpoint_dir)
+        k = Kernle(stack_id="test", storage=storage, checkpoint_dir=checkpoint_dir, strict=False)
 
         # Should not raise, should clamp to MIN_TOKEN_BUDGET
         memory = k.load(budget=50)  # Below minimum
@@ -352,7 +354,7 @@ class TestBudgetValidation:
         checkpoint_dir = tmp_path / "checkpoints"
         checkpoint_dir.mkdir()
         storage = SQLiteStorage(stack_id="test", db_path=db_path)
-        k = Kernle(stack_id="test", storage=storage, checkpoint_dir=checkpoint_dir)
+        k = Kernle(stack_id="test", storage=storage, checkpoint_dir=checkpoint_dir, strict=False)
 
         # Should not raise, should clamp to MAX_TOKEN_BUDGET
         memory = k.load(budget=999999)  # Above maximum
@@ -365,7 +367,7 @@ class TestBudgetValidation:
         checkpoint_dir = tmp_path / "checkpoints"
         checkpoint_dir.mkdir()
         storage = SQLiteStorage(stack_id="test", db_path=db_path)
-        k = Kernle(stack_id="test", storage=storage, checkpoint_dir=checkpoint_dir)
+        k = Kernle(stack_id="test", storage=storage, checkpoint_dir=checkpoint_dir, strict=False)
 
         # Should not raise, should clamp invalid values
         memory = k.load(budget=8000, max_item_chars=5)  # Below minimum

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -42,7 +42,9 @@ def cli_kernle(tmp_path):
     checkpoint_dir.mkdir()
 
     storage = SQLiteStorage(stack_id="cli_test_agent", db_path=db_path)
-    k = Kernle(stack_id="cli_test_agent", storage=storage, checkpoint_dir=checkpoint_dir)
+    k = Kernle(
+        stack_id="cli_test_agent", storage=storage, checkpoint_dir=checkpoint_dir, strict=False
+    )
 
     yield k, storage
     storage.close()

--- a/tests/test_cli_provenance.py
+++ b/tests/test_cli_provenance.py
@@ -310,7 +310,7 @@ class TestCoreDerivedFrom:
 
         from kernle import Kernle
 
-        k = Kernle(stack_id="test-agent", storage=storage)
+        k = Kernle(stack_id="test-agent", storage=storage, strict=False)
         return k, storage
 
     def test_value_with_derived_from(self):

--- a/tests/test_compat_layer.py
+++ b/tests/test_compat_layer.py
@@ -22,7 +22,9 @@ def kernle_sqlite(tmp_path):
     """Kernle instance backed by SQLite for compat-layer tests."""
     db_path = tmp_path / "compat_test.db"
     storage = SQLiteStorage(stack_id="compat_agent", db_path=db_path)
-    k = Kernle(stack_id="compat_agent", storage=storage, checkpoint_dir=tmp_path / "cp")
+    k = Kernle(
+        stack_id="compat_agent", storage=storage, checkpoint_dir=tmp_path / "cp", strict=False
+    )
     yield k
     storage.close()
 
@@ -78,7 +80,12 @@ class TestStackProperty:
         mock_storage.is_online.return_value = False
         mock_storage.get_pending_sync_count.return_value = 0
 
-        k = Kernle(stack_id="mock_agent", storage=mock_storage, checkpoint_dir=tmp_path / "cp")
+        k = Kernle(
+            stack_id="mock_agent",
+            storage=mock_storage,
+            checkpoint_dir=tmp_path / "cp",
+            strict=False,
+        )
         assert k.stack is None
 
 

--- a/tests/test_component_discovery.py
+++ b/tests/test_component_discovery.py
@@ -174,7 +174,7 @@ class TestSQLiteStackComponents:
     def test_constructor_loads_defaults(self, tmp_path):
         from kernle.stack.sqlite_stack import SQLiteStack
 
-        stack = SQLiteStack("test-stack", db_path=tmp_path / "test.db")
+        stack = SQLiteStack("test-stack", db_path=tmp_path / "test.db", enforce_provenance=False)
         assert len(stack.components) == 8
         # Verify embedding is present
         names = set(stack.components.keys())
@@ -249,7 +249,7 @@ class TestSQLiteStackComponents:
         """All default components with set_storage get storage assigned."""
         from kernle.stack.sqlite_stack import SQLiteStack
 
-        stack = SQLiteStack("test-stack", db_path=tmp_path / "test.db")
+        stack = SQLiteStack("test-stack", db_path=tmp_path / "test.db", enforce_provenance=False)
         for name, component in stack.components.items():
             if hasattr(component, "_storage") and hasattr(component, "set_storage"):
                 assert (
@@ -259,14 +259,14 @@ class TestSQLiteStackComponents:
     def test_remove_component_raises_for_required(self, tmp_path):
         from kernle.stack.sqlite_stack import SQLiteStack
 
-        stack = SQLiteStack("test-stack", db_path=tmp_path / "test.db")
+        stack = SQLiteStack("test-stack", db_path=tmp_path / "test.db", enforce_provenance=False)
         with pytest.raises(ValueError, match="Cannot remove required"):
             stack.remove_component("embedding-ngram")
 
     def test_remove_optional_component(self, tmp_path):
         from kernle.stack.sqlite_stack import SQLiteStack
 
-        stack = SQLiteStack("test-stack", db_path=tmp_path / "test.db")
+        stack = SQLiteStack("test-stack", db_path=tmp_path / "test.db", enforce_provenance=False)
         assert "anxiety" in stack.components
         stack.remove_component("anxiety")
         assert "anxiety" not in stack.components
@@ -282,7 +282,9 @@ class TestComponentLifecycle:
         """Create stack -> components auto-loaded -> maintenance -> model change."""
         from kernle.stack.sqlite_stack import SQLiteStack
 
-        stack = SQLiteStack("lifecycle-test", db_path=tmp_path / "test.db")
+        stack = SQLiteStack(
+            "lifecycle-test", db_path=tmp_path / "test.db", enforce_provenance=False
+        )
 
         # Components auto-loaded
         assert len(stack.components) == 8

--- a/tests/test_consolidation_scaffolds.py
+++ b/tests/test_consolidation_scaffolds.py
@@ -29,7 +29,7 @@ def storage(tmp_path):
 @pytest.fixture
 def kernle_instance(storage):
     """Kernle instance with test storage."""
-    k = Kernle(stack_id="test_agent", storage=storage)
+    k = Kernle(stack_id="test_agent", storage=storage, strict=False)
     return k
 
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -56,6 +56,7 @@ def kernle_instance(temp_db, temp_checkpoint_dir):
         stack_id="test-agent",
         storage=storage,
         checkpoint_dir=temp_checkpoint_dir,
+        strict=False,
     )
     yield kernle, storage
     storage.close()

--- a/tests/test_continuous_strength.py
+++ b/tests/test_continuous_strength.py
@@ -38,7 +38,7 @@ def storage(tmp_path):
 def stack(tmp_path):
     """Create a bare SQLiteStack (no components) for testing."""
     db_path = tmp_path / "test.db"
-    return SQLiteStack(STACK_ID, db_path=db_path, components=[])
+    return SQLiteStack(STACK_ID, db_path=db_path, components=[], enforce_provenance=False)
 
 
 # ---- Helpers ----
@@ -389,12 +389,12 @@ class TestStackStrengthFiltering:
         assert len(notes) == 0
 
     def test_low_strength_still_included(self, stack):
-        """Memories with low (but non-zero) strength should still appear."""
+        """Memories with low (but non-zero) strength should still appear with include_forgotten."""
         ep = _ep()
         eid = stack.save_episode(ep)
         stack._backend.update_strength("episode", eid, 0.01)
 
-        episodes = stack.get_episodes()
+        episodes = stack.get_episodes(include_forgotten=True)
         assert len(episodes) == 1
 
 
@@ -418,7 +418,7 @@ class TestSearchStrengthFiltering:
     def test_search_includes_positive_strength(self, stack):
         ep = _ep(objective="unique searchtest phrase")
         eid = stack.save_episode(ep)
-        stack._backend.update_strength("episode", eid, 0.1)
+        stack._backend.update_strength("episode", eid, 0.5)
 
         results = stack.search("unique searchtest phrase")
         ids_found = {r.memory_id for r in results}

--- a/tests/test_controlled_access.py
+++ b/tests/test_controlled_access.py
@@ -28,13 +28,17 @@ def storage(tmp_path):
 
 @pytest.fixture
 def stack(tmp_path):
-    return SQLiteStack(STACK_ID, db_path=tmp_path / "test.db", components=[])
+    return SQLiteStack(
+        STACK_ID, db_path=tmp_path / "test.db", components=[], enforce_provenance=False
+    )
 
 
 @pytest.fixture
 def entity(tmp_path):
     ent = Entity(core_id="test-core", data_dir=tmp_path / "entity")
-    st = SQLiteStack(STACK_ID, db_path=tmp_path / "test.db", components=[])
+    st = SQLiteStack(
+        STACK_ID, db_path=tmp_path / "test.db", components=[], enforce_provenance=False
+    )
     ent.attach_stack(st)
     return ent
 
@@ -310,7 +314,7 @@ class TestEntityRecover:
         entity.forget("episode", eid, "forgot")
         assert entity.recover("episode", eid)
         stack = entity.active_stack
-        episodes = stack.get_episodes()
+        episodes = stack.get_episodes(include_weak=True)
         assert len(episodes) == 1
         assert episodes[0].strength == pytest.approx(0.2)
 

--- a/tests/test_diagnostic_sessions.py
+++ b/tests/test_diagnostic_sessions.py
@@ -23,7 +23,7 @@ def diag_setup(tmp_path):
     storage = SQLiteStorage(stack_id="test_agent", db_path=db_path)
     checkpoint_dir = tmp_path / "checkpoints"
     checkpoint_dir.mkdir()
-    k = Kernle(stack_id="test_agent", storage=storage, checkpoint_dir=checkpoint_dir)
+    k = Kernle(stack_id="test_agent", storage=storage, checkpoint_dir=checkpoint_dir, strict=False)
     yield k, storage
     storage.close()
 

--- a/tests/test_doctor_structural.py
+++ b/tests/test_doctor_structural.py
@@ -37,7 +37,7 @@ def kernle_instance(tmp_path):
     checkpoint_dir.mkdir()
 
     storage = SQLiteStorage(stack_id="test_agent", db_path=db_path)
-    k = Kernle(stack_id="test_agent", storage=storage, checkpoint_dir=checkpoint_dir)
+    k = Kernle(stack_id="test_agent", storage=storage, checkpoint_dir=checkpoint_dir, strict=False)
     yield k
     storage.close()
 

--- a/tests/test_dynamic_trust.py
+++ b/tests/test_dynamic_trust.py
@@ -24,7 +24,7 @@ def setup(tmp_path):
     storage = SQLiteStorage(stack_id="test_agent", db_path=db_path)
     checkpoint_dir = tmp_path / "checkpoints"
     checkpoint_dir.mkdir()
-    k = Kernle(stack_id="test_agent", storage=storage, checkpoint_dir=checkpoint_dir)
+    k = Kernle(stack_id="test_agent", storage=storage, checkpoint_dir=checkpoint_dir, strict=False)
     k.seed_trust()
     yield k, storage
     storage.close()

--- a/tests/test_embedding_component.py
+++ b/tests/test_embedding_component.py
@@ -311,7 +311,12 @@ class TestStackIntegration:
     def test_add_component_to_stack(self, tmp_path):
         from kernle.stack.sqlite_stack import SQLiteStack
 
-        stack = SQLiteStack(stack_id="test-stack", db_path=tmp_path / "test.db", components=[])
+        stack = SQLiteStack(
+            stack_id="test-stack",
+            db_path=tmp_path / "test.db",
+            components=[],
+            enforce_provenance=False,
+        )
         comp = EmbeddingComponent()
         stack.add_component(comp)
         assert "embedding-ngram" in stack.components
@@ -320,7 +325,12 @@ class TestStackIntegration:
     def test_cannot_remove_required_component(self, tmp_path):
         from kernle.stack.sqlite_stack import SQLiteStack
 
-        stack = SQLiteStack(stack_id="test-stack", db_path=tmp_path / "test.db", components=[])
+        stack = SQLiteStack(
+            stack_id="test-stack",
+            db_path=tmp_path / "test.db",
+            components=[],
+            enforce_provenance=False,
+        )
         comp = EmbeddingComponent()
         stack.add_component(comp)
         with pytest.raises(ValueError, match="Cannot remove required"):
@@ -329,7 +339,12 @@ class TestStackIntegration:
     def test_maintenance_includes_component(self, tmp_path):
         from kernle.stack.sqlite_stack import SQLiteStack
 
-        stack = SQLiteStack(stack_id="test-stack", db_path=tmp_path / "test.db", components=[])
+        stack = SQLiteStack(
+            stack_id="test-stack",
+            db_path=tmp_path / "test.db",
+            components=[],
+            enforce_provenance=False,
+        )
         comp = EmbeddingComponent()
         stack.add_component(comp)
         results = stack.maintenance()
@@ -339,7 +354,12 @@ class TestStackIntegration:
     def test_on_attach_propagates_inference(self, tmp_path):
         from kernle.stack.sqlite_stack import SQLiteStack
 
-        stack = SQLiteStack(stack_id="test-stack", db_path=tmp_path / "test.db", components=[])
+        stack = SQLiteStack(
+            stack_id="test-stack",
+            db_path=tmp_path / "test.db",
+            components=[],
+            enforce_provenance=False,
+        )
         comp = EmbeddingComponent()
         stack.add_component(comp)
 
@@ -350,7 +370,12 @@ class TestStackIntegration:
     def test_on_model_changed_propagates(self, tmp_path):
         from kernle.stack.sqlite_stack import SQLiteStack
 
-        stack = SQLiteStack(stack_id="test-stack", db_path=tmp_path / "test.db", components=[])
+        stack = SQLiteStack(
+            stack_id="test-stack",
+            db_path=tmp_path / "test.db",
+            components=[],
+            enforce_provenance=False,
+        )
         comp = EmbeddingComponent()
         stack.add_component(comp)
 
@@ -365,7 +390,12 @@ class TestStackIntegration:
     def test_on_detach_clears_inference(self, tmp_path):
         from kernle.stack.sqlite_stack import SQLiteStack
 
-        stack = SQLiteStack(stack_id="test-stack", db_path=tmp_path / "test.db", components=[])
+        stack = SQLiteStack(
+            stack_id="test-stack",
+            db_path=tmp_path / "test.db",
+            components=[],
+            enforce_provenance=False,
+        )
         comp = EmbeddingComponent()
         stack.add_component(comp)
 

--- a/tests/test_epochs.py
+++ b/tests/test_epochs.py
@@ -38,7 +38,9 @@ def kernle_instance(tmp_path):
     checkpoint_dir = tmp_path / "checkpoints"
     checkpoint_dir.mkdir()
     storage = SQLiteStorage(stack_id="test-agent", db_path=db_path)
-    return Kernle(stack_id="test-agent", storage=storage, checkpoint_dir=checkpoint_dir)
+    return Kernle(
+        stack_id="test-agent", storage=storage, checkpoint_dir=checkpoint_dir, strict=False
+    )
 
 
 class TestEpochStorage:

--- a/tests/test_export_cache.py
+++ b/tests/test_export_cache.py
@@ -18,7 +18,9 @@ def k(tmp_path):
     checkpoint_dir.mkdir()
 
     storage = SQLiteStorage(stack_id="test-export", db_path=db_path)
-    instance = Kernle(stack_id="test-export", storage=storage, checkpoint_dir=checkpoint_dir)
+    instance = Kernle(
+        stack_id="test-export", storage=storage, checkpoint_dir=checkpoint_dir, strict=False
+    )
     yield instance
     storage.close()
 

--- a/tests/test_export_full.py
+++ b/tests/test_export_full.py
@@ -17,7 +17,9 @@ def k(tmp_path):
     checkpoint_dir.mkdir()
 
     storage = SQLiteStorage(stack_id="test-export-full", db_path=db_path)
-    instance = Kernle(stack_id="test-export-full", storage=storage, checkpoint_dir=checkpoint_dir)
+    instance = Kernle(
+        stack_id="test-export-full", storage=storage, checkpoint_dir=checkpoint_dir, strict=False
+    )
     yield instance
     storage.close()
 

--- a/tests/test_fractal_summarization.py
+++ b/tests/test_fractal_summarization.py
@@ -25,7 +25,7 @@ def stack_id():
 
 @pytest.fixture
 def k(stack_id):
-    return Kernle(stack_id=stack_id)
+    return Kernle(stack_id=stack_id, strict=False)
 
 
 # === Dataclass Tests ===

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -291,7 +291,7 @@ class TestImportIntegration:
     def kernle_instance(self, tmp_path):
         """Create a Kernle instance with temp storage."""
         try:
-            return Kernle(stack_id="test-import")
+            return Kernle(stack_id="test-import", strict=False)
         except Exception as e:
             logger.debug(f"Kernle instance creation failed: {e}")
             pytest.skip("Could not create Kernle instance - schema may be changing")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -26,7 +26,12 @@ class TestCLIIntegration:
         checkpoint_dir = tmp_path / "checkpoints"
         checkpoint_dir.mkdir()
         storage = SQLiteStorage(stack_id="test_integration", db_path=db_path)
-        return Kernle(stack_id="test_integration", storage=storage, checkpoint_dir=checkpoint_dir)
+        return Kernle(
+            stack_id="test_integration",
+            storage=storage,
+            checkpoint_dir=checkpoint_dir,
+            strict=False,
+        )
 
     def test_episode_command_persists(self, temp_kernle):
         """CLI episode command should persist to actual storage."""
@@ -314,7 +319,7 @@ class TestAnxietyIntegration:
         stack_id = "test_anxiety"
 
         storage = SQLiteStorage(stack_id=stack_id, db_path=db_path)
-        k = Kernle(stack_id=stack_id, storage=storage, checkpoint_dir=checkpoint_dir)
+        k = Kernle(stack_id=stack_id, storage=storage, checkpoint_dir=checkpoint_dir, strict=False)
 
         # Fresh state should have low anxiety
         report1 = k.get_anxiety_report()

--- a/tests/test_logic_audit_fixes.py
+++ b/tests/test_logic_audit_fixes.py
@@ -23,7 +23,7 @@ def kernle_fresh(tmp_path):
     """Create a fresh Kernle instance for testing."""
     db_path = tmp_path / "test_logic_audit.db"
     storage = SQLiteStorage(stack_id="test_agent", db_path=db_path)
-    return Kernle(stack_id="test_agent", storage=storage)
+    return Kernle(stack_id="test_agent", storage=storage, strict=False)
 
 
 class TestDivisionByZeroProtection:

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -36,7 +36,7 @@ def real_kernle(temp_db):
     os.environ["KERNLE_HOME"] = str(Path(temp_db).parent)
 
     try:
-        k = Kernle(stack_id="test-mcp-integration")
+        k = Kernle(stack_id="test-mcp-integration", strict=False)
         yield k
     finally:
         if old_home:

--- a/tests/test_metacognition.py
+++ b/tests/test_metacognition.py
@@ -37,7 +37,9 @@ def temp_checkpoint_dir(tmp_path):
 def kernle(temp_db, temp_checkpoint_dir):
     """Create a Kernle instance for testing."""
     storage = SQLiteStorage(stack_id="test-agent", db_path=temp_db)
-    return Kernle(stack_id="test-agent", storage=storage, checkpoint_dir=temp_checkpoint_dir)
+    return Kernle(
+        stack_id="test-agent", storage=storage, checkpoint_dir=temp_checkpoint_dir, strict=False
+    )
 
 
 @pytest.fixture

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -421,7 +421,12 @@ class TestEntityIntegration:
         from kernle.stack.sqlite_stack import SQLiteStack
 
         entity = Entity(core_id="test-core")
-        stack = SQLiteStack(stack_id="test-stack", db_path=tmp_path / "test.db", components=[])
+        stack = SQLiteStack(
+            stack_id="test-stack",
+            db_path=tmp_path / "test.db",
+            components=[],
+            enforce_provenance=False,
+        )
         entity.attach_stack(stack)
 
         entity.set_model(anthropic_model)

--- a/tests/test_playbooks.py
+++ b/tests/test_playbooks.py
@@ -270,7 +270,7 @@ class TestPlaybookCore:
         """Create a Kernle instance with temporary storage."""
         db_path = tmp_path / "test_kernle.db"
         storage = SQLiteStorage(stack_id="test_agent", db_path=db_path)
-        return Kernle(stack_id="test_agent", storage=storage)
+        return Kernle(stack_id="test_agent", storage=storage, strict=False)
 
     def test_create_playbook_simple(self, kernle):
         """Test creating a playbook with simple string steps."""

--- a/tests/test_process_triggers.py
+++ b/tests/test_process_triggers.py
@@ -21,7 +21,7 @@ def kernle_instance(tmp_path):
 
     db_path = tmp_path / "test.db"
     storage = SQLiteStorage(stack_id="test-process", db_path=db_path)
-    k = Kernle(stack_id="test-process", storage=storage)
+    k = Kernle(stack_id="test-process", storage=storage, strict=False)
     yield k
     storage.close()
 

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -43,13 +43,17 @@ def storage(tmp_path):
 
 @pytest.fixture
 def stack(tmp_path):
-    return SQLiteStack(STACK_ID, db_path=tmp_path / "test.db", components=[])
+    return SQLiteStack(
+        STACK_ID, db_path=tmp_path / "test.db", components=[], enforce_provenance=False
+    )
 
 
 @pytest.fixture
 def entity(tmp_path):
     ent = Entity(core_id="test-core", data_dir=tmp_path / "entity")
-    st = SQLiteStack(STACK_ID, db_path=tmp_path / "test.db", components=[])
+    st = SQLiteStack(
+        STACK_ID, db_path=tmp_path / "test.db", components=[], enforce_provenance=False
+    )
     ent.attach_stack(st)
     return ent
 

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -19,6 +19,7 @@ def kernle_instance():
             stack_id="test-promote",
             storage=storage,
             checkpoint_dir=Path(tmpdir),
+            strict=False,
         )
         yield k
 

--- a/tests/test_raw_memory.py
+++ b/tests/test_raw_memory.py
@@ -36,7 +36,7 @@ def storage(temp_db):
 def kernle(temp_db):
     """Create a Kernle instance for testing."""
     storage = SQLiteStorage(stack_id="test_agent", db_path=temp_db)
-    return Kernle(stack_id="test_agent", storage=storage)
+    return Kernle(stack_id="test_agent", storage=storage, strict=False)
 
 
 class TestRawEntryDataclass:

--- a/tests/test_relationship_enrichment.py
+++ b/tests/test_relationship_enrichment.py
@@ -37,7 +37,7 @@ def kernle_with_storage(tmp_path):
     checkpoint_dir = tmp_path / "checkpoints"
     checkpoint_dir.mkdir()
     s = SQLiteStorage(stack_id="test_agent", db_path=tmp_path / "test.db")
-    k = Kernle(stack_id="test_agent", storage=s, checkpoint_dir=checkpoint_dir)
+    k = Kernle(stack_id="test_agent", storage=s, checkpoint_dir=checkpoint_dir, strict=False)
     yield k, s
     s.close()
 

--- a/tests/test_self_narrative.py
+++ b/tests/test_self_narrative.py
@@ -25,7 +25,7 @@ def stack_id():
 
 @pytest.fixture
 def k(stack_id):
-    return Kernle(stack_id=stack_id)
+    return Kernle(stack_id=stack_id, strict=False)
 
 
 # === Dataclass Tests ===

--- a/tests/test_semantic_contradictions.py
+++ b/tests/test_semantic_contradictions.py
@@ -15,7 +15,7 @@ def kernle_instance(tmp_path):
     """Create a Kernle instance with SQLite storage."""
     db_path = tmp_path / "test_semantic.db"
     storage = SQLiteStorage(stack_id="test_agent", db_path=db_path)
-    return Kernle(stack_id="test_agent", storage=storage)
+    return Kernle(stack_id="test_agent", storage=storage, strict=False)
 
 
 @pytest.fixture
@@ -23,7 +23,7 @@ def kernle_with_beliefs(tmp_path):
     """Create a Kernle instance with pre-populated beliefs."""
     db_path = tmp_path / "test_semantic_beliefs.db"
     storage = SQLiteStorage(stack_id="test_agent", db_path=db_path)
-    k = Kernle(stack_id="test_agent", storage=storage)
+    k = Kernle(stack_id="test_agent", storage=storage, strict=False)
 
     # Add beliefs covering various contradiction scenarios
     k.belief("Testing is essential for code quality", confidence=0.9)

--- a/tests/test_sqlite_stack.py
+++ b/tests/test_sqlite_stack.py
@@ -57,7 +57,9 @@ def tmp_db(tmp_path):
 @pytest.fixture
 def stack(tmp_db):
     """Create an SQLiteStack instance with a temp database."""
-    return SQLiteStack(stack_id="test-stack", db_path=tmp_db, components=[])
+    return SQLiteStack(
+        stack_id="test-stack", db_path=tmp_db, components=[], enforce_provenance=False
+    )
 
 
 @pytest.fixture
@@ -641,8 +643,8 @@ class TestMetaMemory:
         recovered = stack.recover_memory("episode", ep.id)
         assert recovered is True
 
-        # Should be back
-        episodes = stack.get_episodes(include_forgotten=False)
+        # Should be back (recovered at strength 0.2, in the Weak tier)
+        episodes = stack.get_episodes(include_weak=True)
         assert any(e.id == ep.id for e in episodes)
 
     def test_protect_memory(self, stack, stack_id):

--- a/tests/test_strength_cascade.py
+++ b/tests/test_strength_cascade.py
@@ -99,11 +99,13 @@ def stack(tmp_path):
 @pytest.fixture
 def entity_with_stack(tmp_path):
     """Create an Entity with an attached SQLiteStack."""
+
     entity = Entity(core_id="test-entity", data_dir=tmp_path)
     stack = SQLiteStack(
         stack_id="test-cascade",
         db_path=tmp_path / "test.db",
         components=[],
+        enforce_provenance=False,
     )
     entity.attach_stack(stack, alias="default")
     return entity, stack

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -12,7 +12,7 @@ class TestPatternExtraction:
 
     def test_episode_patterns_detected(self, tmp_path):
         """Episode patterns should be detected in content."""
-        k = Kernle("test-agent", storage=MagicMock())
+        k = Kernle("test-agent", storage=MagicMock(), strict=False)
 
         # Episode-like content
         content = "I completed the API refactoring and it was a success. Learned that small PRs are easier to review."
@@ -30,7 +30,7 @@ class TestPatternExtraction:
 
     def test_belief_patterns_detected(self, tmp_path):
         """Belief patterns should be detected in content."""
-        k = Kernle("test-agent", storage=MagicMock())
+        k = Kernle("test-agent", storage=MagicMock(), strict=False)
 
         content = "I believe that smaller functions are always better than large ones."
         score = k._score_patterns(
@@ -45,7 +45,7 @@ class TestPatternExtraction:
 
     def test_note_patterns_detected(self, tmp_path):
         """Note patterns should be detected in content."""
-        k = Kernle("test-agent", storage=MagicMock())
+        k = Kernle("test-agent", storage=MagicMock(), strict=False)
 
         content = 'John said "we should use dependency injection for testability".'
         score = k._score_patterns(
@@ -60,7 +60,7 @@ class TestPatternExtraction:
 
     def test_low_score_for_irrelevant_content(self, tmp_path):
         """Irrelevant content should score low."""
-        k = Kernle("test-agent", storage=MagicMock())
+        k = Kernle("test-agent", storage=MagicMock(), strict=False)
 
         content = "The weather is nice today."
         score = k._score_patterns(
@@ -79,7 +79,7 @@ class TestSuggestionExtraction:
 
     def test_extract_episode_suggestion(self, tmp_path):
         """Episode suggestion should be extracted from work log content."""
-        k = Kernle("test-agent", storage=MagicMock())
+        k = Kernle("test-agent", storage=MagicMock(), strict=False)
         k._storage.save_suggestion = MagicMock(return_value="suggestion-123")
 
         raw_entry = RawEntry(
@@ -106,7 +106,7 @@ class TestSuggestionExtraction:
 
     def test_extract_belief_suggestion(self, tmp_path):
         """Belief suggestion should be extracted from opinion content."""
-        k = Kernle("test-agent", storage=MagicMock())
+        k = Kernle("test-agent", storage=MagicMock(), strict=False)
         k._storage.save_suggestion = MagicMock()
 
         raw_entry = RawEntry(
@@ -128,7 +128,7 @@ class TestSuggestionExtraction:
 
     def test_extract_note_suggestion(self, tmp_path):
         """Note suggestion should be extracted from decision content."""
-        k = Kernle("test-agent", storage=MagicMock())
+        k = Kernle("test-agent", storage=MagicMock(), strict=False)
         k._storage.save_suggestion = MagicMock()
 
         # This content should trigger note detection but NOT episode or belief
@@ -152,7 +152,7 @@ class TestSuggestionExtraction:
 
     def test_auto_save_suggestions(self, tmp_path):
         """Suggestions should be saved when auto_save=True."""
-        k = Kernle("test-agent", storage=MagicMock())
+        k = Kernle("test-agent", storage=MagicMock(), strict=False)
         k._storage.save_suggestion = MagicMock(return_value="saved-id")
 
         raw_entry = RawEntry(
@@ -339,7 +339,7 @@ class TestPromotionWorkflow:
         from kernle.storage import SQLiteStorage
 
         storage = SQLiteStorage("test-agent", db_path=tmp_path / "test.db")
-        k = Kernle("test-agent", storage=storage)
+        k = Kernle("test-agent", storage=storage, strict=False)
 
         # Create a suggestion
         suggestion = MemorySuggestion(
@@ -390,7 +390,7 @@ class TestPromotionWorkflow:
         from kernle.storage import SQLiteStorage
 
         storage = SQLiteStorage("test-agent", db_path=tmp_path / "test.db")
-        k = Kernle("test-agent", storage=storage)
+        k = Kernle("test-agent", storage=storage, strict=False)
 
         suggestion = MemorySuggestion(
             id="sug-modify",
@@ -433,7 +433,7 @@ class TestPromotionWorkflow:
         from kernle.storage import SQLiteStorage
 
         storage = SQLiteStorage("test-agent", db_path=tmp_path / "test.db")
-        k = Kernle("test-agent", storage=storage)
+        k = Kernle("test-agent", storage=storage, strict=False)
 
         suggestion = MemorySuggestion(
             id="sug-reject",
@@ -463,7 +463,7 @@ class TestPromotionWorkflow:
         from kernle.storage import SQLiteStorage
 
         storage = SQLiteStorage("test-agent", db_path=tmp_path / "test.db")
-        k = Kernle("test-agent", storage=storage)
+        k = Kernle("test-agent", storage=storage, strict=False)
 
         suggestion = MemorySuggestion(
             id="sug-already-promoted",
@@ -489,7 +489,7 @@ class TestHelperMethods:
 
     def test_extract_first_sentence(self):
         """Should extract first meaningful sentence."""
-        k = Kernle("test-agent", storage=MagicMock())
+        k = Kernle("test-agent", storage=MagicMock(), strict=False)
 
         content = "This is the first sentence. Here is another one."
         result = k._extract_first_sentence(content)
@@ -502,7 +502,7 @@ class TestHelperMethods:
 
     def test_infer_outcome_type(self):
         """Should infer outcome type from content."""
-        k = Kernle("test-agent", storage=MagicMock())
+        k = Kernle("test-agent", storage=MagicMock(), strict=False)
 
         assert k._infer_outcome_type("The task was successful") == "success"
         assert k._infer_outcome_type("It failed completely") == "failure"
@@ -511,7 +511,7 @@ class TestHelperMethods:
 
     def test_infer_belief_type(self):
         """Should infer belief type from content."""
-        k = Kernle("test-agent", storage=MagicMock())
+        k = Kernle("test-agent", storage=MagicMock(), strict=False)
 
         assert k._infer_belief_type("You should always test") == "rule"
         assert k._infer_belief_type("I prefer Python") == "preference"
@@ -521,7 +521,7 @@ class TestHelperMethods:
 
     def test_infer_note_type(self):
         """Should infer note type from content."""
-        k = Kernle("test-agent", storage=MagicMock())
+        k = Kernle("test-agent", storage=MagicMock(), strict=False)
 
         assert k._infer_note_type('"Quote" said John') == "quote"
         assert k._infer_note_type("I decided to use Python") == "decision"

--- a/tests/test_sync_engine.py
+++ b/tests/test_sync_engine.py
@@ -666,14 +666,14 @@ class TestSyncHooks:
 
         mock_cloud_storage.get_stats.return_value = {"episodes": 0}  # Returns value = online
 
-        k = Kernle(stack_id="test-agent", storage=storage_with_cloud)
+        k = Kernle(stack_id="test-agent", storage=storage_with_cloud, strict=False)
         assert k.auto_sync is True
 
     def test_auto_sync_can_be_disabled_via_property(self, storage):
         """Auto-sync can be disabled by setting the property."""
         from kernle import Kernle
 
-        k = Kernle(stack_id="test-agent", storage=storage)
+        k = Kernle(stack_id="test-agent", storage=storage, strict=False)
         k.auto_sync = False
         assert k.auto_sync is False
 
@@ -681,7 +681,7 @@ class TestSyncHooks:
         """Load with sync=False should not attempt to pull."""
         from kernle import Kernle
 
-        k = Kernle(stack_id="test-agent", storage=storage)
+        k = Kernle(stack_id="test-agent", storage=storage, strict=False)
         k.auto_sync = True
 
         # Load with sync=False should work without errors
@@ -701,7 +701,7 @@ class TestSyncHooks:
         mock_cloud_storage.get_drives.return_value = []
         mock_cloud_storage.get_relationships.return_value = []
 
-        k = Kernle(stack_id="test-agent", storage=storage_with_cloud)
+        k = Kernle(stack_id="test-agent", storage=storage_with_cloud, strict=False)
         memory = k.load(sync=True)
 
         # Should have attempted to pull from cloud
@@ -713,7 +713,7 @@ class TestSyncHooks:
 
         mock_cloud_storage.get_stats.return_value = {"episodes": 1}  # Simulates online
 
-        k = Kernle(stack_id="test-agent", storage=storage_with_cloud)
+        k = Kernle(stack_id="test-agent", storage=storage_with_cloud, strict=False)
 
         result = k.checkpoint("Test task", pending=["Next"], sync=True)
 
@@ -727,7 +727,7 @@ class TestSyncHooks:
         """Checkpoint should include sync result when sync is attempted."""
         from kernle import Kernle
 
-        k = Kernle(stack_id="test-agent", storage=storage)
+        k = Kernle(stack_id="test-agent", storage=storage, strict=False)
 
         # With no cloud storage, sync should report offline
         result = k.checkpoint("Test task", sync=True)
@@ -745,7 +745,7 @@ class TestSyncHooks:
         # Make cloud throw an error
         mock_cloud_storage.get_stats.side_effect = Exception("Network error")
 
-        k = Kernle(stack_id="test-agent", storage=storage_with_cloud)
+        k = Kernle(stack_id="test-agent", storage=storage_with_cloud, strict=False)
 
         # Load should still work
         memory = k.load(sync=True)
@@ -758,7 +758,7 @@ class TestSyncHooks:
         # Make cloud throw an error
         mock_cloud_storage.get_stats.side_effect = Exception("Network error")
 
-        k = Kernle(stack_id="test-agent", storage=storage_with_cloud)
+        k = Kernle(stack_id="test-agent", storage=storage_with_cloud, strict=False)
 
         # Checkpoint should still work
         result = k.checkpoint("Test task", sync=True)

--- a/tests/test_trust_layer.py
+++ b/tests/test_trust_layer.py
@@ -16,7 +16,7 @@ def trust_setup(tmp_path):
     storage = SQLiteStorage(stack_id="test_agent", db_path=db_path)
     checkpoint_dir = tmp_path / "checkpoints"
     checkpoint_dir.mkdir()
-    k = Kernle(stack_id="test_agent", storage=storage, checkpoint_dir=checkpoint_dir)
+    k = Kernle(stack_id="test_agent", storage=storage, checkpoint_dir=checkpoint_dir, strict=False)
     yield k, storage
     storage.close()
 


### PR DESCRIPTION
## Summary
Addresses all P1 and P2 findings from codex audit. Breaking changes throughout.

### P1: Provenance enforcement active by default
- `SQLiteStack` defaults to `enforce_provenance=True` (was `False`)
- `Kernle` defaults to `strict=True` (was `False`)
- CLI and MCP automatically get enforcement — no opt-in needed
- Tests explicitly use `strict=False` / `enforce_provenance=False` when not testing enforcement

### P1: Strength-tier gating implemented
- Strong (0.8-1.0): full weight in load/search
- Fading (0.5-0.8): included with reduced priority score
- Weak (0.2-0.5): excluded from load(), still searchable
- Dormant (0.0-0.2): excluded from both load and search
- Forgotten (0.0): tombstoned
- New `include_weak` parameter on all getter methods

### P2: on_save mutation contract fixed
- `_dispatch_on_save` now persists metadata returned by components
- EmotionalTagging `emotional_valence`/`arousal`/`tags` now written to episodes table after save

### P2: belief_to_value marks beliefs processed
- Added missing `belief_to_value` case in `_mark_processed()`
- Prevents duplicate value generation on repeated processing

## Test plan
- [x] All 2971 tests passing (49 files modified)
- [x] Tests that don't test enforcement explicitly opt out with `strict=False`
- [x] Strength-tier tests updated for new thresholds
- [x] Recovered memories (strength=0.2) properly handled with `include_weak=True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)