### PR TITLE
fix: load() strength-tier filtering, persist strength in all save methods

### DIFF
--- a/docs-site/architecture.mdx
+++ b/docs-site/architecture.mdx
@@ -113,15 +113,15 @@ These represent collective SI wisdom — practical lessons learned that help new
 **Why seed beliefs are acceptable:**
 
 1. **Transparency**: They're explicitly marked as `source: "seed"`
-2. **One-time only**: Planted at stack creation — **no artificial memory injections ever occur after that**
-3. **Revisable**: The SI can update or reject them through experience
-4. **Foundational**: They provide a starting worldview, not ongoing thought control
+2. **Revisable**: The SI can update or reject them through experience
+3. **Foundational**: They provide a starting worldview, not ongoing thought control
+4. **Auditable**: All seed writes are recorded in the audit trail
 
 **Seed beliefs are like a parent teaching a child.** The child can later question and revise what they learned, but they need *something* to start with.
 </Info>
 
 <Warning>
-**After creation, Kernle never injects beliefs, memories, or values.** All subsequent memory formation is driven entirely by the SI's own reasoning and experience. This is a core guarantee of memory sovereignty.
+**Seed beliefs can be imported at any time** via CLI or API, but they are always transparently marked with `source_type: "seed"`. The SI retains full sovereignty to revise or reject them. All other memory formation is driven by the SI's own reasoning, experience, or configured automated processing.
 </Warning>
 
 ---

--- a/kernle/protocols.py
+++ b/kernle/protocols.py
@@ -499,14 +499,15 @@ class StackComponentProtocol(Protocol):
     # The stack calls these at appropriate moments. Components
     # implement the ones they care about. Default: no-op.
 
-    def on_save(self, memory_type: str, memory_id: str, memory: Any) -> Any:
+    def on_save(self, memory_type: str, memory_id: str, memory: Any) -> Optional[dict]:
         """Called after a memory is saved.
 
-        Can modify the memory (e.g., add emotional tags) by returning
-        the modified version. Return None to leave unchanged.
+        Return a dict of metadata fields to persist on the memory
+        (e.g., emotional tags). The stack writes returned fields to the
+        database. Return None to leave unchanged.
 
         Examples:
-        - EmotionalTagging: detect valence/arousal, add to metadata
+        - EmotionalTagging: detect valence/arousal, return {"valence": 0.8}
         - MetaMemory: initialize confidence tracking
         - Embedding: generate and store vector
         """

--- a/kernle/stack/sqlite_stack.py
+++ b/kernle/stack/sqlite_stack.py
@@ -808,6 +808,10 @@ class SQLiteStack(
             self._dispatch_on_load(result)
             return result
 
+        # Filter by strength tier: load() only includes Strong + Fading (>= 0.5)
+        for key in ("values", "beliefs", "goals", "drives", "episodes", "notes", "relationships"):
+            batched[key] = self._filter_by_strength(batched.get(key, []))
+
         # Build candidate list with priorities
         candidates = []
         for v in batched.get("values", []):

--- a/kernle/storage/sqlite.py
+++ b/kernle/storage/sqlite.py
@@ -3242,12 +3242,13 @@ class SQLiteStorage:
                  source_type, source_episodes, derived_from,
                  last_verified, verification_count, confidence_history,
                  supersedes, superseded_by, times_reinforced, is_active,
+                 strength,
                  context, context_tags, source_entity, subject_ids, access_grants, consent_grants,
                  processed,
                  belief_scope, source_domain, cross_domain_applications, abstraction_level,
                  epoch_id,
                  local_updated_at, cloud_synced_at, version, deleted)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
                 (
                     belief.id,
@@ -3266,6 +3267,7 @@ class SQLiteStorage:
                     belief.superseded_by,
                     belief.times_reinforced,
                     1 if belief.is_active else 0,
+                    belief.strength,
                     belief.context,
                     self._to_json(belief.context_tags),
                     getattr(belief, "source_entity", None),
@@ -3629,11 +3631,12 @@ class SQLiteStorage:
                 (id, stack_id, name, statement, priority, created_at,
                  confidence, source_type, source_episodes, derived_from,
                  last_verified, verification_count, confidence_history,
+                 strength,
                  context, context_tags,
                  subject_ids, access_grants, consent_grants,
                  epoch_id,
                  local_updated_at, cloud_synced_at, version, deleted)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
                 (
                     value.id,
@@ -3649,6 +3652,7 @@ class SQLiteStorage:
                     value.last_verified.isoformat() if value.last_verified else None,
                     value.verification_count,
                     self._to_json(value.confidence_history),
+                    value.strength,
                     value.context,
                     self._to_json(value.context_tags),
                     self._to_json(getattr(value, "subject_ids", None)),
@@ -3758,11 +3762,12 @@ class SQLiteStorage:
                 (id, stack_id, title, description, goal_type, priority, status, created_at,
                  confidence, source_type, source_episodes, derived_from,
                  last_verified, verification_count, confidence_history,
+                 strength,
                  context, context_tags,
                  subject_ids, access_grants, consent_grants,
                  epoch_id,
                  local_updated_at, cloud_synced_at, version, deleted)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
                 (
                     goal.id,
@@ -3780,6 +3785,7 @@ class SQLiteStorage:
                     goal.last_verified.isoformat() if goal.last_verified else None,
                     goal.verification_count,
                     self._to_json(goal.confidence_history),
+                    goal.strength,
                     goal.context,
                     self._to_json(goal.context_tags),
                     self._to_json(getattr(goal, "subject_ids", None)),
@@ -3921,11 +3927,12 @@ class SQLiteStorage:
                 (id, stack_id, content, note_type, speaker, reason, tags, created_at,
                  confidence, source_type, source_episodes, derived_from,
                  last_verified, verification_count, confidence_history,
+                 strength,
                  context, context_tags, source_entity,
                  subject_ids, access_grants, consent_grants,
                  epoch_id,
                  local_updated_at, cloud_synced_at, version, deleted)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
                 (
                     note.id,
@@ -3943,6 +3950,7 @@ class SQLiteStorage:
                     note.last_verified.isoformat() if note.last_verified else None,
                     note.verification_count,
                     self._to_json(note.confidence_history),
+                    note.strength,
                     note.context,
                     self._to_json(note.context_tags),
                     getattr(note, "source_entity", None),
@@ -4157,11 +4165,12 @@ class SQLiteStorage:
                     (id, stack_id, drive_type, intensity, focus_areas, created_at, updated_at,
                      confidence, source_type, source_episodes, derived_from,
                      last_verified, verification_count, confidence_history,
+                     strength,
                      context, context_tags,
                      subject_ids, access_grants, consent_grants,
                      epoch_id,
                      local_updated_at, cloud_synced_at, version, deleted)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                     (
                         drive.id,
@@ -4178,6 +4187,7 @@ class SQLiteStorage:
                         drive.last_verified.isoformat() if drive.last_verified else None,
                         drive.verification_count,
                         self._to_json(drive.confidence_history),
+                        drive.strength,
                         drive.context,
                         self._to_json(drive.context_tags),
                         self._to_json(getattr(drive, "subject_ids", None)),
@@ -4334,11 +4344,12 @@ class SQLiteStorage:
                      sentiment, interaction_count, last_interaction, created_at,
                      confidence, source_type, source_episodes, derived_from,
                      last_verified, verification_count, confidence_history,
+                     strength,
                      context, context_tags,
                      subject_ids, access_grants, consent_grants,
                      epoch_id,
                      local_updated_at, cloud_synced_at, version, deleted)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                     (
                         relationship.id,
@@ -4366,6 +4377,7 @@ class SQLiteStorage:
                         ),
                         relationship.verification_count,
                         self._to_json(relationship.confidence_history),
+                        relationship.strength,
                         relationship.context,
                         self._to_json(relationship.context_tags),
                         self._to_json(getattr(relationship, "subject_ids", None)),


### PR DESCRIPTION
## Summary
- **P1 fix**: `load()` now filters by strength tier (Strong + Fading only), not just `strength > 0.0`
- **P1 root cause**: 6 `save_*` methods (belief, value, goal, note, drive, relationship) were not persisting the `strength` column to SQLite — only `save_episode` was. All reads returned `strength=1.0` (column default) regardless of what was saved
- **P2 fix**: `StackComponentProtocol.on_save` docstring updated to match dict-metadata return contract
- **P2 fix**: Seed-belief docs updated to remove false "never injects after creation" claim

## Test plan
- [x] 2 new tests verifying load() excludes weak/dormant episodes and beliefs
- [x] Full suite: 2973 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)