### PR TITLE
fix: sync full silently dropped all non-delete push operations

### DIFF
--- a/kernle/cli/commands/sync.py
+++ b/kernle/cli/commands/sync.py
@@ -737,7 +737,7 @@ def cmd_sync(args, k: "Kernle"):
                                 "UPDATE sync_queue SET synced = 1 WHERE id = ?",
                                 (change.id,),
                             )
-                    continue
+                        continue
 
                 operations.append(op_data)
 


### PR DESCRIPTION
## Summary

- Fix critical bug where `kernle sync full` silently dropped all non-delete operations during push — only deletes were actually sent to the backend
- Replace placeholder `test_format_datetime_none` with a real test
- Add regression test verifying non-delete operations are included in sync full push payload

## Root Cause

In `sync.py` line 740, a `continue` statement was at the wrong indentation level — inside the `if op_type != "delete":` block but outside both branches of the `if record_dict: / else:` conditional. This caused every non-delete operation to hit `continue` and skip `operations.append()`, meaning only delete operations were ever pushed during full sync.

The standalone `push` command (line 357) had the `continue` correctly inside the `else` (orphan) branch — this was a copy-paste indentation error in the `full` sync path only.

## Test plan

- [x] New regression test `test_full_sync_pushes_non_delete_operations` — creates an episode, runs sync full, verifies the push payload contains the operation with record data
- [x] Fixed placeholder `test_format_datetime_none` — now exercises the None→null path through status JSON
- [x] 4,077 tests pass, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)