### PR TITLE
fix: resolve source_type mismatch with canonical SourceType taxonomy

### DIFF
--- a/kernle/cli/commands/migrate.py
+++ b/kernle/cli/commands/migrate.py
@@ -388,6 +388,10 @@ def _migrate_backfill_provenance(args: "argparse.Namespace", k: "Kernle") -> Non
                     f"context:kernle_seed_v{SEED_BELIEFS_VERSION}"
                 ]
                 needs_update = True
+        elif source_type == "processed":
+            # Legacy "processed" value — migrate to canonical "processing"
+            new_source_type = "processing"
+            needs_update = True
         elif not source_type or source_type in ("unknown", ""):
             # Non-seed belief with no source — mark as direct_experience
             new_source_type = "direct_experience"
@@ -416,7 +420,10 @@ def _migrate_backfill_provenance(args: "argparse.Namespace", k: "Kernle") -> Non
         new_source_type = source_type
         new_derived_from = derived_from or []
 
-        if not source_type or source_type in ("unknown", ""):
+        if source_type == "processed":
+            new_source_type = "processing"
+            needs_update = True
+        elif not source_type or source_type in ("unknown", ""):
             new_source_type = "direct_experience"
             needs_update = True
 
@@ -449,7 +456,10 @@ def _migrate_backfill_provenance(args: "argparse.Namespace", k: "Kernle") -> Non
         new_source_type = source_type
         new_derived_from = derived_from or []
 
-        if not source_type or source_type in ("unknown", ""):
+        if source_type == "processed":
+            new_source_type = "processing"
+            needs_update = True
+        elif not source_type or source_type in ("unknown", ""):
             new_source_type = "direct_experience"
             needs_update = True
 

--- a/kernle/mcp/tool_definitions.py
+++ b/kernle/mcp/tool_definitions.py
@@ -6,15 +6,11 @@ Validators and handlers live in kernle.mcp.handlers.
 
 from mcp.types import Tool
 
-VALID_SOURCE_TYPES = [
-    "direct_experience",
-    "inference",
-    "consolidation",
-    "external",
-    "seed",
-    "observation",
-    "unknown",
-]
+from kernle.types import VALID_SOURCE_TYPE_VALUES
+
+# Re-export as a list for JSON Schema enum validation and backward compat.
+# Single source of truth is SourceType enum in kernle.types.
+VALID_SOURCE_TYPES = sorted(VALID_SOURCE_TYPE_VALUES)
 
 TOOLS = [
     Tool(

--- a/kernle/processing.py
+++ b/kernle/processing.py
@@ -596,7 +596,7 @@ class MemoryProcessor:
                         outcome_type=item.get("outcome_type", "neutral"),
                         lessons=item.get("lessons"),
                         created_at=now,
-                        source_type="processed",
+                        source_type="processing",
                         source_entity=f"core:{self._core_id}",
                         derived_from=derived_from,
                     )
@@ -612,7 +612,7 @@ class MemoryProcessor:
                         content=item["content"],
                         note_type=item.get("note_type", "observation"),
                         created_at=now,
-                        source_type="processed",
+                        source_type="processing",
                         source_entity=f"core:{self._core_id}",
                         derived_from=derived_from,
                     )
@@ -629,7 +629,7 @@ class MemoryProcessor:
                         belief_type=item.get("belief_type", "factual"),
                         confidence=item.get("confidence", 0.7),
                         created_at=now,
-                        source_type="processed",
+                        source_type="processing",
                         source_entity=f"core:{self._core_id}",
                         derived_from=derived_from,
                     )
@@ -647,7 +647,7 @@ class MemoryProcessor:
                         goal_type=item.get("goal_type", "task"),
                         priority=item.get("priority", "medium"),
                         created_at=now,
-                        source_type="processed",
+                        source_type="processing",
                         derived_from=derived_from,
                     )
                     gid = self._stack.save_goal(goal)
@@ -665,7 +665,7 @@ class MemoryProcessor:
                         notes=item.get("context_note"),
                         sentiment=item.get("sentiment", 0.0),
                         created_at=now,
-                        source_type="processed",
+                        source_type="processing",
                         derived_from=derived_from,
                     )
                     rid = self._stack.save_relationship(rel)
@@ -681,7 +681,7 @@ class MemoryProcessor:
                         statement=item.get("statement", item["name"]),
                         priority=item.get("priority", 50),
                         created_at=now,
-                        source_type="processed",
+                        source_type="processing",
                         derived_from=derived_from,
                     )
                     vid = self._stack.save_value(value)
@@ -696,7 +696,7 @@ class MemoryProcessor:
                         drive_type=item.get("drive_type", "motivation"),
                         intensity=item.get("intensity", 0.5),
                         created_at=now,
-                        source_type="processed",
+                        source_type="processing",
                         derived_from=derived_from,
                     )
                     did = self._stack.save_drive(drive)

--- a/kernle/types.py
+++ b/kernle/types.py
@@ -36,13 +36,25 @@ def parse_datetime(s: Optional[str]) -> Optional[datetime]:
 
 
 class SourceType(Enum):
-    """How a memory was created/acquired."""
+    """How a memory was created/acquired.
+
+    This is the single authoritative taxonomy for source_type values.
+    All components, CLI, MCP, and processing code must use these values.
+    """
 
     DIRECT_EXPERIENCE = "direct_experience"  # Directly observed/experienced
     INFERENCE = "inference"  # Inferred from other memories
     EXTERNAL = "external"  # Information received from another being (entity-neutral)
     CONSOLIDATION = "consolidation"  # Created during consolidation
+    PROCESSING = "processing"  # Created by automated memory processing/promotion
+    SEED = "seed"  # Initial seed memories provided at setup
+    OBSERVATION = "observation"  # Passive observation (not direct interaction)
     UNKNOWN = "unknown"  # Legacy or untracked
+
+
+# Canonical set of valid source_type string values, derived from the enum.
+# Use this for validation instead of maintaining separate lists.
+VALID_SOURCE_TYPE_VALUES = frozenset(st.value for st in SourceType)
 
 
 class SyncStatus(Enum):

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1312,7 +1312,7 @@ class TestWriteMemories:
         saved_ep = mock_stack.save_episode.call_args[0][0]
         assert saved_ep.objective == "learned things"
         assert saved_ep.derived_from == ["raw:r1", "raw:r2"]
-        assert saved_ep.source_type == "processed"
+        assert saved_ep.source_type == "processing"
 
     def test_write_raw_to_note(self):
         mock_stack = _make_mock_stack()

--- a/tests/test_source_type_taxonomy.py
+++ b/tests/test_source_type_taxonomy.py
@@ -1,0 +1,537 @@
+"""Tests for canonical SourceType taxonomy and validation.
+
+Covers:
+- SourceType enum has all canonical values
+- VALID_SOURCE_TYPE_VALUES is derived from the enum
+- VALID_SOURCE_TYPES in tool_definitions matches the enum
+- Strict mode rejects unknown source_type values
+- Strict mode accepts all canonical source_type values
+- Processing uses canonical "processing" (not "processed")
+- Migration handles legacy "processed" entries
+"""
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from kernle.protocols import ProvenanceError, StackState
+from kernle.stack.sqlite_stack import SQLiteStack
+from kernle.types import (
+    VALID_SOURCE_TYPE_VALUES,
+    Belief,
+    Drive,
+    Episode,
+    Goal,
+    Note,
+    RawEntry,
+    Relationship,
+    SourceType,
+    Value,
+)
+
+
+def _uid():
+    return str(uuid.uuid4())
+
+
+def _now():
+    return datetime.now(timezone.utc)
+
+
+# ---- SourceType Enum Completeness ----
+
+
+class TestSourceTypeEnum:
+    def test_all_canonical_values_present(self):
+        """SourceType enum contains all canonical values."""
+        expected = {
+            "direct_experience",
+            "inference",
+            "external",
+            "consolidation",
+            "processing",
+            "seed",
+            "observation",
+            "unknown",
+        }
+        actual = {st.value for st in SourceType}
+        assert actual == expected
+
+    def test_valid_source_type_values_matches_enum(self):
+        """VALID_SOURCE_TYPE_VALUES is derived from SourceType enum."""
+        enum_values = frozenset(st.value for st in SourceType)
+        assert VALID_SOURCE_TYPE_VALUES == enum_values
+
+    def test_valid_source_type_values_is_frozenset(self):
+        """VALID_SOURCE_TYPE_VALUES is immutable."""
+        assert isinstance(VALID_SOURCE_TYPE_VALUES, frozenset)
+
+    def test_processed_not_in_enum(self):
+        """The legacy 'processed' value is NOT in the canonical enum."""
+        assert "processed" not in VALID_SOURCE_TYPE_VALUES
+
+
+class TestToolDefinitionsAlignment:
+    def test_valid_source_types_matches_enum(self):
+        """MCP VALID_SOURCE_TYPES list matches the canonical enum."""
+        from kernle.mcp.tool_definitions import VALID_SOURCE_TYPES
+
+        assert set(VALID_SOURCE_TYPES) == VALID_SOURCE_TYPE_VALUES
+
+    def test_valid_source_types_is_sorted(self):
+        """MCP VALID_SOURCE_TYPES list is sorted for deterministic schema."""
+        from kernle.mcp.tool_definitions import VALID_SOURCE_TYPES
+
+        assert VALID_SOURCE_TYPES == sorted(VALID_SOURCE_TYPES)
+
+
+# ---- Strict Mode Validation ----
+
+
+@pytest.fixture
+def active_enforced_stack(tmp_path):
+    """Stack in ACTIVE state with provenance enforcement enabled."""
+    stack = SQLiteStack(
+        stack_id="test-strict",
+        db_path=tmp_path / "test.db",
+        components=[],
+        enforce_provenance=True,
+    )
+    # Create a raw entry for provenance (during INITIALIZING — no validation)
+    raw = RawEntry(id=_uid(), stack_id="test-strict", blob="test input", source="test")
+    raw_id = stack.save_raw(raw)
+    # Transition to ACTIVE via on_attach (triggers provenance enforcement)
+    stack.on_attach(core_id="test-core", inference=None)
+    stack._test_raw_id = raw_id
+    return stack
+
+
+class TestSourceTypeValidation:
+    """Strict mode rejects unknown source_type values."""
+
+    def test_reject_unknown_source_type_episode(self, active_enforced_stack):
+        ep = Episode(
+            id=_uid(),
+            stack_id="test-strict",
+            objective="Test",
+            outcome="Done",
+            source_type="bogus_type",
+            derived_from=[f"raw:{active_enforced_stack._test_raw_id}"],
+            created_at=_now(),
+        )
+        with pytest.raises(ProvenanceError, match="Unknown source_type 'bogus_type'"):
+            active_enforced_stack.save_episode(ep)
+
+    def test_reject_legacy_processed_source_type(self, active_enforced_stack):
+        """The legacy 'processed' value is rejected in strict mode."""
+        ep = Episode(
+            id=_uid(),
+            stack_id="test-strict",
+            objective="Test",
+            outcome="Done",
+            source_type="processed",
+            derived_from=[f"raw:{active_enforced_stack._test_raw_id}"],
+            created_at=_now(),
+        )
+        with pytest.raises(ProvenanceError, match="Unknown source_type 'processed'"):
+            active_enforced_stack.save_episode(ep)
+
+    def test_reject_unknown_source_type_belief(self, active_enforced_stack):
+        # Need an episode for belief provenance
+        ep = Episode(
+            id=_uid(),
+            stack_id="test-strict",
+            objective="Test",
+            outcome="Done",
+            source_type="direct_experience",
+            derived_from=[f"raw:{active_enforced_stack._test_raw_id}"],
+            created_at=_now(),
+        )
+        eid = active_enforced_stack.save_episode(ep)
+
+        belief = Belief(
+            id=_uid(),
+            stack_id="test-strict",
+            statement="Test belief",
+            source_type="invented_type",
+            derived_from=[f"episode:{eid}"],
+            created_at=_now(),
+        )
+        with pytest.raises(ProvenanceError, match="Unknown source_type 'invented_type'"):
+            active_enforced_stack.save_belief(belief)
+
+    def test_reject_unknown_source_type_note(self, active_enforced_stack):
+        note = Note(
+            id=_uid(),
+            stack_id="test-strict",
+            content="Test note",
+            source_type="made_up",
+            derived_from=[f"raw:{active_enforced_stack._test_raw_id}"],
+            created_at=_now(),
+        )
+        with pytest.raises(ProvenanceError, match="Unknown source_type 'made_up'"):
+            active_enforced_stack.save_note(note)
+
+    def test_reject_unknown_source_type_value(self, active_enforced_stack):
+        # Build provenance chain: raw -> episode -> belief -> value
+        ep = Episode(
+            id=_uid(),
+            stack_id="test-strict",
+            objective="Test",
+            outcome="Done",
+            source_type="direct_experience",
+            derived_from=[f"raw:{active_enforced_stack._test_raw_id}"],
+            created_at=_now(),
+        )
+        eid = active_enforced_stack.save_episode(ep)
+        belief = Belief(
+            id=_uid(),
+            stack_id="test-strict",
+            statement="Test",
+            source_type="inference",
+            derived_from=[f"episode:{eid}"],
+            created_at=_now(),
+        )
+        bid = active_enforced_stack.save_belief(belief)
+
+        value = Value(
+            id=_uid(),
+            stack_id="test-strict",
+            name="Test",
+            statement="Test value",
+            source_type="wrong",
+            derived_from=[f"belief:{bid}"],
+            created_at=_now(),
+        )
+        with pytest.raises(ProvenanceError, match="Unknown source_type 'wrong'"):
+            active_enforced_stack.save_value(value)
+
+    def test_reject_unknown_source_type_goal(self, active_enforced_stack):
+        ep = Episode(
+            id=_uid(),
+            stack_id="test-strict",
+            objective="Test",
+            outcome="Done",
+            source_type="direct_experience",
+            derived_from=[f"raw:{active_enforced_stack._test_raw_id}"],
+            created_at=_now(),
+        )
+        eid = active_enforced_stack.save_episode(ep)
+
+        goal = Goal(
+            id=_uid(),
+            stack_id="test-strict",
+            title="Test goal",
+            source_type="nope",
+            derived_from=[f"episode:{eid}"],
+            created_at=_now(),
+        )
+        with pytest.raises(ProvenanceError, match="Unknown source_type 'nope'"):
+            active_enforced_stack.save_goal(goal)
+
+    def test_reject_unknown_source_type_drive(self, active_enforced_stack):
+        ep = Episode(
+            id=_uid(),
+            stack_id="test-strict",
+            objective="Test",
+            outcome="Done",
+            source_type="direct_experience",
+            derived_from=[f"raw:{active_enforced_stack._test_raw_id}"],
+            created_at=_now(),
+        )
+        eid = active_enforced_stack.save_episode(ep)
+
+        drive = Drive(
+            id=_uid(),
+            stack_id="test-strict",
+            drive_type="curiosity",
+            source_type="invalid",
+            derived_from=[f"episode:{eid}"],
+            created_at=_now(),
+        )
+        with pytest.raises(ProvenanceError, match="Unknown source_type 'invalid'"):
+            active_enforced_stack.save_drive(drive)
+
+    def test_reject_unknown_source_type_relationship(self, active_enforced_stack):
+        ep = Episode(
+            id=_uid(),
+            stack_id="test-strict",
+            objective="Test",
+            outcome="Done",
+            source_type="direct_experience",
+            derived_from=[f"raw:{active_enforced_stack._test_raw_id}"],
+            created_at=_now(),
+        )
+        eid = active_enforced_stack.save_episode(ep)
+
+        rel = Relationship(
+            id=_uid(),
+            stack_id="test-strict",
+            entity_name="Alice",
+            entity_type="person",
+            relationship_type="collaborator",
+            source_type="fake",
+            derived_from=[f"episode:{eid}"],
+            created_at=_now(),
+        )
+        with pytest.raises(ProvenanceError, match="Unknown source_type 'fake'"):
+            active_enforced_stack.save_relationship(rel)
+
+
+class TestSourceTypeAcceptance:
+    """Strict mode accepts all canonical source_type values."""
+
+    @pytest.mark.parametrize(
+        "source_type",
+        [
+            "direct_experience",
+            "inference",
+            "external",
+            "consolidation",
+            "processing",
+            "seed",
+            "observation",
+            "unknown",
+        ],
+    )
+    def test_accept_canonical_source_type_episode(self, active_enforced_stack, source_type):
+        ep = Episode(
+            id=_uid(),
+            stack_id="test-strict",
+            objective="Test",
+            outcome="Done",
+            source_type=source_type,
+            derived_from=[f"raw:{active_enforced_stack._test_raw_id}"],
+            created_at=_now(),
+        )
+        eid = active_enforced_stack.save_episode(ep)
+        assert eid
+
+    @pytest.mark.parametrize(
+        "source_type",
+        [
+            "direct_experience",
+            "inference",
+            "external",
+            "consolidation",
+            "processing",
+            "seed",
+            "observation",
+            "unknown",
+        ],
+    )
+    def test_accept_canonical_source_type_belief(self, active_enforced_stack, source_type):
+        ep = Episode(
+            id=_uid(),
+            stack_id="test-strict",
+            objective="Test",
+            outcome="Done",
+            source_type="direct_experience",
+            derived_from=[f"raw:{active_enforced_stack._test_raw_id}"],
+            created_at=_now(),
+        )
+        eid = active_enforced_stack.save_episode(ep)
+        belief = Belief(
+            id=_uid(),
+            stack_id="test-strict",
+            statement="Test",
+            source_type=source_type,
+            derived_from=[f"episode:{eid}"],
+            created_at=_now(),
+        )
+        bid = active_enforced_stack.save_belief(belief)
+        assert bid
+
+
+class TestSourceTypeNoEnforcement:
+    """Without enforcement, unknown source_type values are allowed."""
+
+    def test_allow_unknown_without_enforcement(self, tmp_path):
+        stack = SQLiteStack(
+            stack_id="test-relaxed",
+            db_path=tmp_path / "test.db",
+            components=[],
+            enforce_provenance=False,
+        )
+        stack.on_attach(core_id="test-core", inference=None)
+        ep = Episode(
+            id=_uid(),
+            stack_id="test-relaxed",
+            objective="Test",
+            outcome="Done",
+            source_type="completely_made_up",
+            created_at=_now(),
+        )
+        eid = stack.save_episode(ep)
+        assert eid
+
+    def test_allow_unknown_during_initializing(self, tmp_path):
+        stack = SQLiteStack(
+            stack_id="test-init",
+            db_path=tmp_path / "test.db",
+            components=[],
+            enforce_provenance=True,
+        )
+        # Stack starts in INITIALIZING — unknown source_type should be allowed
+        assert stack._state == StackState.INITIALIZING
+        ep = Episode(
+            id=_uid(),
+            stack_id="test-init",
+            objective="Seed",
+            outcome="Done",
+            source_type="anything_goes_during_init",
+            created_at=_now(),
+        )
+        eid = stack.save_episode(ep)
+        assert eid
+
+
+class TestSourceTypeBatchValidation:
+    """Batch writes also validate source_type in strict mode."""
+
+    def test_reject_unknown_source_type_batch_episodes(self, active_enforced_stack):
+        episodes = [
+            Episode(
+                id=_uid(),
+                stack_id="test-strict",
+                objective="Test",
+                outcome="Done",
+                source_type="bad_value",
+                derived_from=[f"raw:{active_enforced_stack._test_raw_id}"],
+                created_at=_now(),
+            )
+        ]
+        with pytest.raises(ProvenanceError, match="Unknown source_type 'bad_value'"):
+            active_enforced_stack.save_episodes_batch(episodes)
+
+    def test_reject_unknown_source_type_batch_beliefs(self, active_enforced_stack):
+        ep = Episode(
+            id=_uid(),
+            stack_id="test-strict",
+            objective="Test",
+            outcome="Done",
+            source_type="direct_experience",
+            derived_from=[f"raw:{active_enforced_stack._test_raw_id}"],
+            created_at=_now(),
+        )
+        eid = active_enforced_stack.save_episode(ep)
+
+        beliefs = [
+            Belief(
+                id=_uid(),
+                stack_id="test-strict",
+                statement="Test",
+                source_type="nonsense",
+                derived_from=[f"episode:{eid}"],
+                created_at=_now(),
+            )
+        ]
+        with pytest.raises(ProvenanceError, match="Unknown source_type 'nonsense'"):
+            active_enforced_stack.save_beliefs_batch(beliefs)
+
+    def test_reject_unknown_source_type_batch_notes(self, active_enforced_stack):
+        notes = [
+            Note(
+                id=_uid(),
+                stack_id="test-strict",
+                content="Test",
+                source_type="garbage",
+                derived_from=[f"raw:{active_enforced_stack._test_raw_id}"],
+                created_at=_now(),
+            )
+        ]
+        with pytest.raises(ProvenanceError, match="Unknown source_type 'garbage'"):
+            active_enforced_stack.save_notes_batch(notes)
+
+
+# ---- Processing Uses Canonical Values ----
+
+
+class TestProcessingSourceType:
+    """Processing module uses canonical 'processing' value."""
+
+    def test_processing_write_memories_uses_processing(self):
+        """_write_memories sets source_type='processing', not 'processed'."""
+        from unittest.mock import MagicMock
+
+        from kernle.processing import MemoryProcessor
+
+        mock_stack = MagicMock()
+        mock_stack.stack_id = "test"
+        mock_stack.save_episode.return_value = "ep-1"
+        mock_inference = MagicMock()
+
+        processor = MemoryProcessor(
+            stack=mock_stack,
+            inference=mock_inference,
+            core_id="test-core",
+        )
+
+        parsed = [
+            {
+                "objective": "test",
+                "outcome": "done",
+                "outcome_type": "success",
+                "source_raw_ids": ["r1"],
+            }
+        ]
+        processor._write_memories("raw_to_episode", parsed, [])
+        saved_ep = mock_stack.save_episode.call_args[0][0]
+        assert saved_ep.source_type == "processing"
+        assert saved_ep.source_type != "processed"
+
+    def test_processing_all_transitions_use_processing(self):
+        """All transitions in _write_memories use 'processing' source_type."""
+        from unittest.mock import MagicMock
+
+        from kernle.processing import MemoryProcessor
+
+        mock_stack = MagicMock()
+        mock_stack.stack_id = "test"
+        mock_stack.save_episode.return_value = "ep-1"
+        mock_stack.save_note.return_value = "n-1"
+        mock_stack.save_belief.return_value = "b-1"
+        mock_stack.save_goal.return_value = "g-1"
+        mock_stack.save_relationship.return_value = "r-1"
+        mock_stack.save_value.return_value = "v-1"
+        mock_stack.save_drive.return_value = "d-1"
+        mock_inference = MagicMock()
+
+        processor = MemoryProcessor(
+            stack=mock_stack,
+            inference=mock_inference,
+            core_id="test-core",
+        )
+
+        transitions_and_data = [
+            ("raw_to_episode", {"objective": "t", "outcome": "d", "source_raw_ids": ["r1"]}),
+            ("raw_to_note", {"content": "note", "source_raw_ids": ["r1"]}),
+            ("episode_to_belief", {"statement": "b", "source_episode_ids": ["e1"]}),
+            ("episode_to_goal", {"title": "g", "source_episode_ids": ["e1"]}),
+            (
+                "episode_to_relationship",
+                {"entity_name": "Alice", "source_episode_ids": ["e1"]},
+            ),
+            ("belief_to_value", {"name": "v", "source_belief_ids": ["b1"]}),
+            ("episode_to_drive", {"drive_type": "curiosity", "source_episode_ids": ["e1"]}),
+        ]
+
+        save_methods = {
+            "raw_to_episode": mock_stack.save_episode,
+            "raw_to_note": mock_stack.save_note,
+            "episode_to_belief": mock_stack.save_belief,
+            "episode_to_goal": mock_stack.save_goal,
+            "episode_to_relationship": mock_stack.save_relationship,
+            "belief_to_value": mock_stack.save_value,
+            "episode_to_drive": mock_stack.save_drive,
+        }
+
+        for transition, data in transitions_and_data:
+            processor._write_memories(transition, [data], [])
+            method = save_methods[transition]
+            saved = method.call_args[0][0]
+            assert saved.source_type == "processing", (
+                f"Transition {transition} used source_type='{saved.source_type}' "
+                f"instead of 'processing'"
+            )

--- a/tests/test_stack_provenance.py
+++ b/tests/test_stack_provenance.py
@@ -152,7 +152,7 @@ class TestProvenanceOff:
             id=_uid(),
             stack_id="test-stack",
             statement="Test belief",
-            source_type="inferred",
+            source_type="inference",
             created_at=_now(),
         )
         belief_id = stack.save_belief(belief)
@@ -202,7 +202,7 @@ class TestProvenanceEnforced:
             id=_uid(),
             stack_id="test-stack",
             statement="Test belief",
-            source_type="inferred",
+            source_type="inference",
             created_at=_now(),
             derived_from=[f"episode:{episode_id}"],
         )
@@ -302,7 +302,7 @@ class TestProvenanceEnforced:
             id=_uid(),
             stack_id="test-stack",
             statement="From note",
-            source_type="inferred",
+            source_type="inference",
             created_at=_now(),
             derived_from=[f"note:{note_id}"],
         )
@@ -317,7 +317,7 @@ class TestProvenanceEnforced:
             id=_uid(),
             stack_id="test-stack",
             statement="Skip a layer",
-            source_type="inferred",
+            source_type="inference",
             created_at=_now(),
             derived_from=[f"raw:{raw_id}"],
         )
@@ -330,7 +330,7 @@ class TestProvenanceEnforced:
             id=_uid(),
             stack_id="test-stack",
             statement="No provenance",
-            source_type="inferred",
+            source_type="inference",
             created_at=_now(),
         )
         with pytest.raises(ProvenanceError, match="derived_from must cite"):
@@ -349,7 +349,7 @@ class TestProvenanceEnforced:
             stack_id="test-stack",
             name="honesty",
             statement="Value honesty",
-            source_type="inferred",
+            source_type="inference",
             created_at=_now(),
             derived_from=[f"belief:{belief_id}"],
         )
@@ -366,7 +366,7 @@ class TestProvenanceEnforced:
             stack_id="test-stack",
             name="honesty",
             statement="Value honesty",
-            source_type="inferred",
+            source_type="inference",
             created_at=_now(),
             derived_from=[f"episode:{ep_id}"],
         )
@@ -384,7 +384,7 @@ class TestProvenanceEnforced:
             id=_uid(),
             stack_id="test-stack",
             title="Test goal",
-            source_type="stated",
+            source_type="direct_experience",
             created_at=_now(),
             derived_from=[f"episode:{ep_id}"],
         )
@@ -401,7 +401,7 @@ class TestProvenanceEnforced:
             id=_uid(),
             stack_id="test-stack",
             title="Test goal",
-            source_type="stated",
+            source_type="direct_experience",
             created_at=_now(),
             derived_from=[f"belief:{belief_id}"],
         )
@@ -421,7 +421,7 @@ class TestProvenanceEnforced:
             entity_name="Alice",
             entity_type="human",
             relationship_type="colleague",
-            source_type="observed",
+            source_type="observation",
             created_at=_now(),
             derived_from=[f"episode:{ep_id}"],
         )
@@ -441,7 +441,7 @@ class TestProvenanceEnforced:
             entity_name="Bob",
             entity_type="human",
             relationship_type="colleague",
-            source_type="observed",
+            source_type="observation",
             created_at=_now(),
             derived_from=[f"belief:{belief_id}"],
         )
@@ -459,7 +459,7 @@ class TestProvenanceEnforced:
             id=_uid(),
             stack_id="test-stack",
             drive_type="curiosity",
-            source_type="inferred",
+            source_type="inference",
             created_at=_now(),
             derived_from=[f"episode:{ep_id}"],
         )
@@ -476,7 +476,7 @@ class TestProvenanceEnforced:
             id=_uid(),
             stack_id="test-stack",
             drive_type="curiosity",
-            source_type="inferred",
+            source_type="inference",
             created_at=_now(),
             derived_from=[f"belief:{belief_id}"],
         )
@@ -526,7 +526,7 @@ class TestProvenanceEnforced:
             id=_uid(),
             stack_id="test-stack",
             statement="From two episodes",
-            source_type="inferred",
+            source_type="inference",
             created_at=_now(),
             derived_from=[f"episode:{ep_id1}", f"episode:{ep_id2}"],
         )
@@ -544,7 +544,7 @@ class TestProvenanceEnforced:
             id=_uid(),
             stack_id="test-stack",
             statement="From episode and note",
-            source_type="inferred",
+            source_type="inference",
             created_at=_now(),
             derived_from=[f"episode:{ep_id}", f"note:{note_id}"],
         )
@@ -561,7 +561,7 @@ class TestProvenanceEnforced:
             id=_uid(),
             stack_id="test-stack",
             statement="One bad ref",
-            source_type="inferred",
+            source_type="inference",
             created_at=_now(),
             derived_from=[f"episode:{ep_id}", "raw:some-raw"],
         )
@@ -607,7 +607,7 @@ class TestMemoryExists:
             id=_uid(),
             stack_id="test-stack",
             statement="Test",
-            source_type="inferred",
+            source_type="inference",
             created_at=_now(),
         )
         belief_id = stack.save_belief(belief)
@@ -654,7 +654,7 @@ class TestSeedWrites:
             id=_uid(),
             stack_id="test-stack",
             statement="Post-seed belief",
-            source_type="inferred",
+            source_type="inference",
             created_at=_now(),
         )
         with pytest.raises(ProvenanceError):
@@ -704,7 +704,7 @@ class TestAnnotationRefs:
             id=_uid(),
             stack_id="test-stack",
             statement="Belief with context annotation",
-            source_type="inferred",
+            source_type="inference",
             derived_from=[
                 f"episode:{active_stack._test_ep_id}",
                 "context:cli",
@@ -720,7 +720,7 @@ class TestAnnotationRefs:
             id=_uid(),
             stack_id="test-stack",
             statement="Belief with kernle annotation",
-            source_type="inferred",
+            source_type="inference",
             derived_from=[
                 f"episode:{active_stack._test_ep_id}",
                 "kernle:system",
@@ -736,7 +736,7 @@ class TestAnnotationRefs:
             id=_uid(),
             stack_id="test-stack",
             statement="Only annotations",
-            source_type="inferred",
+            source_type="inference",
             derived_from=["context:cli", "kernle:system"],
             created_at=_now(),
         )
@@ -749,7 +749,7 @@ class TestAnnotationRefs:
             id=_uid(),
             stack_id="test-stack",
             statement="Context ref with colons",
-            source_type="inferred",
+            source_type="inference",
             derived_from=[
                 f"episode:{active_stack._test_ep_id}",
                 "context:kernle_seed_v2:batch_1",
@@ -766,7 +766,7 @@ class TestAnnotationRefs:
             stack_id="test-stack",
             objective="Episode with annotation",
             outcome="Done",
-            source_type="processed",
+            source_type="processing",
             derived_from=[
                 f"raw:{active_stack._test_raw_id}",
                 "context:consolidation",
@@ -918,7 +918,7 @@ class TestPluginProvenanceBypass:
             id=_uid(),
             stack_id="test",
             statement="Plugin belief",
-            source_type="inferred",
+            source_type="inference",
             derived_from=None,
             created_at=_now(),
         )
@@ -932,7 +932,7 @@ class TestPluginProvenanceBypass:
             id=_uid(),
             stack_id="test",
             statement="Spoofed plugin belief",
-            source_type="inferred",
+            source_type="inference",
             derived_from=None,
             created_at=_now(),
         )
@@ -946,7 +946,7 @@ class TestPluginProvenanceBypass:
             id=_uid(),
             stack_id="test",
             statement="Core belief",
-            source_type="inferred",
+            source_type="inference",
             derived_from=None,
             created_at=_now(),
         )
@@ -962,7 +962,7 @@ class TestPluginProvenanceBypass:
             title="Plugin goal",
             goal_type="task",
             priority="medium",
-            source_type="inferred",
+            source_type="inference",
             derived_from=None,
             created_at=_now(),
         )
@@ -977,7 +977,7 @@ class TestPluginProvenanceBypass:
             id=_uid(),
             stack_id="test",
             statement="Revoked plugin",
-            source_type="inferred",
+            source_type="inference",
             derived_from=None,
             created_at=_now(),
         )
@@ -992,7 +992,7 @@ class TestPluginProvenanceBypass:
             id=_uid(),
             stack_id="test",
             statement="Plugin belief in maintenance",
-            source_type="inferred",
+            source_type="inference",
             derived_from=None,
             created_at=_now(),
         )
@@ -1023,7 +1023,7 @@ class TestMaintenanceModeIndependence:
             id=_uid(),
             stack_id="test",
             statement="Should be blocked",
-            source_type="inferred",
+            source_type="inference",
             created_at=_now(),
         )
         with pytest.raises(MaintenanceModeError):
@@ -1098,7 +1098,7 @@ class TestBatchWriteProvenance:
                 id=_uid(),
                 stack_id="test",
                 statement="No provenance",
-                source_type="inferred",
+                source_type="inference",
                 derived_from=None,
                 created_at=_now(),
             )
@@ -1113,7 +1113,7 @@ class TestBatchWriteProvenance:
                 id=_uid(),
                 stack_id="test",
                 statement="Valid provenance",
-                source_type="inferred",
+                source_type="inference",
                 derived_from=[f"episode:{active_enforced_stack._test_ep_id}"],
                 created_at=_now(),
             )
@@ -1128,7 +1128,7 @@ class TestBatchWriteProvenance:
                 stack_id="test",
                 objective="No provenance",
                 outcome="Done",
-                source_type="processed",
+                source_type="processing",
                 derived_from=None,
                 created_at=_now(),
             )
@@ -1143,7 +1143,7 @@ class TestBatchWriteProvenance:
                 stack_id="test",
                 content="No provenance",
                 note_type="note",
-                source_type="processed",
+                source_type="processing",
                 derived_from=None,
                 created_at=_now(),
             )
@@ -1159,7 +1159,7 @@ class TestBatchWriteProvenance:
                 id=_uid(),
                 stack_id="test",
                 statement="Maintenance",
-                source_type="inferred",
+                source_type="inference",
                 derived_from=[f"episode:{active_enforced_stack._test_ep_id}"],
                 created_at=_now(),
             )
@@ -1221,7 +1221,7 @@ class TestStackScopedSettings:
             id=_uid(),
             stack_id="test",
             statement="No provenance",
-            source_type="inferred",
+            source_type="inference",
             created_at=_now(),
         )
         assert stack.save_belief(b1)
@@ -1234,7 +1234,7 @@ class TestStackScopedSettings:
             id=_uid(),
             stack_id="test",
             statement="No provenance after enable",
-            source_type="inferred",
+            source_type="inference",
             created_at=_now(),
         )
         with pytest.raises(ProvenanceError):
@@ -1247,7 +1247,7 @@ class TestStackScopedSettings:
             id=_uid(),
             stack_id="test",
             statement="Allowed again",
-            source_type="inferred",
+            source_type="inference",
             created_at=_now(),
         )
         assert stack.save_belief(b3)


### PR DESCRIPTION
## Summary

Closes #400

- **Single authoritative SourceType enum** in `types.py` with all canonical values: `direct_experience`, `inference`, `external`, `consolidation`, `processing`, `seed`, `observation`, `unknown`
- **Added `VALID_SOURCE_TYPE_VALUES`** frozenset derived from the enum — replaces the manually-maintained list in `tool_definitions.py`
- **Replaced all `source_type="processed"`** with `"processing"` in `processing.py` (7 occurrences across all layer transitions)
- **Added `_validate_source_type()`** in `SQLiteStack` — rejects unknown source_type values when `enforce_provenance=True` and stack is `ACTIVE`
- **Migration path**: `backfill-provenance` command now migrates existing `"processed"` entries to `"processing"` for beliefs, episodes, and notes
- **Fixed test values**: `"inferred"` -> `"inference"`, `"observed"` -> `"observation"`, `"stated"` -> `"direct_experience"` in existing tests

## Changes

| File | Change |
|------|--------|
| `kernle/types.py` | Add `PROCESSING`, `SEED`, `OBSERVATION` to `SourceType` enum; add `VALID_SOURCE_TYPE_VALUES` frozenset |
| `kernle/processing.py` | Replace 7x `source_type="processed"` with `"processing"` |
| `kernle/mcp/tool_definitions.py` | Derive `VALID_SOURCE_TYPES` from enum instead of manual list |
| `kernle/stack/sqlite_stack.py` | Add `_validate_source_type()` called from all save methods + batch saves |
| `kernle/cli/commands/migrate.py` | Add `"processed"` -> `"processing"` migration in `backfill-provenance` |
| `tests/test_source_type_taxonomy.py` | 37 new tests |
| `tests/test_stack_provenance.py` | Fix non-canonical source_type values in existing tests |
| `tests/test_processing.py` | Update assertion: `"processed"` -> `"processing"` |

## Test plan

- [x] 37 new tests in `test_source_type_taxonomy.py` covering:
  - Enum completeness (all 8 canonical values present)
  - `VALID_SOURCE_TYPE_VALUES` matches enum
  - MCP `VALID_SOURCE_TYPES` matches enum
  - Strict mode rejects unknown source_type for all 7 memory types
  - Strict mode rejects legacy `"processed"` value
  - Strict mode accepts all 8 canonical values (parametrized)
  - No enforcement allows unknown values
  - INITIALIZING state allows unknown values
  - Batch writes validate source_type
  - Processing module uses `"processing"` for all 7 transitions
- [x] All 262 tests in modified files pass
- [x] Full suite: 4494 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)