### PR TITLE
test: add coverage tests to cross 70% threshold

### DIFF
--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -1,0 +1,874 @@
+"""Tests for kernle doctor CLI commands — hook checks, platform detection,
+cmd_doctor, cmd_doctor_structural, structural check functions, and _generate_summary."""
+
+import json
+import uuid
+from argparse import Namespace
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from kernle.cli.commands.doctor import (
+    ComplianceCheck,
+    StructuralFinding,
+    _generate_summary,
+    check_belief_contradictions,
+    check_claude_code_hook,
+    check_hooks,
+    check_low_confidence_beliefs,
+    check_orphaned_references,
+    check_stale_goals,
+    check_stale_relationships,
+    cmd_doctor,
+    cmd_doctor_structural,
+    detect_platform,
+)
+from kernle.types import Belief, Goal, Relationship
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_args(**kwargs):
+    defaults = {"json": False, "fix": False, "full": False, "save_note": False}
+    defaults.update(kwargs)
+    return Namespace(**defaults)
+
+
+def _make_belief(
+    belief_id=None,
+    statement="test belief",
+    confidence=0.8,
+    last_verified=None,
+):
+    return Belief(
+        id=belief_id or str(uuid.uuid4()),
+        stack_id="test",
+        statement=statement,
+        confidence=confidence,
+        last_verified=last_verified,
+    )
+
+
+def _make_relationship(
+    rel_id=None,
+    entity_name="Alice",
+    interaction_count=5,
+    last_interaction=None,
+):
+    return Relationship(
+        id=rel_id or str(uuid.uuid4()),
+        stack_id="test",
+        entity_name=entity_name,
+        entity_type="person",
+        relationship_type="colleague",
+        interaction_count=interaction_count,
+        last_interaction=last_interaction,
+    )
+
+
+def _make_goal(goal_id=None, title="Test goal", created_at=None):
+    return Goal(
+        id=goal_id or str(uuid.uuid4()),
+        stack_id="test",
+        title=title,
+        created_at=created_at,
+    )
+
+
+def _mock_kernle():
+    k = MagicMock()
+    k.stack_id = "test-stack"
+    return k
+
+
+# ===================================================================
+# detect_platform
+# ===================================================================
+
+
+class TestDetectPlatform:
+    def test_clawdbot_detected(self, tmp_path, monkeypatch):
+        clawdbot_dir = tmp_path / ".clawdbot"
+        clawdbot_dir.mkdir()
+        (clawdbot_dir / "clawdbot.json").write_text("{}")
+
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        monkeypatch.setattr(Path, "cwd", staticmethod(lambda: tmp_path / "project"))
+
+        assert detect_platform() == "clawdbot"
+
+    def test_claude_code_global_detected(self, tmp_path, monkeypatch):
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "settings.json").write_text("{}")
+
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        monkeypatch.setattr(Path, "cwd", staticmethod(lambda: tmp_path / "project"))
+
+        assert detect_platform() == "claude-code"
+
+    def test_claude_code_local_detected(self, tmp_path, monkeypatch):
+        project = tmp_path / "project"
+        project.mkdir()
+        claude_dir = project / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "settings.json").write_text("{}")
+
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        monkeypatch.setattr(Path, "cwd", staticmethod(lambda: project))
+
+        assert detect_platform() == "claude-code"
+
+    def test_unknown_when_neither_exists(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        monkeypatch.setattr(Path, "cwd", staticmethod(lambda: tmp_path / "project"))
+
+        assert detect_platform() == "unknown"
+
+
+# ===================================================================
+# check_claude_code_hook
+# ===================================================================
+
+
+class TestCheckClaudeCodeHook:
+    def _write_settings(self, path, data):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(data))
+
+    def test_all_4_hooks_configured_passes(self, tmp_path, monkeypatch):
+        settings = {
+            "hooks": {
+                "SessionStart": ["kernle hook session-start"],
+                "PreToolUse": ["kernle hook pre-tool-use"],
+                "PreCompact": ["kernle hook pre-compact"],
+                "SessionEnd": ["kernle hook session-end"],
+            }
+        }
+        self._write_settings(tmp_path / ".claude" / "settings.json", settings)
+
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        monkeypatch.setattr(Path, "cwd", staticmethod(lambda: tmp_path / "project"))
+
+        result = check_claude_code_hook("test-stack")
+        assert result.passed is True
+        assert "4/4" in result.message
+        assert "global" in result.message
+
+    def test_partial_hooks_fails_with_missing(self, tmp_path, monkeypatch):
+        settings = {
+            "hooks": {
+                "SessionStart": ["kernle hook session-start"],
+            }
+        }
+        self._write_settings(tmp_path / ".claude" / "settings.json", settings)
+
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        monkeypatch.setattr(Path, "cwd", staticmethod(lambda: tmp_path / "project"))
+
+        result = check_claude_code_hook("test-stack")
+        assert result.passed is False
+        assert "1/4" in result.message
+        assert result.fix is not None
+        # Check that the missing events are listed
+        assert "PreCompact" in result.fix or "PreToolUse" in result.fix
+
+    def test_no_settings_file_not_configured(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        monkeypatch.setattr(Path, "cwd", staticmethod(lambda: tmp_path / "project"))
+
+        result = check_claude_code_hook("test-stack")
+        assert result.passed is False
+        assert "not configured" in result.message
+
+    def test_global_config_takes_precedence(self, tmp_path, monkeypatch):
+        """Global config with all hooks wins even if no local config."""
+        global_settings = {
+            "hooks": {
+                "SessionStart": ["kernle hook session-start"],
+                "PreToolUse": ["kernle hook pre-tool-use"],
+                "PreCompact": ["kernle hook pre-compact"],
+                "SessionEnd": ["kernle hook session-end"],
+            }
+        }
+        self._write_settings(tmp_path / ".claude" / "settings.json", global_settings)
+
+        project = tmp_path / "project"
+        project.mkdir()
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        monkeypatch.setattr(Path, "cwd", staticmethod(lambda: project))
+
+        result = check_claude_code_hook("test-stack")
+        assert result.passed is True
+        assert "global" in result.message
+
+    def test_local_config_used_when_global_absent(self, tmp_path, monkeypatch):
+        project = tmp_path / "project"
+        project.mkdir()
+        local_settings = {
+            "hooks": {
+                "SessionStart": ["kernle hook session-start"],
+                "PreToolUse": ["kernle hook pre-tool-use"],
+                "PreCompact": ["kernle hook pre-compact"],
+                "SessionEnd": ["kernle hook session-end"],
+            }
+        }
+        self._write_settings(project / ".claude" / "settings.json", local_settings)
+
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        monkeypatch.setattr(Path, "cwd", staticmethod(lambda: project))
+
+        result = check_claude_code_hook("test-stack")
+        assert result.passed is True
+        assert "project" in result.message
+
+    def test_invalid_json_in_settings(self, tmp_path, monkeypatch):
+        settings_path = tmp_path / ".claude" / "settings.json"
+        settings_path.parent.mkdir(parents=True)
+        settings_path.write_text("{not valid json!!!")
+
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        monkeypatch.setattr(Path, "cwd", staticmethod(lambda: tmp_path / "project"))
+
+        result = check_claude_code_hook("test-stack")
+        assert result.passed is False
+        assert "not configured" in result.message
+
+    def test_hooks_key_missing_in_settings(self, tmp_path, monkeypatch):
+        self._write_settings(tmp_path / ".claude" / "settings.json", {"other": "data"})
+
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        monkeypatch.setattr(Path, "cwd", staticmethod(lambda: tmp_path / "project"))
+
+        result = check_claude_code_hook("test-stack")
+        assert result.passed is False
+        assert "not configured" in result.message
+
+
+# ===================================================================
+# check_hooks
+# ===================================================================
+
+
+class TestCheckHooks:
+    def test_claude_code_platform_delegates(self, monkeypatch):
+        monkeypatch.setattr("kernle.cli.commands.doctor.detect_platform", lambda: "claude-code")
+        mock_result = ComplianceCheck("claude_code_hook", True, "ok")
+        monkeypatch.setattr(
+            "kernle.cli.commands.doctor.check_claude_code_hook",
+            lambda sid: mock_result,
+        )
+
+        checks = check_hooks("test-stack")
+        assert len(checks) == 1
+        assert checks[0].name == "claude_code_hook"
+
+    def test_clawdbot_platform_delegates(self, monkeypatch):
+        monkeypatch.setattr("kernle.cli.commands.doctor.detect_platform", lambda: "clawdbot")
+        mock_result = ComplianceCheck("clawdbot_hook", True, "ok")
+        monkeypatch.setattr("kernle.cli.commands.doctor.check_clawdbot_hook", lambda: mock_result)
+
+        checks = check_hooks("test-stack")
+        assert len(checks) == 1
+        assert checks[0].name == "clawdbot_hook"
+
+    def test_unknown_platform_both_fail(self, monkeypatch):
+        monkeypatch.setattr("kernle.cli.commands.doctor.detect_platform", lambda: "unknown")
+        monkeypatch.setattr(
+            "kernle.cli.commands.doctor.check_clawdbot_hook",
+            lambda: ComplianceCheck("clawdbot_hook", False, "not installed"),
+        )
+        monkeypatch.setattr(
+            "kernle.cli.commands.doctor.check_claude_code_hook",
+            lambda sid: ComplianceCheck("claude_code_hook", False, "not configured"),
+        )
+
+        checks = check_hooks("test-stack")
+        assert len(checks) == 1
+        assert checks[0].name == "hooks"
+        assert checks[0].passed is False
+        assert "No platform hooks" in checks[0].message
+
+    def test_unknown_platform_clawdbot_passes(self, monkeypatch):
+        monkeypatch.setattr("kernle.cli.commands.doctor.detect_platform", lambda: "unknown")
+        clawdbot_ok = ComplianceCheck("clawdbot_hook", True, "installed")
+        monkeypatch.setattr("kernle.cli.commands.doctor.check_clawdbot_hook", lambda: clawdbot_ok)
+        monkeypatch.setattr(
+            "kernle.cli.commands.doctor.check_claude_code_hook",
+            lambda sid: ComplianceCheck("claude_code_hook", False, "not configured"),
+        )
+
+        checks = check_hooks("test-stack")
+        assert len(checks) == 1
+        assert checks[0].name == "clawdbot_hook"
+        assert checks[0].passed is True
+
+    def test_unknown_platform_claude_passes(self, monkeypatch):
+        monkeypatch.setattr("kernle.cli.commands.doctor.detect_platform", lambda: "unknown")
+        monkeypatch.setattr(
+            "kernle.cli.commands.doctor.check_clawdbot_hook",
+            lambda: ComplianceCheck("clawdbot_hook", False, "not installed"),
+        )
+        claude_ok = ComplianceCheck("claude_code_hook", True, "configured")
+        monkeypatch.setattr(
+            "kernle.cli.commands.doctor.check_claude_code_hook",
+            lambda sid: claude_ok,
+        )
+
+        checks = check_hooks("test-stack")
+        assert len(checks) == 1
+        assert checks[0].name == "claude_code_hook"
+        assert checks[0].passed is True
+
+
+# ===================================================================
+# cmd_doctor
+# ===================================================================
+
+
+class TestCmdDoctor:
+    def test_no_instruction_file_status(self, capsys, monkeypatch):
+        monkeypatch.setattr("kernle.cli.commands.doctor.find_instruction_file", lambda: None)
+        k = _mock_kernle()
+        args = _make_args()
+
+        cmd_doctor(args, k)
+
+        captured = capsys.readouterr()
+        assert "No instruction file found" in captured.out
+
+    def test_json_output_mode(self, capsys, monkeypatch):
+        monkeypatch.setattr("kernle.cli.commands.doctor.find_instruction_file", lambda: None)
+        k = _mock_kernle()
+        args = _make_args(json=True)
+
+        cmd_doctor(args, k)
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["status"] == "no_file"
+        assert data["file"] is None
+        assert data["stack_id"] == "test-stack"
+        assert "checks" in data
+
+    def test_json_output_with_instruction_file(self, capsys, monkeypatch, tmp_path):
+        instruction_file = tmp_path / "CLAUDE.md"
+        instruction_file.write_text(
+            "## Memory\nkernle load\nkernle anxiety\nevery message\nkernle checkpoint"
+        )
+        monkeypatch.setattr(
+            "kernle.cli.commands.doctor.find_instruction_file",
+            lambda: (instruction_file, "claude"),
+        )
+        k = _mock_kernle()
+        args = _make_args(json=True)
+
+        cmd_doctor(args, k)
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["status"] == "excellent"
+        assert data["file_type"] == "claude"
+
+    def test_full_check_includes_beliefs_and_hooks(self, capsys, monkeypatch, tmp_path):
+        instruction_file = tmp_path / "CLAUDE.md"
+        instruction_file.write_text(
+            "## Memory\nkernle load\nkernle anxiety\nevery message\nkernle checkpoint"
+        )
+        monkeypatch.setattr(
+            "kernle.cli.commands.doctor.find_instruction_file",
+            lambda: (instruction_file, "claude"),
+        )
+        monkeypatch.setattr(
+            "kernle.cli.commands.doctor.check_hooks",
+            lambda sid: [ComplianceCheck("claude_code_hook", True, "ok")],
+        )
+        monkeypatch.setattr(
+            "kernle.cli.commands.doctor.check_seed_beliefs",
+            lambda kobj: (
+                ComplianceCheck("seed_beliefs", True, "ok", category="recommended"),
+                {"total_beliefs": 10},
+            ),
+        )
+        k = _mock_kernle()
+        args = _make_args(full=True)
+
+        cmd_doctor(args, k)
+
+        captured = capsys.readouterr()
+        assert "SEED BELIEFS" in captured.out
+        assert "PLATFORM HOOKS" in captured.out
+
+    def test_fix_mode_with_instruction_file(self, capsys, monkeypatch, tmp_path):
+        instruction_file = tmp_path / "CLAUDE.md"
+        instruction_file.write_text("# My Project\nSome content here")
+        monkeypatch.setattr(
+            "kernle.cli.commands.doctor.find_instruction_file",
+            lambda: (instruction_file, "claude"),
+        )
+        k = _mock_kernle()
+        args = _make_args(fix=True)
+
+        cmd_doctor(args, k)
+
+        captured = capsys.readouterr()
+        assert "Auto-fixing" in captured.out
+
+    def test_fix_mode_no_instruction_file(self, capsys, monkeypatch):
+        monkeypatch.setattr("kernle.cli.commands.doctor.find_instruction_file", lambda: None)
+        k = _mock_kernle()
+        args = _make_args(fix=True)
+
+        cmd_doctor(args, k)
+
+        captured = capsys.readouterr()
+        assert "No instruction file to fix" in captured.out
+
+    def test_good_status_when_required_pass_but_recommended_fail(
+        self, capsys, monkeypatch, tmp_path
+    ):
+        instruction_file = tmp_path / "CLAUDE.md"
+        # Has load and anxiety but missing per_message, checkpoint, memory_section
+        instruction_file.write_text("kernle load\nkernle anxiety")
+        monkeypatch.setattr(
+            "kernle.cli.commands.doctor.find_instruction_file",
+            lambda: (instruction_file, "claude"),
+        )
+        k = _mock_kernle()
+        args = _make_args(json=True)
+
+        cmd_doctor(args, k)
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["status"] == "good"
+
+    def test_needs_work_status(self, capsys, monkeypatch, tmp_path):
+        instruction_file = tmp_path / "CLAUDE.md"
+        # Missing load — a required check
+        instruction_file.write_text("## Memory\nsome content without load")
+        monkeypatch.setattr(
+            "kernle.cli.commands.doctor.find_instruction_file",
+            lambda: (instruction_file, "claude"),
+        )
+        k = _mock_kernle()
+        args = _make_args(json=True)
+
+        cmd_doctor(args, k)
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["status"] == "needs_work"
+
+
+# ===================================================================
+# cmd_doctor_structural
+# ===================================================================
+
+
+class TestCmdDoctorStructural:
+    def test_no_findings_healthy_message(self, capsys, monkeypatch):
+        monkeypatch.setattr("kernle.cli.commands.doctor.run_structural_checks", lambda kobj: [])
+        k = _mock_kernle()
+        args = _make_args()
+
+        cmd_doctor_structural(args, k)
+
+        captured = capsys.readouterr()
+        assert "healthy" in captured.out.lower()
+
+    def test_mixed_findings_displayed(self, capsys, monkeypatch):
+        findings = [
+            StructuralFinding(
+                check="orphaned_reference",
+                severity="error",
+                memory_type="episode",
+                memory_id="abc123456789",
+                message="broken ref",
+            ),
+            StructuralFinding(
+                check="low_confidence_belief",
+                severity="warning",
+                memory_type="belief",
+                memory_id="def123456789",
+                message="low confidence",
+            ),
+            StructuralFinding(
+                check="stale_goal",
+                severity="info",
+                memory_type="goal",
+                memory_id="ghi123456789",
+                message="stale goal",
+            ),
+        ]
+        monkeypatch.setattr(
+            "kernle.cli.commands.doctor.run_structural_checks", lambda kobj: findings
+        )
+        k = _mock_kernle()
+        args = _make_args()
+
+        cmd_doctor_structural(args, k)
+
+        captured = capsys.readouterr()
+        assert "ERRORS" in captured.out
+        assert "WARNINGS" in captured.out
+        assert "INFO" in captured.out
+        assert "1 errors" in captured.out
+
+    def test_json_output_mode(self, capsys, monkeypatch):
+        findings = [
+            StructuralFinding(
+                check="orphaned_reference",
+                severity="error",
+                memory_type="episode",
+                memory_id="abc123",
+                message="broken ref",
+            ),
+        ]
+        monkeypatch.setattr(
+            "kernle.cli.commands.doctor.run_structural_checks", lambda kobj: findings
+        )
+        k = _mock_kernle()
+        args = _make_args(json=True)
+
+        cmd_doctor_structural(args, k)
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["summary"]["errors"] == 1
+        assert len(data["findings"]) == 1
+        assert data["findings"][0]["check"] == "orphaned_reference"
+
+    def test_save_note_mode(self, monkeypatch):
+        findings = [
+            StructuralFinding(
+                check="stale_goal",
+                severity="info",
+                memory_type="goal",
+                memory_id="ghi123456789",
+                message="stale goal",
+            ),
+        ]
+        monkeypatch.setattr(
+            "kernle.cli.commands.doctor.run_structural_checks", lambda kobj: findings
+        )
+        k = _mock_kernle()
+        args = _make_args(save_note=True)
+
+        cmd_doctor_structural(args, k)
+
+        k._storage.save_note.assert_called_once()
+        saved_note = k._storage.save_note.call_args[0][0]
+        assert saved_note.note_type == "diagnostic"
+        assert "stale_goal" in saved_note.content
+
+    def test_save_note_not_called_when_no_findings(self, monkeypatch):
+        monkeypatch.setattr("kernle.cli.commands.doctor.run_structural_checks", lambda kobj: [])
+        k = _mock_kernle()
+        args = _make_args(save_note=True)
+
+        cmd_doctor_structural(args, k)
+
+        k._storage.save_note.assert_not_called()
+
+
+# ===================================================================
+# check_orphaned_references
+# ===================================================================
+
+
+class TestCheckOrphanedReferences:
+    def test_finds_orphaned_references(self):
+        k = _mock_kernle()
+        k.find_orphaned_references.return_value = {
+            "orphans": [
+                {
+                    "memory": "episode:abc123",
+                    "field": "derived_from",
+                    "broken_ref": "belief:xyz789",
+                },
+            ]
+        }
+
+        findings = check_orphaned_references(k)
+        assert len(findings) == 1
+        assert findings[0].severity == "error"
+        assert findings[0].memory_type == "episode"
+        assert findings[0].memory_id == "abc123"
+        assert "broken" in findings[0].message
+
+    def test_no_orphans(self):
+        k = _mock_kernle()
+        k.find_orphaned_references.return_value = {"orphans": []}
+
+        findings = check_orphaned_references(k)
+        assert len(findings) == 0
+
+    def test_handles_memory_ref_without_colon(self):
+        k = _mock_kernle()
+        k.find_orphaned_references.return_value = {
+            "orphans": [
+                {
+                    "memory": "no_colon_here",
+                    "field": "source_episodes",
+                    "broken_ref": "gone",
+                },
+            ]
+        }
+
+        findings = check_orphaned_references(k)
+        assert len(findings) == 1
+        assert findings[0].memory_type == "unknown"
+        assert findings[0].memory_id == "no_colon_here"
+
+
+# ===================================================================
+# check_low_confidence_beliefs
+# ===================================================================
+
+
+class TestCheckLowConfidenceBeliefs:
+    def test_finds_low_confidence_belief(self):
+        k = _mock_kernle()
+        k._storage.get_beliefs.return_value = [
+            _make_belief(belief_id="low1", confidence=0.1, last_verified=None),
+        ]
+
+        findings = check_low_confidence_beliefs(k)
+        assert len(findings) == 1
+        assert findings[0].severity == "warning"
+        assert "never verified" in findings[0].message
+
+    def test_finds_low_confidence_with_verified_date(self):
+        k = _mock_kernle()
+        verified_date = datetime.now(timezone.utc) - timedelta(days=30)
+        k._storage.get_beliefs.return_value = [
+            _make_belief(belief_id="low2", confidence=0.2, last_verified=verified_date),
+        ]
+
+        findings = check_low_confidence_beliefs(k)
+        assert len(findings) == 1
+        assert "30d ago" in findings[0].message
+
+    def test_skips_high_confidence_beliefs(self):
+        k = _mock_kernle()
+        k._storage.get_beliefs.return_value = [
+            _make_belief(confidence=0.9),
+        ]
+
+        findings = check_low_confidence_beliefs(k)
+        assert len(findings) == 0
+
+    def test_handles_storage_exception(self):
+        k = _mock_kernle()
+        k._storage.get_beliefs.side_effect = Exception("DB error")
+
+        findings = check_low_confidence_beliefs(k)
+        assert len(findings) == 0
+
+
+# ===================================================================
+# check_stale_relationships
+# ===================================================================
+
+
+class TestCheckStaleRelationships:
+    def test_zero_interaction_relationship(self):
+        k = _mock_kernle()
+        k._storage.get_relationships.return_value = [
+            _make_relationship(rel_id="rel1", interaction_count=0),
+        ]
+
+        findings = check_stale_relationships(k)
+        assert len(findings) == 1
+        assert findings[0].severity == "warning"
+        assert "zero interactions" in findings[0].message
+
+    def test_stale_last_interaction(self):
+        k = _mock_kernle()
+        old_date = datetime.now(timezone.utc) - timedelta(days=120)
+        k._storage.get_relationships.return_value = [
+            _make_relationship(
+                rel_id="rel2",
+                interaction_count=3,
+                last_interaction=old_date,
+            ),
+        ]
+
+        findings = check_stale_relationships(k)
+        assert len(findings) == 1
+        assert findings[0].severity == "info"
+        assert "120d ago" in findings[0].message
+
+    def test_recent_interaction_not_flagged(self):
+        k = _mock_kernle()
+        recent_date = datetime.now(timezone.utc) - timedelta(days=10)
+        k._storage.get_relationships.return_value = [
+            _make_relationship(
+                interaction_count=5,
+                last_interaction=recent_date,
+            ),
+        ]
+
+        findings = check_stale_relationships(k)
+        assert len(findings) == 0
+
+    def test_handles_storage_exception(self):
+        k = _mock_kernle()
+        k._storage.get_relationships.side_effect = Exception("DB error")
+
+        findings = check_stale_relationships(k)
+        assert len(findings) == 0
+
+
+# ===================================================================
+# check_belief_contradictions
+# ===================================================================
+
+
+class TestCheckBeliefContradictions:
+    def test_detects_contradiction(self):
+        k = _mock_kernle()
+        k._storage.get_beliefs.return_value = [
+            _make_belief(
+                belief_id="b1",
+                statement="I should always help users with coding tasks",
+            ),
+            _make_belief(
+                belief_id="b2",
+                statement="I should never help users with coding tasks",
+            ),
+        ]
+
+        findings = check_belief_contradictions(k)
+        assert len(findings) == 1
+        assert findings[0].severity == "warning"
+        assert "contradiction" in findings[0].message.lower()
+
+    def test_no_contradiction_for_unrelated_beliefs(self):
+        k = _mock_kernle()
+        k._storage.get_beliefs.return_value = [
+            _make_belief(
+                belief_id="b1",
+                statement="I should always help users with coding tasks",
+            ),
+            _make_belief(
+                belief_id="b2",
+                statement="The weather is never pleasant in winter",
+            ),
+        ]
+
+        findings = check_belief_contradictions(k)
+        assert len(findings) == 0
+
+    def test_no_contradiction_same_polarity(self):
+        k = _mock_kernle()
+        k._storage.get_beliefs.return_value = [
+            _make_belief(
+                belief_id="b1",
+                statement="I should always help users with coding",
+            ),
+            _make_belief(
+                belief_id="b2",
+                statement="I must always help users with coding",
+            ),
+        ]
+
+        findings = check_belief_contradictions(k)
+        assert len(findings) == 0
+
+    def test_handles_storage_exception(self):
+        k = _mock_kernle()
+        k._storage.get_beliefs.side_effect = Exception("DB error")
+
+        findings = check_belief_contradictions(k)
+        assert len(findings) == 0
+
+
+# ===================================================================
+# check_stale_goals
+# ===================================================================
+
+
+class TestCheckStaleGoals:
+    def test_finds_stale_goal(self):
+        k = _mock_kernle()
+        old_date = datetime.now(timezone.utc) - timedelta(days=90)
+        k._storage.get_goals.return_value = [
+            _make_goal(goal_id="g1", created_at=old_date),
+        ]
+
+        findings = check_stale_goals(k)
+        assert len(findings) == 1
+        assert findings[0].severity == "info"
+        assert "90d old" in findings[0].message
+
+    def test_recent_goal_not_flagged(self):
+        k = _mock_kernle()
+        recent_date = datetime.now(timezone.utc) - timedelta(days=10)
+        k._storage.get_goals.return_value = [
+            _make_goal(created_at=recent_date),
+        ]
+
+        findings = check_stale_goals(k)
+        assert len(findings) == 0
+
+    def test_goal_without_created_at_skipped(self):
+        k = _mock_kernle()
+        k._storage.get_goals.return_value = [
+            _make_goal(created_at=None),
+        ]
+
+        findings = check_stale_goals(k)
+        assert len(findings) == 0
+
+    def test_handles_storage_exception(self):
+        k = _mock_kernle()
+        k._storage.get_goals.side_effect = Exception("DB error")
+
+        findings = check_stale_goals(k)
+        assert len(findings) == 0
+
+
+# ===================================================================
+# _generate_summary
+# ===================================================================
+
+
+class TestGenerateSummary:
+    def test_no_findings(self):
+        result = _generate_summary([])
+        assert "No issues" in result
+        assert "healthy" in result
+
+    def test_errors_only(self):
+        findings = [{"severity": "error"}]
+        result = _generate_summary(findings)
+        assert "1 finding(s)" in result
+        assert "1 error(s)" in result
+
+    def test_warnings_only(self):
+        findings = [{"severity": "warning"}, {"severity": "warning"}]
+        result = _generate_summary(findings)
+        assert "2 finding(s)" in result
+        assert "2 warning(s)" in result
+
+    def test_info_only(self):
+        findings = [{"severity": "info"}]
+        result = _generate_summary(findings)
+        assert "1 info" in result
+
+    def test_mixed_severities(self):
+        findings = [
+            {"severity": "error"},
+            {"severity": "warning"},
+            {"severity": "warning"},
+            {"severity": "info"},
+        ]
+        result = _generate_summary(findings)
+        assert "4 finding(s)" in result
+        assert "1 error(s)" in result
+        assert "2 warning(s)" in result
+        assert "1 info" in result

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -1,0 +1,371 @@
+"""Tests for kernle setup CLI commands."""
+
+import json
+from argparse import Namespace
+from unittest.mock import MagicMock, patch
+
+from kernle.cli.commands.setup import (
+    _build_claude_code_hooks,
+    _deep_merge,
+    _get_memory_flush_prompt,
+    cmd_setup,
+    setup_claude_code,
+)
+
+# --- Helpers ---
+
+
+def make_args(**kwargs):
+    """Create an argparse Namespace with defaults."""
+    defaults = {"platform": None, "force": False, "enable": False}
+    defaults.update(kwargs)
+    # Use setattr for 'global' since it's a keyword
+    ns = Namespace(**{k: v for k, v in defaults.items() if k != "global"})
+    setattr(ns, "global", defaults.get("global", False))
+    return ns
+
+
+# --- _deep_merge tests ---
+
+
+class TestDeepMerge:
+    def test_merge_flat_dicts(self):
+        base = {"a": 1, "b": 2}
+        updates = {"c": 3}
+        result = _deep_merge(base, updates)
+        assert result == {"a": 1, "b": 2, "c": 3}
+
+    def test_merge_overwrites_flat_value(self):
+        base = {"a": 1}
+        updates = {"a": 2}
+        result = _deep_merge(base, updates)
+        assert result == {"a": 2}
+
+    def test_merge_nested_dicts(self):
+        base = {"a": {"x": 1, "y": 2}}
+        updates = {"a": {"z": 3}}
+        result = _deep_merge(base, updates)
+        assert result == {"a": {"x": 1, "y": 2, "z": 3}}
+
+    def test_merge_deeply_nested(self):
+        base = {"a": {"b": {"c": 1, "d": 2}}}
+        updates = {"a": {"b": {"e": 3}}}
+        result = _deep_merge(base, updates)
+        assert result == {"a": {"b": {"c": 1, "d": 2, "e": 3}}}
+
+    def test_merge_does_not_mutate_base(self):
+        base = {"a": 1}
+        updates = {"b": 2}
+        _deep_merge(base, updates)
+        assert base == {"a": 1}
+
+    def test_merge_empty_base(self):
+        result = _deep_merge({}, {"a": 1})
+        assert result == {"a": 1}
+
+    def test_merge_empty_updates(self):
+        result = _deep_merge({"a": 1}, {})
+        assert result == {"a": 1}
+
+    def test_merge_both_empty(self):
+        result = _deep_merge({}, {})
+        assert result == {}
+
+    def test_merge_overwrites_non_dict_with_dict(self):
+        base = {"a": 1}
+        updates = {"a": {"nested": True}}
+        result = _deep_merge(base, updates)
+        assert result == {"a": {"nested": True}}
+
+    def test_merge_overwrites_dict_with_non_dict(self):
+        base = {"a": {"nested": True}}
+        updates = {"a": "flat"}
+        result = _deep_merge(base, updates)
+        assert result == {"a": "flat"}
+
+
+# --- _build_claude_code_hooks tests ---
+
+
+class TestBuildClaudeCodeHooks:
+    def test_with_stack_id(self):
+        result = _build_claude_code_hooks("my-stack")
+        assert "hooks" in result
+        hooks = result["hooks"]
+        assert set(hooks.keys()) == {
+            "SessionStart",
+            "PreToolUse",
+            "PreCompact",
+            "SessionEnd",
+        }
+
+    def test_stack_id_in_commands(self):
+        result = _build_claude_code_hooks("my-stack")
+        hooks = result["hooks"]
+        # Each event should have the -s flag with the stack_id
+        for event in ("SessionStart", "PreToolUse", "PreCompact", "SessionEnd"):
+            command = hooks[event][0]["hooks"][0]["command"]
+            assert "-s my-stack" in command
+
+    def test_without_stack_id_omits_flag(self):
+        result = _build_claude_code_hooks(None)
+        hooks = result["hooks"]
+        for event in ("SessionStart", "PreToolUse", "PreCompact", "SessionEnd"):
+            command = hooks[event][0]["hooks"][0]["command"]
+            assert "-s " not in command
+            assert command.startswith("kernle hook ")
+
+    def test_all_hooks_are_command_type(self):
+        result = _build_claude_code_hooks("test")
+        hooks = result["hooks"]
+        for event in hooks:
+            for entry in hooks[event]:
+                for hook in entry["hooks"]:
+                    assert hook["type"] == "command"
+
+    def test_all_hooks_have_timeout(self):
+        result = _build_claude_code_hooks("test")
+        hooks = result["hooks"]
+        for event in hooks:
+            for entry in hooks[event]:
+                for hook in entry["hooks"]:
+                    assert hook["timeout"] == 10
+
+    def test_pre_tool_use_has_matcher(self):
+        result = _build_claude_code_hooks("test")
+        pre_tool = result["hooks"]["PreToolUse"][0]
+        assert pre_tool["matcher"] == "Write|Edit|NotebookEdit"
+
+    def test_session_start_no_matcher(self):
+        result = _build_claude_code_hooks("test")
+        session_start = result["hooks"]["SessionStart"][0]
+        assert "matcher" not in session_start
+
+    def test_hook_commands_contain_event_names(self):
+        result = _build_claude_code_hooks("test")
+        hooks = result["hooks"]
+        assert "session-start" in hooks["SessionStart"][0]["hooks"][0]["command"]
+        assert "pre-tool-use" in hooks["PreToolUse"][0]["hooks"][0]["command"]
+        assert "pre-compact" in hooks["PreCompact"][0]["hooks"][0]["command"]
+        assert "session-end" in hooks["SessionEnd"][0]["hooks"][0]["command"]
+
+
+# --- _get_memory_flush_prompt tests ---
+
+
+class TestGetMemoryFlushPrompt:
+    def test_contains_stack_id(self):
+        prompt = _get_memory_flush_prompt("my-stack")
+        assert "my-stack" in prompt
+
+    def test_contains_kernle_command(self):
+        prompt = _get_memory_flush_prompt("test-stack")
+        assert "kernle -s test-stack checkpoint" in prompt
+
+    def test_returns_string(self):
+        result = _get_memory_flush_prompt("abc")
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+
+# --- setup_claude_code tests ---
+
+
+class TestSetupClaudeCode:
+    def test_creates_new_settings_file(self, tmp_path):
+        """Creates .claude/settings.json when it doesn't exist."""
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+
+        with patch("kernle.cli.commands.setup.Path") as mock_path_cls:
+            mock_path_cls.cwd.return_value = project_dir
+            mock_path_cls.home.return_value = tmp_path / "home"
+            # Make Path() constructor work normally for everything else
+            mock_path_cls.side_effect = lambda *a, **kw: type(project_dir)(*a, **kw)
+
+        # Instead of mocking Path, we directly call with mocked cwd
+        with patch("kernle.cli.commands.setup.Path.cwd", return_value=project_dir):
+            setup_claude_code("test-stack")
+
+        settings_file = project_dir / ".claude" / "settings.json"
+        assert settings_file.exists()
+        data = json.loads(settings_file.read_text())
+        assert "hooks" in data
+        assert "SessionStart" in data["hooks"]
+
+    def test_creates_global_settings_file(self, tmp_path):
+        """Creates ~/.claude/settings.json when global=True."""
+        home_dir = tmp_path / "home"
+        home_dir.mkdir()
+
+        with patch("kernle.cli.commands.setup.Path.home", return_value=home_dir):
+            setup_claude_code("test-stack", global_install=True)
+
+        settings_file = home_dir / ".claude" / "settings.json"
+        assert settings_file.exists()
+        data = json.loads(settings_file.read_text())
+        assert "hooks" in data
+
+    def test_merges_with_existing_settings(self, tmp_path):
+        """Merges hooks into existing settings.json without clobbering."""
+        project_dir = tmp_path / "project"
+        claude_dir = project_dir / ".claude"
+        claude_dir.mkdir(parents=True)
+        settings_file = claude_dir / "settings.json"
+        existing = {"allowedTools": ["Read", "Write"], "hooks": {}}
+        settings_file.write_text(json.dumps(existing))
+
+        with patch("kernle.cli.commands.setup.Path.cwd", return_value=project_dir):
+            setup_claude_code("test-stack")
+
+        data = json.loads(settings_file.read_text())
+        # Original key preserved
+        assert data["allowedTools"] == ["Read", "Write"]
+        # Hooks merged in
+        assert "SessionStart" in data["hooks"]
+
+    def test_detects_already_configured(self, tmp_path, capsys):
+        """Detects existing kernle hooks and exits without force."""
+        project_dir = tmp_path / "project"
+        claude_dir = project_dir / ".claude"
+        claude_dir.mkdir(parents=True)
+        settings_file = claude_dir / "settings.json"
+
+        hooks_config = _build_claude_code_hooks("test-stack")
+        settings_file.write_text(json.dumps(hooks_config))
+
+        with patch("kernle.cli.commands.setup.Path.cwd", return_value=project_dir):
+            setup_claude_code("test-stack")
+
+        captured = capsys.readouterr()
+        assert "already configured" in captured.out
+
+    def test_force_overwrites_existing(self, tmp_path, capsys):
+        """--force overwrites existing kernle hooks."""
+        project_dir = tmp_path / "project"
+        claude_dir = project_dir / ".claude"
+        claude_dir.mkdir(parents=True)
+        settings_file = claude_dir / "settings.json"
+
+        hooks_config = _build_claude_code_hooks("old-stack")
+        settings_file.write_text(json.dumps(hooks_config))
+
+        with patch("kernle.cli.commands.setup.Path.cwd", return_value=project_dir):
+            setup_claude_code("new-stack", force=True)
+
+        data = json.loads(settings_file.read_text())
+        # Should have new-stack in the commands
+        cmd = data["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+        assert "-s new-stack" in cmd
+
+        captured = capsys.readouterr()
+        assert "already configured" not in captured.out
+
+    def test_handles_corrupt_json(self, tmp_path, capsys):
+        """Handles corrupt settings.json gracefully by writing fresh."""
+        project_dir = tmp_path / "project"
+        claude_dir = project_dir / ".claude"
+        claude_dir.mkdir(parents=True)
+        settings_file = claude_dir / "settings.json"
+        settings_file.write_text("not valid json {{{")
+
+        with patch("kernle.cli.commands.setup.Path.cwd", return_value=project_dir):
+            setup_claude_code("test-stack")
+
+        # Should have written valid JSON despite corrupt original
+        data = json.loads(settings_file.read_text())
+        assert "hooks" in data
+
+    def test_prints_verify_hint(self, tmp_path, capsys):
+        """Output includes the verify hint."""
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+
+        with patch("kernle.cli.commands.setup.Path.cwd", return_value=project_dir):
+            setup_claude_code("test-stack")
+
+        captured = capsys.readouterr()
+        assert "kernle doctor --full" in captured.out
+
+    def test_prints_stack_id_in_output(self, tmp_path, capsys):
+        """Output mentions the stack id."""
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+
+        with patch("kernle.cli.commands.setup.Path.cwd", return_value=project_dir):
+            setup_claude_code("my-fancy-stack")
+
+        captured = capsys.readouterr()
+        assert "my-fancy-stack" in captured.out
+
+
+# --- cmd_setup tests ---
+
+
+class TestCmdSetup:
+    def _make_kernle_mock(self, stack_id="default"):
+        k = MagicMock()
+        k.stack_id = stack_id
+        return k
+
+    def test_no_platform_shows_usage(self, capsys):
+        """No platform argument shows available platforms."""
+        args = make_args(platform=None)
+        k = self._make_kernle_mock()
+        cmd_setup(args, k)
+        captured = capsys.readouterr()
+        assert "Available platforms:" in captured.out
+        assert "clawdbot" in captured.out
+        assert "claude-code" in captured.out
+
+    def test_unknown_platform_shows_error(self, capsys):
+        """Unknown platform shows error message."""
+        args = make_args(platform="unknown-thing")
+        k = self._make_kernle_mock()
+        cmd_setup(args, k)
+        captured = capsys.readouterr()
+        assert "Unknown platform" in captured.out
+
+    @patch("kernle.cli.commands.setup.setup_claude_code")
+    def test_dispatches_claude_code(self, mock_setup_cc):
+        """Platform 'claude-code' dispatches to setup_claude_code."""
+        args = make_args(platform="claude-code")
+        setattr(args, "global", False)
+        k = self._make_kernle_mock("my-stack")
+        cmd_setup(args, k)
+        mock_setup_cc.assert_called_once_with("my-stack", False, False)
+
+    @patch("kernle.cli.commands.setup.setup_claude_code")
+    def test_dispatches_cowork(self, mock_setup_cc):
+        """Platform 'cowork' dispatches to setup_claude_code (same as claude-code)."""
+        args = make_args(platform="cowork")
+        setattr(args, "global", True)
+        k = self._make_kernle_mock("cowork-stack")
+        cmd_setup(args, k)
+        mock_setup_cc.assert_called_once_with("cowork-stack", False, True)
+
+    @patch("kernle.cli.commands.setup.setup_clawdbot")
+    def test_dispatches_clawdbot(self, mock_setup_cb):
+        """Platform 'clawdbot' dispatches to setup_clawdbot."""
+        args = make_args(platform="clawdbot", force=True, enable=True)
+        k = self._make_kernle_mock("my-stack")
+        cmd_setup(args, k)
+        mock_setup_cb.assert_called_once_with("my-stack", True, True)
+
+    @patch("kernle.cli.commands.setup.setup_claude_code")
+    def test_passes_force_flag(self, mock_setup_cc):
+        """Force flag is passed through to platform setup."""
+        args = make_args(platform="claude-code", force=True)
+        setattr(args, "global", False)
+        k = self._make_kernle_mock("s")
+        cmd_setup(args, k)
+        mock_setup_cc.assert_called_once_with("s", True, False)
+
+    @patch("kernle.cli.commands.setup.setup_claude_code")
+    def test_passes_global_flag(self, mock_setup_cc):
+        """Global flag is passed through for claude-code."""
+        args = make_args(platform="claude-code")
+        setattr(args, "global", True)
+        k = self._make_kernle_mock("s")
+        cmd_setup(args, k)
+        mock_setup_cc.assert_called_once_with("s", False, True)

--- a/tests/test_sqlite_coverage.py
+++ b/tests/test_sqlite_coverage.py
@@ -1,0 +1,450 @@
+"""Tests targeting uncovered methods in SQLiteStorage for coverage improvement.
+
+Covers:
+- Pure functions: _escape_like_pattern, _tokenize_query, _token_match_score, _build_token_filter
+- Boot config CRUD: boot_set, boot_get, boot_list, boot_delete
+- Stack settings: get_stack_setting, set_stack_setting, get_all_stack_settings
+- Raw processing: mark_raw_processed, delete_raw
+- Processing config: get_processing_config, set_processing_config
+- Audit & health: log_audit, log_health_check, get_health_check_stats
+- Memory marking: mark_episode_processed, mark_belief_processed
+- Access tracking: record_access
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from kernle.storage import Belief, Episode, SQLiteStorage
+
+
+@pytest.fixture
+def temp_db():
+    """Create a temporary database path."""
+    path = Path(tempfile.mktemp(suffix=".db"))
+    yield path
+    if path.exists():
+        path.unlink()
+
+
+@pytest.fixture
+def storage(temp_db, monkeypatch):
+    """Create a SQLiteStorage instance for testing."""
+    s = SQLiteStorage(stack_id="test-stack", db_path=temp_db)
+    monkeypatch.setattr(s, "has_cloud_credentials", lambda: False)
+    yield s
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# 1. Pure functions: _escape_like_pattern
+# ---------------------------------------------------------------------------
+
+
+class TestEscapeLikePattern:
+    def test_no_special_chars(self, storage):
+        assert storage._escape_like_pattern("hello world") == "hello world"
+
+    def test_escapes_percent(self, storage):
+        assert storage._escape_like_pattern("100%") == "100\\%"
+
+    def test_escapes_underscore(self, storage):
+        assert storage._escape_like_pattern("file_name") == "file\\_name"
+
+    def test_escapes_backslash(self, storage):
+        assert storage._escape_like_pattern("path\\to") == "path\\\\to"
+
+    def test_escapes_all_special_chars(self, storage):
+        result = storage._escape_like_pattern("a%b_c\\d")
+        assert result == "a\\%b\\_c\\\\d"
+
+    def test_empty_string(self, storage):
+        assert storage._escape_like_pattern("") == ""
+
+
+# ---------------------------------------------------------------------------
+# 2. Pure functions: _tokenize_query
+# ---------------------------------------------------------------------------
+
+
+class TestTokenizeQuery:
+    def test_basic_tokenization(self):
+        tokens = SQLiteStorage._tokenize_query("hello world today")
+        assert tokens == ["hello", "world", "today"]
+
+    def test_filters_short_words(self):
+        tokens = SQLiteStorage._tokenize_query("I am a big cat")
+        assert tokens == ["big", "cat"]
+
+    def test_empty_query(self):
+        tokens = SQLiteStorage._tokenize_query("")
+        assert tokens == []
+
+    def test_all_short_words(self):
+        tokens = SQLiteStorage._tokenize_query("a be it")
+        assert tokens == []
+
+    def test_preserves_case(self):
+        tokens = SQLiteStorage._tokenize_query("Hello WORLD")
+        assert tokens == ["Hello", "WORLD"]
+
+
+# ---------------------------------------------------------------------------
+# 3. Pure functions: _token_match_score
+# ---------------------------------------------------------------------------
+
+
+class TestTokenMatchScore:
+    def test_all_tokens_match(self):
+        score = SQLiteStorage._token_match_score("hello world today", ["hello", "world"])
+        assert score == 1.0
+
+    def test_no_tokens_match(self):
+        score = SQLiteStorage._token_match_score("hello world", ["xyz", "abc"])
+        assert score == 0.0
+
+    def test_partial_match(self):
+        score = SQLiteStorage._token_match_score("hello world", ["hello", "xyz"])
+        assert score == 0.5
+
+    def test_empty_tokens_returns_one(self):
+        score = SQLiteStorage._token_match_score("any text", [])
+        assert score == 1.0
+
+    def test_case_insensitive(self):
+        score = SQLiteStorage._token_match_score("Hello World", ["hello", "world"])
+        assert score == 1.0
+
+
+# ---------------------------------------------------------------------------
+# 4. Pure functions: _build_token_filter
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTokenFilter:
+    def test_single_token_single_column(self):
+        sql, params = SQLiteStorage._build_token_filter(["hello"], ["content"])
+        assert sql == "(content LIKE ?)"
+        assert params == ["%hello%"]
+
+    def test_multiple_tokens_multiple_columns(self):
+        sql, params = SQLiteStorage._build_token_filter(["hello", "world"], ["content", "title"])
+        assert "content LIKE ?" in sql
+        assert "title LIKE ?" in sql
+        assert " OR " in sql
+        assert len(params) == 4
+        assert params == ["%hello%", "%hello%", "%world%", "%world%"]
+
+    def test_empty_tokens(self):
+        sql, params = SQLiteStorage._build_token_filter([], ["content"])
+        assert sql == "()"
+        assert params == []
+
+
+# ---------------------------------------------------------------------------
+# 5. Boot config CRUD: boot_set, boot_get, boot_list, boot_delete
+# ---------------------------------------------------------------------------
+
+
+class TestBootConfig:
+    def test_set_and_get(self, storage):
+        storage.boot_set("key1", "value1")
+        assert storage.boot_get("key1") == "value1"
+
+    def test_get_nonexistent_returns_default(self, storage):
+        assert storage.boot_get("missing") is None
+        assert storage.boot_get("missing", "fallback") == "fallback"
+
+    def test_set_overwrites_existing(self, storage):
+        storage.boot_set("key1", "value1")
+        storage.boot_set("key1", "value2")
+        assert storage.boot_get("key1") == "value2"
+
+    def test_list_returns_all(self, storage):
+        storage.boot_set("alpha", "1")
+        storage.boot_set("beta", "2")
+        result = storage.boot_list()
+        assert result == {"alpha": "1", "beta": "2"}
+
+    def test_list_empty(self, storage):
+        assert storage.boot_list() == {}
+
+    def test_delete_existing(self, storage):
+        storage.boot_set("key1", "value1")
+        assert storage.boot_delete("key1") is True
+        assert storage.boot_get("key1") is None
+
+    def test_delete_nonexistent(self, storage):
+        assert storage.boot_delete("missing") is False
+
+    def test_set_validates_empty_key(self, storage):
+        with pytest.raises(ValueError, match="non-empty string"):
+            storage.boot_set("", "value")
+
+    def test_set_strips_whitespace_key(self, storage):
+        storage.boot_set("  key  ", "value")
+        assert storage.boot_get("key") == "value"
+
+
+# ---------------------------------------------------------------------------
+# 6. Stack settings: get_stack_setting, set_stack_setting, get_all_stack_settings
+# ---------------------------------------------------------------------------
+
+
+class TestStackSettings:
+    def test_set_and_get(self, storage):
+        storage.set_stack_setting("theme", "dark")
+        assert storage.get_stack_setting("theme") == "dark"
+
+    def test_get_nonexistent_returns_none(self, storage):
+        assert storage.get_stack_setting("missing") is None
+
+    def test_set_overwrites_existing(self, storage):
+        storage.set_stack_setting("theme", "dark")
+        storage.set_stack_setting("theme", "light")
+        assert storage.get_stack_setting("theme") == "light"
+
+    def test_get_all_stack_settings(self, storage):
+        storage.set_stack_setting("alpha", "1")
+        storage.set_stack_setting("beta", "2")
+        result = storage.get_all_stack_settings()
+        assert result == {"alpha": "1", "beta": "2"}
+
+    def test_get_all_empty(self, storage):
+        assert storage.get_all_stack_settings() == {}
+
+    def test_settings_scoped_to_stack(self, temp_db):
+        """Two stacks using the same DB have independent settings."""
+        s1 = SQLiteStorage(stack_id="stack-a", db_path=temp_db)
+        s2 = SQLiteStorage(stack_id="stack-b", db_path=temp_db)
+        s1.set_stack_setting("key", "from-a")
+        s2.set_stack_setting("key", "from-b")
+        assert s1.get_stack_setting("key") == "from-a"
+        assert s2.get_stack_setting("key") == "from-b"
+        s1.close()
+        s2.close()
+
+
+# ---------------------------------------------------------------------------
+# 7. Raw processing: mark_raw_processed, delete_raw
+# ---------------------------------------------------------------------------
+
+
+class TestRawProcessing:
+    def test_mark_raw_processed(self, storage):
+        raw_id = storage.save_raw("some raw content", source="cli")
+        result = storage.mark_raw_processed(raw_id, ["episode:ep-1", "note:n-1"])
+        assert result is True
+
+    def test_mark_raw_processed_nonexistent(self, storage):
+        result = storage.mark_raw_processed("nonexistent-id", ["episode:ep-1"])
+        assert result is False
+
+    def test_delete_raw(self, storage):
+        raw_id = storage.save_raw("content to delete", source="cli")
+        result = storage.delete_raw(raw_id)
+        assert result is True
+
+    def test_delete_raw_nonexistent(self, storage):
+        result = storage.delete_raw("nonexistent-id")
+        assert result is False
+
+    def test_delete_raw_already_deleted(self, storage):
+        raw_id = storage.save_raw("content", source="cli")
+        storage.delete_raw(raw_id)
+        # Second delete should return False (already soft-deleted)
+        assert storage.delete_raw(raw_id) is False
+
+
+# ---------------------------------------------------------------------------
+# 8. Processing config: get_processing_config, set_processing_config
+# ---------------------------------------------------------------------------
+
+
+class TestProcessingConfig:
+    def test_get_empty(self, storage):
+        configs = storage.get_processing_config()
+        assert isinstance(configs, list)
+
+    def test_set_and_get(self, storage):
+        storage.set_processing_config(
+            "raw_to_episode",
+            enabled=True,
+            model_id="test-model",
+            quantity_threshold=5,
+            batch_size=10,
+        )
+        configs = storage.get_processing_config()
+        match = [c for c in configs if c["layer_transition"] == "raw_to_episode"]
+        assert len(match) == 1
+        assert match[0]["enabled"] is True
+        assert match[0]["model_id"] == "test-model"
+        assert match[0]["quantity_threshold"] == 5
+
+    def test_update_existing_config(self, storage):
+        storage.set_processing_config("raw_to_episode", enabled=True, batch_size=10)
+        storage.set_processing_config("raw_to_episode", enabled=False, batch_size=20)
+        configs = storage.get_processing_config()
+        match = [c for c in configs if c["layer_transition"] == "raw_to_episode"]
+        assert len(match) == 1
+        assert match[0]["enabled"] is False
+        assert match[0]["batch_size"] == 20
+
+    def test_set_returns_true(self, storage):
+        result = storage.set_processing_config("episode_to_belief")
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# 9. Audit & health: log_audit, log_health_check, get_health_check_stats
+# ---------------------------------------------------------------------------
+
+
+class TestAuditLog:
+    def test_log_audit_returns_id(self, storage):
+        audit_id = storage.log_audit(
+            memory_type="episode",
+            memory_id="ep-1",
+            operation="forget",
+            actor="core:test",
+        )
+        assert isinstance(audit_id, str)
+        assert len(audit_id) > 0
+
+    def test_log_audit_with_details(self, storage):
+        audit_id = storage.log_audit(
+            memory_type="belief",
+            memory_id="b-1",
+            operation="protect",
+            actor="plugin:test",
+            details={"reason": "core identity"},
+        )
+        assert isinstance(audit_id, str)
+
+    def test_log_audit_without_details(self, storage):
+        audit_id = storage.log_audit(
+            memory_type="value",
+            memory_id="v-1",
+            operation="verify",
+            actor="core:test",
+        )
+        assert isinstance(audit_id, str)
+
+
+class TestHealthCheck:
+    def test_log_health_check_returns_id(self, storage):
+        event_id = storage.log_health_check(anxiety_score=42, source="cli")
+        assert isinstance(event_id, str)
+        assert len(event_id) > 0
+
+    def test_get_stats_empty(self, storage):
+        stats = storage.get_health_check_stats()
+        assert stats["total_checks"] == 0
+        assert stats["avg_per_day"] == 0.0
+        assert stats["last_check_at"] is None
+        assert stats["last_anxiety_score"] is None
+        assert stats["checks_by_source"] == {}
+        assert stats["checks_by_trigger"] == {}
+
+    def test_get_stats_after_checks(self, storage):
+        storage.log_health_check(anxiety_score=30, source="cli", triggered_by="boot")
+        storage.log_health_check(anxiety_score=50, source="mcp", triggered_by="heartbeat")
+        storage.log_health_check(anxiety_score=10, source="cli", triggered_by="manual")
+
+        stats = storage.get_health_check_stats()
+        assert stats["total_checks"] == 3
+        assert stats["last_anxiety_score"] == 10
+        assert stats["last_check_at"] is not None
+        assert stats["checks_by_source"]["cli"] == 2
+        assert stats["checks_by_source"]["mcp"] == 1
+        assert stats["checks_by_trigger"]["boot"] == 1
+        assert stats["checks_by_trigger"]["heartbeat"] == 1
+        assert stats["checks_by_trigger"]["manual"] == 1
+
+
+# ---------------------------------------------------------------------------
+# 10. Memory marking: mark_episode_processed, mark_belief_processed
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryMarking:
+    def test_mark_episode_processed(self, storage):
+        episode = Episode(
+            id="ep-1",
+            stack_id="test-stack",
+            objective="test objective",
+            outcome="test outcome",
+        )
+        storage.save_episode(episode)
+        result = storage.mark_episode_processed("ep-1")
+        assert result is True
+
+    def test_mark_episode_processed_nonexistent(self, storage):
+        result = storage.mark_episode_processed("nonexistent-ep")
+        assert result is False
+
+    def test_mark_belief_processed(self, storage):
+        belief = Belief(
+            id="b-1",
+            stack_id="test-stack",
+            statement="test belief",
+        )
+        storage.save_belief(belief)
+        result = storage.mark_belief_processed("b-1")
+        assert result is True
+
+    def test_mark_belief_processed_nonexistent(self, storage):
+        result = storage.mark_belief_processed("nonexistent-b")
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# 11. Access tracking: record_access
+# ---------------------------------------------------------------------------
+
+
+class TestRecordAccess:
+    def test_record_access_episode(self, storage):
+        episode = Episode(
+            id="ep-access-1",
+            stack_id="test-stack",
+            objective="test",
+            outcome="test",
+        )
+        storage.save_episode(episode)
+        result = storage.record_access("episode", "ep-access-1")
+        assert result is True
+
+    def test_record_access_belief(self, storage):
+        belief = Belief(
+            id="b-access-1",
+            stack_id="test-stack",
+            statement="test belief",
+        )
+        storage.save_belief(belief)
+        result = storage.record_access("belief", "b-access-1")
+        assert result is True
+
+    def test_record_access_unknown_type(self, storage):
+        result = storage.record_access("unknown_type", "some-id")
+        assert result is False
+
+    def test_record_access_nonexistent_id(self, storage):
+        result = storage.record_access("episode", "nonexistent-id")
+        assert result is False
+
+    def test_record_access_increments_count(self, storage):
+        episode = Episode(
+            id="ep-count-1",
+            stack_id="test-stack",
+            objective="test",
+            outcome="test",
+        )
+        storage.save_episode(episode)
+        storage.record_access("episode", "ep-count-1")
+        storage.record_access("episode", "ep-count-1")
+        # Retrieve episode to verify times_accessed was incremented
+        episodes = storage.get_episodes()
+        ep = [e for e in episodes if e.id == "ep-count-1"][0]
+        assert ep.times_accessed == 2


### PR DESCRIPTION
## Summary
- Adds 193 new tests across 4 files targeting the lowest-coverage modules
- Pushes overall coverage from 69% to 72%, crossing the 70% CI threshold
- All 3239 tests pass, 0 failures

## New test files
| File | Tests | Module covered |
|------|-------|---------------|
| `test_cli_setup.py` | 36 | `_build_claude_code_hooks`, `setup_claude_code`, `_deep_merge`, `cmd_setup` |
| `test_processing.py` | 46 | `MemoryProcessor`, `evaluate_triggers`, all 7 transitions, `_parse_response` |
| `test_cli_doctor.py` | 53 | compliance checks, `detect_platform`, `check_claude_code_hook`, structural findings |
| `test_sqlite_coverage.py` | 58 | pure functions, boot config CRUD, stack settings, processing config, audit/health |

## Test plan
- [x] All 193 new tests pass individually
- [x] Full test suite passes (3239 passed, 2 skipped)
- [x] Coverage at 72% (above 70% threshold)
- [x] ruff + black pass
- [ ] CI pipeline confirms coverage >= 70%

🤖 Generated with [Claude Code](https://claude.com/claude-code)