### PR TITLE
feat: add memory lint pass before commit (#402)

### DIFF
--- a/kernle/lint.py
+++ b/kernle/lint.py
@@ -1,0 +1,278 @@
+"""Memory lint — reject malformed or low-signal beliefs and values before commit.
+
+The pipeline can produce truncated/low-quality statements: value names that read
+like partial sentences, belief statements that are templated noise like
+"Value: Worked on ...", and other artifacts. Once stored, they contaminate
+retrieval forever.
+
+This module provides configurable lint rules that run before save_belief and
+save_value. On failure, the memory is redirected to a MemorySuggestion with
+resolution_reason indicating the lint failure, instead of being committed
+directly. This keeps the agent's structured memory clean while preserving
+the content for manual review.
+
+Lint rules are configurable via stack settings (key: "lint_rules") as a
+JSON object. Individual rules can be enabled/disabled and thresholds tuned.
+
+Example lint_rules setting:
+    {
+        "min_length": 10,
+        "max_length": 2000,
+        "check_fragments": true,
+        "check_prefix_artifacts": true,
+        "check_templated_noise": true,
+        "enabled": true
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Configuration
+# =============================================================================
+
+# Default lint configuration
+DEFAULT_LINT_CONFIG: Dict[str, Any] = {
+    "enabled": True,
+    "min_length": 10,
+    "max_length": 2000,
+    "check_fragments": True,
+    "check_prefix_artifacts": True,
+    "check_templated_noise": True,
+}
+
+# Prefix artifacts: patterns that look like the LLM echoed a field label
+# into the content itself. Case-insensitive matching.
+PREFIX_ARTIFACT_PATTERNS: List[re.Pattern] = [
+    re.compile(r"^(value|belief|goal|note|episode|statement|name)\s*:\s*", re.IGNORECASE),
+    re.compile(r"^(title|description|objective|outcome)\s*:\s*", re.IGNORECASE),
+]
+
+# Templated noise: content that looks like boilerplate or placeholder text.
+TEMPLATED_NOISE_PATTERNS: List[re.Pattern] = [
+    # "Worked on ...", "Updated ...", "Fixed ..." with no substance
+    re.compile(
+        r"^(worked on|updated|fixed|changed|modified|edited|added|removed)\s+\.{2,}", re.IGNORECASE
+    ),
+    # Placeholder ellipsis content
+    re.compile(r"^\.\.\.$"),
+    re.compile(r"^…$"),
+    # Content that is just "TODO" or "TBD" variants
+    re.compile(r"^(todo|tbd|fixme|xxx|placeholder|n/a|none|null|undefined)$", re.IGNORECASE),
+    # Repeated single character
+    re.compile(r"^(.)\1{4,}$"),
+    # Content that is only whitespace and punctuation
+    re.compile(r"^[\s\W]+$"),
+]
+
+# Fragment indicators: signs of truncated or incomplete text
+FRAGMENT_ENDINGS: List[str] = [
+    " the",
+    " a",
+    " an",
+    " and",
+    " or",
+    " but",
+    " with",
+    " for",
+    " to",
+    " in",
+    " on",
+    " at",
+    " by",
+    " of",
+    " is",
+    " was",
+    " are",
+    " were",
+    " that",
+    " which",
+    " when",
+    " if",
+    " as",
+]
+
+
+# =============================================================================
+# Result Type
+# =============================================================================
+
+
+@dataclass
+class LintResult:
+    """Result of running lint on a memory.
+
+    Attributes:
+        passed: Whether the content passed all lint checks.
+        failures: List of human-readable failure reason strings.
+        rule_name: The name of the first failing rule (for audit log).
+    """
+
+    passed: bool
+    failures: List[str] = field(default_factory=list)
+
+    @property
+    def rule_name(self) -> Optional[str]:
+        """Name of the first failing rule, or None if passed."""
+        if self.passed or not self.failures:
+            return None
+        return self.failures[0].split(":")[0].strip().lower().replace(" ", "_")
+
+    @property
+    def summary(self) -> str:
+        """One-line summary for audit log."""
+        if self.passed:
+            return "lint_passed"
+        return "; ".join(self.failures)
+
+
+# =============================================================================
+# Lint Functions
+# =============================================================================
+
+
+def get_lint_config(settings_getter=None) -> Dict[str, Any]:
+    """Get lint configuration from stack settings or use defaults.
+
+    Args:
+        settings_getter: Callable that takes a key and returns Optional[str].
+                        Typically stack.get_stack_setting.
+
+    Returns:
+        Merged lint configuration dict.
+    """
+    config = dict(DEFAULT_LINT_CONFIG)
+    if settings_getter:
+        raw = settings_getter("lint_rules")
+        if raw:
+            try:
+                overrides = json.loads(raw)
+                if isinstance(overrides, dict):
+                    config.update(overrides)
+            except (json.JSONDecodeError, TypeError):
+                logger.warning("Invalid lint_rules setting, using defaults")
+    return config
+
+
+def lint_text(text: str, config: Optional[Dict[str, Any]] = None) -> LintResult:
+    """Run lint rules against a text string.
+
+    This is the core lint function. It checks the text against all enabled
+    rules and returns a LintResult.
+
+    Args:
+        text: The text to lint (e.g., belief statement or value name).
+        config: Lint configuration dict. Uses DEFAULT_LINT_CONFIG if None.
+
+    Returns:
+        LintResult with passed=True if all checks pass.
+    """
+    if config is None:
+        config = DEFAULT_LINT_CONFIG
+
+    if not config.get("enabled", True):
+        return LintResult(passed=True)
+
+    failures: List[str] = []
+
+    # Strip for analysis but check original length
+    stripped = text.strip() if text else ""
+
+    # Rule 1: Minimum length
+    min_length = config.get("min_length", 10)
+    if len(stripped) < min_length:
+        failures.append(f"too_short: content is {len(stripped)} chars, minimum is {min_length}")
+
+    # Rule 2: Maximum length
+    max_length = config.get("max_length", 2000)
+    if len(stripped) > max_length:
+        failures.append(f"too_long: content is {len(stripped)} chars, maximum is {max_length}")
+
+    # Rule 3: Prefix artifacts
+    if config.get("check_prefix_artifacts", True):
+        for pattern in PREFIX_ARTIFACT_PATTERNS:
+            if pattern.match(stripped):
+                failures.append(
+                    f"prefix_artifact: content starts with field label pattern '{pattern.pattern}'"
+                )
+                break
+
+    # Rule 4: Templated noise
+    if config.get("check_templated_noise", True):
+        for pattern in TEMPLATED_NOISE_PATTERNS:
+            if pattern.match(stripped):
+                failures.append(
+                    f"templated_noise: content matches noise pattern '{pattern.pattern}'"
+                )
+                break
+
+    # Rule 5: Fragment detection (trailing incomplete phrases)
+    if config.get("check_fragments", True):
+        lower_stripped = stripped.lower()
+        for ending in FRAGMENT_ENDINGS:
+            if lower_stripped.endswith(ending):
+                failures.append(
+                    f"trailing_fragment: content ends with incomplete phrase '{ending.strip()}'"
+                )
+                break
+
+    return LintResult(passed=len(failures) == 0, failures=failures)
+
+
+def lint_belief(statement: str, config: Optional[Dict[str, Any]] = None) -> LintResult:
+    """Lint a belief statement.
+
+    Args:
+        statement: The belief's statement text.
+        config: Lint configuration dict.
+
+    Returns:
+        LintResult.
+    """
+    return lint_text(statement, config)
+
+
+def lint_value(name: str, statement: str, config: Optional[Dict[str, Any]] = None) -> LintResult:
+    """Lint a value's name and statement.
+
+    Both the name and statement are checked. The name has a reduced minimum
+    length (3 chars) since value names are typically short labels.
+
+    Args:
+        name: The value's name.
+        statement: The value's statement text.
+        config: Lint configuration dict.
+
+    Returns:
+        LintResult combining failures from both name and statement checks.
+    """
+    if config is None:
+        config = dict(DEFAULT_LINT_CONFIG)
+
+    failures: List[str] = []
+
+    if not config.get("enabled", True):
+        return LintResult(passed=True)
+
+    # Lint the name with a lower min length threshold
+    name_config = dict(config)
+    name_config["min_length"] = max(3, config.get("min_length", 10) // 3)
+    name_result = lint_text(name, name_config)
+    for f in name_result.failures:
+        failures.append(f"name: {f}")
+
+    # Lint the statement with full config
+    statement_result = lint_text(statement, config)
+    for f in statement_result.failures:
+        failures.append(f"statement: {f}")
+
+    return LintResult(passed=len(failures) == 0, failures=failures)

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -1,0 +1,766 @@
+"""Tests for memory lint — reject malformed or low-signal beliefs/values.
+
+Tests cover:
+- lint_text: core lint function with all rule types
+- lint_belief: belief-specific linting
+- lint_value: value-specific linting (name + statement)
+- Configuration: custom configs, disabled lint, settings-based config
+- Integration: lint in save_belief/save_value redirects to suggestions
+- Audit log: lint failures are surfaced in audit entries
+- Known-bad patterns: truncated, templated, fragment, prefix artifacts
+- Known-good patterns: valid beliefs and values pass lint
+"""
+
+import json
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from kernle.lint import (
+    DEFAULT_LINT_CONFIG,
+    LintResult,
+    get_lint_config,
+    lint_belief,
+    lint_text,
+    lint_value,
+)
+from kernle.stack import SQLiteStack
+from kernle.types import Belief, Episode, Value
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    return tmp_path / "test_lint.db"
+
+
+@pytest.fixture
+def stack(tmp_db):
+    """Stack with lint enabled (default), provenance OFF for simpler tests.
+
+    Transitions to ACTIVE state so lint is enforced (lint only runs in ACTIVE).
+    """
+    s = SQLiteStack(
+        stack_id="test-lint",
+        db_path=tmp_db,
+        components=[],
+        enforce_provenance=False,
+    )
+    # Transition to ACTIVE so lint runs
+    s.on_attach("test-core")
+    return s
+
+
+@pytest.fixture
+def stack_with_provenance(tmp_db):
+    """Stack with both lint and provenance enabled."""
+    return SQLiteStack(
+        stack_id="test-lint-prov",
+        db_path=tmp_db,
+        components=[],
+        enforce_provenance=True,
+    )
+
+
+def _make_belief(stack_id: str, statement: str, **overrides) -> Belief:
+    defaults = {
+        "id": str(uuid.uuid4()),
+        "stack_id": stack_id,
+        "statement": statement,
+        "belief_type": "fact",
+        "confidence": 0.8,
+        "created_at": datetime.now(timezone.utc),
+    }
+    defaults.update(overrides)
+    return Belief(**defaults)
+
+
+def _make_value(stack_id: str, name: str, statement: str, **overrides) -> Value:
+    defaults = {
+        "id": str(uuid.uuid4()),
+        "stack_id": stack_id,
+        "name": name,
+        "statement": statement,
+        "priority": 50,
+        "created_at": datetime.now(timezone.utc),
+    }
+    defaults.update(overrides)
+    return Value(**defaults)
+
+
+def _make_episode(stack_id: str, **overrides) -> Episode:
+    defaults = {
+        "id": str(uuid.uuid4()),
+        "stack_id": stack_id,
+        "objective": "Test objective",
+        "outcome": "Test outcome",
+        "created_at": datetime.now(timezone.utc),
+    }
+    defaults.update(overrides)
+    return Episode(**defaults)
+
+
+# ============================================================================
+# lint_text — Core Lint Function
+# ============================================================================
+
+
+class TestLintText:
+    """Tests for the core lint_text function."""
+
+    def test_valid_text_passes(self):
+        result = lint_text("This is a perfectly valid belief statement about the world.")
+        assert result.passed is True
+        assert result.failures == []
+
+    def test_empty_string_fails_min_length(self):
+        result = lint_text("")
+        assert result.passed is False
+        assert any("too_short" in f for f in result.failures)
+
+    def test_short_string_fails_min_length(self):
+        result = lint_text("short")
+        assert result.passed is False
+        assert any("too_short" in f for f in result.failures)
+
+    def test_exactly_min_length_passes(self):
+        result = lint_text("abcdefghij")  # 10 distinct chars
+        assert result.passed is True
+
+    def test_one_below_min_length_fails(self):
+        result = lint_text("abcdefghi")  # 9 chars
+        assert result.passed is False
+
+    def test_max_length_exceeded(self):
+        result = lint_text("x" * 2001)
+        assert result.passed is False
+        assert any("too_long" in f for f in result.failures)
+
+    def test_exactly_max_length_passes(self):
+        # Use a repeated phrase (not a single repeated character)
+        phrase = "This is a sentence. "
+        text = (phrase * (2000 // len(phrase) + 1))[:2000]
+        result = lint_text(text)
+        assert result.passed is True
+
+    # ---- Prefix artifact detection ----
+
+    def test_prefix_artifact_value_colon(self):
+        result = lint_text("Value: something about code quality")
+        assert result.passed is False
+        assert any("prefix_artifact" in f for f in result.failures)
+
+    def test_prefix_artifact_belief_colon(self):
+        result = lint_text("Belief: the system should be reliable")
+        assert result.passed is False
+        assert any("prefix_artifact" in f for f in result.failures)
+
+    def test_prefix_artifact_statement_colon(self):
+        result = lint_text("Statement: I prefer Python over Java")
+        assert result.passed is False
+        assert any("prefix_artifact" in f for f in result.failures)
+
+    def test_prefix_artifact_title_colon(self):
+        result = lint_text("Title: A valid goal that should not have a prefix")
+        assert result.passed is False
+        assert any("prefix_artifact" in f for f in result.failures)
+
+    def test_prefix_artifact_case_insensitive(self):
+        result = lint_text("BELIEF: the system should be reliable")
+        assert result.passed is False
+        assert any("prefix_artifact" in f for f in result.failures)
+
+    def test_no_prefix_artifact_for_normal_text(self):
+        """Text that starts with 'value' but not as a label should pass."""
+        result = lint_text("Valuing user feedback leads to better products")
+        assert not any("prefix_artifact" in f for f in result.failures)
+
+    # ---- Templated noise detection ----
+
+    def test_templated_noise_worked_on_ellipsis(self):
+        result = lint_text("Worked on ...")
+        assert result.passed is False
+        assert any("templated_noise" in f for f in result.failures)
+
+    def test_templated_noise_updated_ellipsis(self):
+        result = lint_text("Updated ...")
+        assert result.passed is False
+        assert any("templated_noise" in f for f in result.failures)
+
+    def test_templated_noise_just_ellipsis(self):
+        result = lint_text("...")
+        assert result.passed is False
+
+    def test_templated_noise_unicode_ellipsis(self):
+        result = lint_text("\u2026")
+        assert result.passed is False
+
+    def test_templated_noise_todo(self):
+        result = lint_text("TODO")
+        assert result.passed is False
+        assert any("templated_noise" in f for f in result.failures)
+
+    def test_templated_noise_placeholder(self):
+        result = lint_text("placeholder")
+        assert result.passed is False
+
+    def test_templated_noise_repeated_char(self):
+        result = lint_text("aaaaa")
+        assert result.passed is False
+
+    def test_templated_noise_only_punctuation(self):
+        result = lint_text("---!!! ???")
+        assert result.passed is False
+
+    def test_templated_noise_n_a(self):
+        result = lint_text("n/a")
+        assert result.passed is False
+
+    # ---- Fragment detection ----
+
+    def test_trailing_fragment_the(self):
+        result = lint_text("I should always consider the")
+        assert result.passed is False
+        assert any("trailing_fragment" in f for f in result.failures)
+
+    def test_trailing_fragment_and(self):
+        result = lint_text("Code quality is important and")
+        assert result.passed is False
+        assert any("trailing_fragment" in f for f in result.failures)
+
+    def test_trailing_fragment_with(self):
+        result = lint_text("Always test code with")
+        assert result.passed is False
+        assert any("trailing_fragment" in f for f in result.failures)
+
+    def test_trailing_fragment_to(self):
+        result = lint_text("The best approach is to")
+        assert result.passed is False
+        assert any("trailing_fragment" in f for f in result.failures)
+
+    def test_trailing_fragment_of(self):
+        result = lint_text("This is a matter of")
+        assert result.passed is False
+        assert any("trailing_fragment" in f for f in result.failures)
+
+    def test_no_fragment_for_complete_sentence(self):
+        result = lint_text("Good code is readable and maintainable.")
+        assert result.passed is True
+
+    def test_no_fragment_for_sentence_ending_with_word_containing_article(self):
+        """'together' ends with 'the' but is a complete word, not a fragment."""
+        result = lint_text("Teams work better together")
+        assert result.passed is True  # "together" != " the"
+
+    # ---- Multiple failures ----
+
+    def test_multiple_failures_reported(self):
+        result = lint_text("Value: x")
+        assert result.passed is False
+        assert len(result.failures) >= 2  # too_short + prefix_artifact
+
+    # ---- Configuration ----
+
+    def test_custom_min_length(self):
+        config = {**DEFAULT_LINT_CONFIG, "min_length": 5}
+        result = lint_text("hello", config)
+        assert result.passed is True
+
+    def test_disabled_lint_passes_everything(self):
+        config = {**DEFAULT_LINT_CONFIG, "enabled": False}
+        result = lint_text("", config)
+        assert result.passed is True
+
+    def test_disabled_fragments_check(self):
+        config = {**DEFAULT_LINT_CONFIG, "check_fragments": False}
+        result = lint_text("This is incomplete and", config)
+        assert not any("trailing_fragment" in f for f in result.failures)
+
+    def test_disabled_prefix_artifacts_check(self):
+        config = {**DEFAULT_LINT_CONFIG, "check_prefix_artifacts": False}
+        result = lint_text("Value: something valid enough in length", config)
+        assert not any("prefix_artifact" in f for f in result.failures)
+
+    def test_disabled_templated_noise_check(self):
+        config = {**DEFAULT_LINT_CONFIG, "check_templated_noise": False, "min_length": 1}
+        result = lint_text("TODO", config)
+        assert not any("templated_noise" in f for f in result.failures)
+
+
+# ============================================================================
+# lint_belief
+# ============================================================================
+
+
+class TestLintBelief:
+    """Tests for belief-specific linting."""
+
+    def test_valid_belief_passes(self):
+        result = lint_belief("Testing code early catches bugs before they compound.")
+        assert result.passed is True
+
+    def test_short_belief_fails(self):
+        result = lint_belief("short")
+        assert result.passed is False
+
+    def test_belief_with_prefix_artifact(self):
+        result = lint_belief("Belief: testing is important for code quality")
+        assert result.passed is False
+
+    def test_belief_fragment(self):
+        result = lint_belief("The most important thing about code quality is")
+        assert result.passed is False
+
+
+# ============================================================================
+# lint_value
+# ============================================================================
+
+
+class TestLintValue:
+    """Tests for value-specific linting (name + statement)."""
+
+    def test_valid_value_passes(self):
+        result = lint_value("Code Quality", "Writing clean, maintainable code is essential.")
+        assert result.passed is True
+
+    def test_short_name_fails(self):
+        result = lint_value("CQ", "Writing clean, maintainable code is essential.")
+        assert result.passed is False
+        assert any("name:" in f for f in result.failures)
+
+    def test_short_statement_fails(self):
+        result = lint_value("Code Quality", "short")
+        assert result.passed is False
+        assert any("statement:" in f for f in result.failures)
+
+    def test_both_name_and_statement_fail(self):
+        result = lint_value("CQ", "bad")
+        assert result.passed is False
+        assert any("name:" in f for f in result.failures)
+        assert any("statement:" in f for f in result.failures)
+
+    def test_name_prefix_artifact(self):
+        result = lint_value(
+            "Value: Code Quality", "Writing clean code is essential for long-term success."
+        )
+        assert result.passed is False
+        assert any("name:" in f and "prefix_artifact" in f for f in result.failures)
+
+    def test_statement_fragment(self):
+        result = lint_value("Code Quality", "The most important aspect of coding is the")
+        assert result.passed is False
+        assert any("statement:" in f and "trailing_fragment" in f for f in result.failures)
+
+
+# ============================================================================
+# LintResult
+# ============================================================================
+
+
+class TestLintResult:
+    """Tests for LintResult properties."""
+
+    def test_passed_result_properties(self):
+        result = LintResult(passed=True)
+        assert result.rule_name is None
+        assert result.summary == "lint_passed"
+
+    def test_failed_result_properties(self):
+        result = LintResult(passed=False, failures=["too_short: content is 3 chars, minimum is 10"])
+        assert result.rule_name == "too_short"
+        assert "too_short" in result.summary
+
+    def test_multiple_failures_summary(self):
+        result = LintResult(
+            passed=False,
+            failures=[
+                "too_short: content is 3 chars",
+                "prefix_artifact: starts with label",
+            ],
+        )
+        assert "too_short" in result.summary
+        assert "prefix_artifact" in result.summary
+
+
+# ============================================================================
+# get_lint_config
+# ============================================================================
+
+
+class TestGetLintConfig:
+    """Tests for configuration loading."""
+
+    def test_default_config_without_getter(self):
+        config = get_lint_config()
+        assert config == DEFAULT_LINT_CONFIG
+
+    def test_config_from_settings(self):
+        def getter(key):
+            if key == "lint_rules":
+                return json.dumps({"min_length": 20})
+            return None
+
+        config = get_lint_config(getter)
+        assert config["min_length"] == 20
+        assert config["enabled"] is True  # preserved from defaults
+
+    def test_invalid_json_falls_back_to_defaults(self):
+        def getter(key):
+            if key == "lint_rules":
+                return "not valid json"
+            return None
+
+        config = get_lint_config(getter)
+        assert config == DEFAULT_LINT_CONFIG
+
+    def test_none_setting_uses_defaults(self):
+        def getter(key):
+            return None
+
+        config = get_lint_config(getter)
+        assert config == DEFAULT_LINT_CONFIG
+
+
+# ============================================================================
+# Integration: save_belief with lint
+# ============================================================================
+
+
+class TestSaveBeliefLint:
+    """Tests for lint integration in SQLiteStack.save_belief."""
+
+    def test_valid_belief_saves_normally(self, stack):
+        belief = _make_belief(
+            stack.stack_id,
+            "Testing code early catches bugs before they compound in complexity.",
+        )
+        result_id = stack.save_belief(belief)
+        assert not result_id.startswith("suggestion:")
+        # Verify it was actually saved as a belief
+        beliefs = stack.get_beliefs()
+        assert len(beliefs) == 1
+        assert beliefs[0].statement == belief.statement
+
+    def test_short_belief_redirected_to_suggestion(self, stack):
+        belief = _make_belief(stack.stack_id, "short")
+        result_id = stack.save_belief(belief)
+        assert result_id.startswith("suggestion:")
+        # Verify no belief was saved
+        beliefs = stack.get_beliefs()
+        assert len(beliefs) == 0
+
+    def test_prefix_artifact_belief_redirected(self, stack):
+        belief = _make_belief(
+            stack.stack_id,
+            "Belief: testing is important for code quality and reliability",
+        )
+        result_id = stack.save_belief(belief)
+        assert result_id.startswith("suggestion:")
+
+    def test_fragment_belief_redirected(self, stack):
+        belief = _make_belief(
+            stack.stack_id,
+            "The most important thing about code quality is the",
+        )
+        result_id = stack.save_belief(belief)
+        assert result_id.startswith("suggestion:")
+
+    def test_templated_noise_belief_redirected(self, stack):
+        belief = _make_belief(stack.stack_id, "TODO")
+        result_id = stack.save_belief(belief)
+        assert result_id.startswith("suggestion:")
+
+    def test_redirected_suggestion_has_correct_fields(self, stack):
+        belief = _make_belief(stack.stack_id, "bad")
+        result_id = stack.save_belief(belief)
+        suggestion_id = result_id.replace("suggestion:", "")
+        # Get the suggestion from the backend
+        suggestion = stack._backend.get_suggestion(suggestion_id)
+        assert suggestion is not None
+        assert suggestion.memory_type == "belief"
+        assert suggestion.status == "rejected"
+        assert "lint_failed" in suggestion.resolution_reason
+        assert suggestion.content["statement"] == "bad"
+        assert suggestion.confidence == 0.0
+
+    def test_lint_failure_logged_to_audit(self, stack):
+        belief = _make_belief(stack.stack_id, "bad")
+        stack.save_belief(belief)
+        audit = stack.get_audit_log(operation="lint_rejected")
+        assert len(audit) == 1
+        entry = audit[0]
+        assert entry["operation"] == "lint_rejected"
+        assert entry["memory_type"] == "belief"
+        details = entry.get("details", {})
+        if isinstance(details, str):
+            details = json.loads(details)
+        assert "failures" in details
+        assert "redirected_to" in details
+
+    def test_lint_disabled_via_settings_saves_normally(self, stack):
+        stack.set_stack_setting("lint_rules", json.dumps({"enabled": False}))
+        belief = _make_belief(stack.stack_id, "bad")
+        result_id = stack.save_belief(belief)
+        assert not result_id.startswith("suggestion:")
+
+    def test_custom_min_length_via_settings(self, stack):
+        stack.set_stack_setting("lint_rules", json.dumps({"min_length": 3}))
+        belief = _make_belief(stack.stack_id, "ok!")
+        result_id = stack.save_belief(belief)
+        assert not result_id.startswith("suggestion:")
+
+    def test_derived_from_preserved_in_suggestion(self, stack):
+        belief = _make_belief(
+            stack.stack_id,
+            "bad",
+            derived_from=["episode:abc123", "note:def456"],
+        )
+        result_id = stack.save_belief(belief)
+        suggestion_id = result_id.replace("suggestion:", "")
+        suggestion = stack._backend.get_suggestion(suggestion_id)
+        assert "episode:abc123" in suggestion.source_raw_ids
+        assert "note:def456" in suggestion.source_raw_ids
+
+
+# ============================================================================
+# Integration: save_value with lint
+# ============================================================================
+
+
+class TestSaveValueLint:
+    """Tests for lint integration in SQLiteStack.save_value."""
+
+    def test_valid_value_saves_normally(self, stack):
+        value = _make_value(
+            stack.stack_id,
+            "Code Quality",
+            "Writing clean, maintainable code is essential for long-term success.",
+        )
+        result_id = stack.save_value(value)
+        assert not result_id.startswith("suggestion:")
+        values = stack.get_values()
+        assert len(values) == 1
+
+    def test_short_value_name_redirected(self, stack):
+        value = _make_value(
+            stack.stack_id,
+            "CQ",
+            "Writing clean, maintainable code is essential for long-term success.",
+        )
+        result_id = stack.save_value(value)
+        assert result_id.startswith("suggestion:")
+        values = stack.get_values()
+        assert len(values) == 0
+
+    def test_short_value_statement_redirected(self, stack):
+        value = _make_value(stack.stack_id, "Code Quality", "short")
+        result_id = stack.save_value(value)
+        assert result_id.startswith("suggestion:")
+
+    def test_value_name_prefix_artifact_redirected(self, stack):
+        value = _make_value(
+            stack.stack_id,
+            "Value: Code Quality",
+            "Writing clean, maintainable code is essential for long-term success.",
+        )
+        result_id = stack.save_value(value)
+        assert result_id.startswith("suggestion:")
+
+    def test_value_statement_fragment_redirected(self, stack):
+        value = _make_value(
+            stack.stack_id,
+            "Code Quality",
+            "The most important aspect of coding is the",
+        )
+        result_id = stack.save_value(value)
+        assert result_id.startswith("suggestion:")
+
+    def test_redirected_value_suggestion_has_name_and_statement(self, stack):
+        value = _make_value(stack.stack_id, "CQ", "bad")
+        result_id = stack.save_value(value)
+        suggestion_id = result_id.replace("suggestion:", "")
+        suggestion = stack._backend.get_suggestion(suggestion_id)
+        assert suggestion is not None
+        assert suggestion.memory_type == "value"
+        assert suggestion.content["name"] == "CQ"
+        assert suggestion.content["statement"] == "bad"
+
+    def test_value_lint_failure_logged_to_audit(self, stack):
+        value = _make_value(stack.stack_id, "CQ", "bad")
+        stack.save_value(value)
+        audit = stack.get_audit_log(operation="lint_rejected")
+        assert len(audit) == 1
+        assert audit[0]["memory_type"] == "value"
+
+
+# ============================================================================
+# Known-Good Patterns (should always pass)
+# ============================================================================
+
+
+class TestKnownGoodPatterns:
+    """Patterns that must always pass lint."""
+
+    @pytest.mark.parametrize(
+        "statement",
+        [
+            "Testing code early catches bugs before they compound in complexity.",
+            "Clear variable naming improves readability more than comments do.",
+            "Pair programming produces fewer defects per line of code written.",
+            "Incremental refactoring is safer than big-bang rewrites of existing systems.",
+            "Automated tests provide confidence when making changes to unfamiliar code.",
+            "Code reviews distribute knowledge across the team and catch blind spots.",
+            "Simple solutions are easier to debug, maintain, and extend over time.",
+            "Monitoring production systems reveals problems before users report them.",
+            "Documentation decays unless it is treated as code and tested regularly.",
+            "Frequent small deployments reduce risk compared to large batched releases.",
+        ],
+    )
+    def test_good_belief_passes(self, statement):
+        result = lint_belief(statement)
+        assert result.passed is True, f"Good belief rejected: {result.failures}"
+
+    @pytest.mark.parametrize(
+        "name,statement",
+        [
+            (
+                "Code Quality",
+                "Writing clean, maintainable code is essential for long-term success.",
+            ),
+            (
+                "Collaboration",
+                "Working together produces better outcomes than working in isolation.",
+            ),
+            ("Continuous Learning", "Investing in learning new skills keeps capabilities current."),
+            ("User Empathy", "Understanding user needs leads to better product decisions."),
+            ("Reliability", "Systems should be designed to handle failures gracefully."),
+        ],
+    )
+    def test_good_value_passes(self, name, statement):
+        result = lint_value(name, statement)
+        assert result.passed is True, f"Good value rejected: {result.failures}"
+
+
+# ============================================================================
+# Known-Bad Patterns (should always fail)
+# ============================================================================
+
+
+class TestKnownBadPatterns:
+    """Patterns that must always fail lint."""
+
+    @pytest.mark.parametrize(
+        "statement,expected_failure",
+        [
+            # Truncated / too short
+            ("", "too_short"),
+            ("hi", "too_short"),
+            ("test", "too_short"),
+            # Prefix artifacts
+            ("Value: Worked on the API integration pipeline", "prefix_artifact"),
+            ("Belief: Code should be clean and readable always", "prefix_artifact"),
+            ("Statement: I prefer declarative programming styles", "prefix_artifact"),
+            ("Goal: improve the testing infrastructure for CI", "prefix_artifact"),
+            ("Name: refactoring the authentication module soon", "prefix_artifact"),
+            # Templated noise
+            ("Worked on ...", "templated_noise"),
+            ("Updated ...", "templated_noise"),
+            ("Fixed ...", "templated_noise"),
+            ("TODO", "templated_noise"),
+            ("placeholder", "templated_noise"),
+            ("n/a", "templated_noise"),
+            # Trailing fragments
+            ("The system should always handle the", "trailing_fragment"),
+            ("We need to focus on improving the quality of", "trailing_fragment"),
+            ("This feature was designed to work with", "trailing_fragment"),
+            ("The primary benefit of this approach is", "trailing_fragment"),
+        ],
+    )
+    def test_bad_belief_fails(self, statement, expected_failure):
+        result = lint_belief(statement)
+        assert result.passed is False, f"Bad belief passed: '{statement}'"
+        assert any(
+            expected_failure in f for f in result.failures
+        ), f"Expected '{expected_failure}' failure, got: {result.failures}"
+
+    @pytest.mark.parametrize(
+        "name,statement,expected_failure",
+        [
+            ("CQ", "Writing clean code is essential for long-term success.", "name:"),
+            ("x", "A valid statement about code quality and maintainability.", "name:"),
+            ("Value: Quality", "Valid statement about software engineering practices.", "name:"),
+            ("Quality", "bad", "statement:"),
+            ("Quality", "Belief: something about code quality standards", "statement:"),
+        ],
+    )
+    def test_bad_value_fails(self, name, statement, expected_failure):
+        result = lint_value(name, statement)
+        assert result.passed is False, f"Bad value passed: name='{name}', statement='{statement}'"
+        assert any(
+            expected_failure in f for f in result.failures
+        ), f"Expected '{expected_failure}' failure, got: {result.failures}"
+
+
+# ============================================================================
+# Lifecycle state interaction
+# ============================================================================
+
+
+class TestLintLifecycleState:
+    """Test that lint only runs in ACTIVE state, not INITIALIZING."""
+
+    def test_lint_skipped_in_initializing_state(self, tmp_path):
+        """In INITIALIZING state (seed data), lint should NOT run."""
+        db = tmp_path / "test_init.db"
+        stack = SQLiteStack(
+            stack_id="test-init",
+            db_path=db,
+            components=[],
+            enforce_provenance=False,
+        )
+        # Stack starts in INITIALIZING — lint should be skipped
+        belief = _make_belief(stack.stack_id, "bad")
+        result_id = stack.save_belief(belief)
+        # Should save normally, not redirect
+        assert not result_id.startswith("suggestion:")
+
+    def test_lint_runs_after_attach(self, tmp_path):
+        """After on_attach, stack transitions to ACTIVE and lint runs."""
+        db = tmp_path / "test_attach.db"
+        stack = SQLiteStack(
+            stack_id="test-attach",
+            db_path=db,
+            components=[],
+            enforce_provenance=False,
+        )
+        stack.on_attach("test-core")
+        belief = _make_belief(stack.stack_id, "bad")
+        result_id = stack.save_belief(belief)
+        assert result_id.startswith("suggestion:")
+
+
+# ============================================================================
+# Provenance + Lint interaction
+# ============================================================================
+
+
+class TestProvenanceLintInteraction:
+    """Test that provenance validation runs before lint (provenance errors
+    should take priority over lint failures)."""
+
+    def test_provenance_error_before_lint(self, stack_with_provenance):
+        """If provenance is enforced, provenance errors fire before lint."""
+        stack = stack_with_provenance
+        # Transition from INITIALIZING to ACTIVE
+        stack.on_attach("test-core")
+        belief = _make_belief(stack.stack_id, "bad", derived_from=None)
+        # Should get provenance error, not lint redirect
+        from kernle.protocols import ProvenanceError
+
+        with pytest.raises(ProvenanceError):
+            stack.save_belief(belief)

--- a/tests/test_source_type_taxonomy.py
+++ b/tests/test_source_type_taxonomy.py
@@ -188,7 +188,7 @@ class TestSourceTypeValidation:
         belief = Belief(
             id=_uid(),
             stack_id="test-strict",
-            statement="Test",
+            statement="This is a sufficiently long test belief statement for lint",
             source_type="inference",
             derived_from=[f"episode:{eid}"],
             created_at=_now(),
@@ -198,8 +198,8 @@ class TestSourceTypeValidation:
         value = Value(
             id=_uid(),
             stack_id="test-strict",
-            name="Test",
-            statement="Test value",
+            name="Test Value Name",
+            statement="This is a sufficiently long test value statement for lint",
             source_type="wrong",
             derived_from=[f"belief:{bid}"],
             created_at=_now(),


### PR DESCRIPTION
## Summary

- Add `kernle/lint.py` with configurable validation rules for memory quality: minimum/maximum length, prefix artifact detection (e.g. "Value: ..."), templated noise patterns (e.g. "TODO", "Worked on ..."), and trailing fragment detection
- Integrate lint into `save_belief` and `save_value` in `SQLiteStack` — on lint failure, content is redirected to a `MemorySuggestion` with `resolution_reason` indicating the specific lint failure, instead of being committed directly
- Lint only runs in ACTIVE state (not during INITIALIZING seed writes or MAINTENANCE), matching the provenance enforcement pattern
- Lint failures are surfaced in the audit log via `lint_rejected` operation entries
- All lint rules are configurable via the `lint_rules` stack setting (JSON), allowing individual rules to be enabled/disabled and thresholds tuned

### Lint Rules

| Rule | What it catches | Example |
|------|----------------|---------|
| `min_length` | Too-short content | `"bad"`, `""` |
| `max_length` | Excessively long content | 2000+ chars |
| `check_prefix_artifacts` | LLM echoing field labels | `"Value: Worked on ..."`, `"Belief: code should..."` |
| `check_templated_noise` | Placeholder/boilerplate | `"TODO"`, `"n/a"`, `"Worked on ..."`, `"..."` |
| `check_fragments` | Truncated sentences | `"The most important thing is the"` |

### Configuration

```json
// Stack setting: lint_rules
{
  "enabled": true,
  "min_length": 10,
  "max_length": 2000,
  "check_fragments": true,
  "check_prefix_artifacts": true,
  "check_templated_noise": true
}
```

## Test plan

- [x] 110 new tests in `tests/test_lint.py`
- [x] Core lint function tests for all 5 rule types
- [x] Known-good patterns (10 beliefs, 5 values) always pass
- [x] Known-bad patterns (20+ cases) always fail with correct failure type
- [x] Integration tests: save_belief/save_value redirect to suggestions on lint failure
- [x] Audit log entries created for lint rejections
- [x] Configuration override via stack settings
- [x] Lint disabled via settings saves normally
- [x] Lifecycle state tests: lint skipped in INITIALIZING, runs in ACTIVE
- [x] Provenance + lint interaction: provenance errors take priority
- [x] Full test suite passes (4567 passed, 0 regressions)

Closes #402

Generated with [Claude Code](https://claude.com/claude-code)