### PR TITLE
feat: add no-inference safe-mode for identity-layer writes

### DIFF
--- a/kernle/cli/__main__.py
+++ b/kernle/cli/__main__.py
@@ -1075,6 +1075,11 @@ def main():
     process_run.add_argument(
         "--force", "-f", action="store_true", help="Process even if thresholds aren't met"
     )
+    process_run.add_argument(
+        "--allow-no-inference-override",
+        action="store_true",
+        help="Allow identity-layer writes without inference (except values). Requires --force.",
+    )
     process_run.add_argument("--json", "-j", action="store_true", help="Output as JSON")
 
     process_status = process_sub.add_parser(

--- a/kernle/core/writers.py
+++ b/kernle/core/writers.py
@@ -384,16 +384,22 @@ class WritersMixin:
             for e in entries
         ]
 
-    def process(self, transition=None, force=False):
-        """Run memory processing. Requires a bound model.
+    def process(self, transition=None, force=False, allow_no_inference_override=False):
+        """Run memory processing.
 
         Promotes memories up the hierarchy using the bound model:
         raw -> episode/note, episode -> belief/goal/relationship/drive,
         belief -> value.
 
+        When no model is bound, identity-layer transitions are blocked
+        by the no-inference safety policy. Values can never be created
+        without inference.
+
         Args:
             transition: Specific layer transition to process (None = check all)
             force: Process even if triggers aren't met
+            allow_no_inference_override: Allow identity-layer writes without
+                inference (except values). Only effective with force=True.
 
         Returns:
             List of ProcessingResult for each transition that ran
@@ -401,7 +407,11 @@ class WritersMixin:
         entity = self.entity
         if entity is None:
             raise RuntimeError("process() requires Entity (use SQLite storage)")
-        return entity.process(transition=transition, force=force)
+        return entity.process(
+            transition=transition,
+            force=force,
+            allow_no_inference_override=allow_no_inference_override,
+        )
 
     def process_raw(
         self,

--- a/kernle/mcp/tool_definitions.py
+++ b/kernle/mcp/tool_definitions.py
@@ -836,7 +836,7 @@ TOOLS = [
     ),
     Tool(
         name="memory_process",
-        description="Run memory processing to promote memories up the hierarchy using the bound model. Transitions: raw->episode, raw->note, episode->belief, episode->goal, episode->relationship, belief->value, episode->drive. Requires a bound model.",
+        description="Run memory processing to promote memories up the hierarchy using the bound model. Transitions: raw->episode, raw->note, episode->belief, episode->goal, episode->relationship, belief->value, episode->drive. When no model is bound, identity-layer transitions (belief, value, goal, relationship, drive) are blocked by the no-inference safety policy.",
         inputSchema={
             "type": "object",
             "properties": {
@@ -856,6 +856,11 @@ TOOLS = [
                 "force": {
                     "type": "boolean",
                     "description": "Process even if trigger thresholds aren't met (default: false)",
+                    "default": False,
+                },
+                "allow_no_inference_override": {
+                    "type": "boolean",
+                    "description": "Allow identity-layer writes without inference (except values, which are always blocked). Requires force=true. Use with caution.",
                     "default": False,
                 },
             },


### PR DESCRIPTION
## Summary

Closes #399.

- When inference is unavailable, identity-layer transitions (beliefs, values, goals, relationships, drives) are blocked by a pipeline safety policy
- Values can **never** be created without inference (highest identity layer)
- Other identity layers can be overridden with explicit `force=True` + `allow_no_inference_override=True`
- Raw transitions (raw_to_episode, raw_to_note) are not policy-blocked
- `force` processing now respects inference availability -- no silent promotion to identity layers
- Entity.process() no longer raises RuntimeError when no model is bound; it uses safety gates instead

## Changes

- `kernle/processing.py`: Add `IDENTITY_LAYER_TRANSITIONS`, `NO_OVERRIDE_TRANSITIONS`, `OVERRIDE_TRANSITIONS` constants; `inference_available` flag on MemoryProcessor; `_check_inference_safety()` gating method; `inference_blocked` field on ProcessingResult
- `kernle/entity.py`: Entity.process() passes `inference_available` and `allow_no_inference_override` to MemoryProcessor
- `kernle/core/writers.py`: Kernle.process() compat layer forwards new parameter
- `kernle/cli/__main__.py`: Add `--allow-no-inference-override` CLI flag
- `kernle/cli/commands/process.py`: Display BLOCKED status for inference-gated results
- `kernle/mcp/handlers/processing.py`: Validate and pass `allow_no_inference_override` parameter
- `kernle/mcp/tool_definitions.py`: Add `allow_no_inference_override` to MCP schema
- Tests: 28 new tests covering inference-on/off behaviors, override mechanics, Entity integration

## Test plan

- [x] 160 processing tests pass (28 new)
- [x] 31 process trigger tests pass (updated 3 for new behavior)
- [x] Full suite: 4484 passed, 2 skipped

Generated with [Claude Code](https://claude.com/claude-code)