### PR TITLE
chore: bump version to 0.11.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kernle"
-version = "0.10.0"
+version = "0.11.0"
 description = "Stratified memory for synthetic intelligences"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump version from 0.10.0 to 0.11.0

### v0.11.0 — Platform Integrations
- OpenClaw Plugin SDK plugin (#343)
- Claude Code plugin with 4 lifecycle hooks (#344)
- `kernle hook` CLI commands — `pip install kernle` users need no repo access (#346)
- `kernle setup claude-code` writes hooks directly to `.claude/settings.json`
- Docs updates (#345, #347)

## Test plan

- [x] Version bump only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)