### PR TITLE
chore: add coverage governance to pyproject.toml and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ test-all:
 	pytest tests/ -v --tb=short
 
 test-cov:
-	pytest tests/ -v --tb=short --cov=kernle --cov-report=html --ignore=tests/test_postgres_storage.py
+	pytest tests/ -v --tb=short --cov=kernle --cov-branch --cov-report=html --cov-fail-under=73 --ignore=tests/test_postgres_storage.py
 
 lint:
 	ruff check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,12 @@ line-length = 100
 select = ["E", "F", "I", "N", "W"]
 ignore = ["E501"]
 
+[tool.coverage.run]
+branch = true
+
+[tool.coverage.report]
+fail_under = 73
+
 [tool.pytest.ini_options]
 markers = [
     "stub: marks tests that verify stub behavior (will need replacement with integration tests)",


### PR DESCRIPTION
## Summary

- Add `[tool.coverage.run]` and `[tool.coverage.report]` with `fail_under = 73` to pyproject.toml
- Update Makefile `test-cov` target with `--cov-branch --cov-fail-under=73`
- Both now match the existing CI threshold in `.github/workflows/test.yml`

Closes #450

## Test plan

- [x] `make test-cov` now fails if coverage drops below 73%
- [x] `pytest --cov=kernle` picks up branch coverage and fail-under from pyproject.toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)