### PR TITLE
fix: add allow_no_inference_override to CoreProtocol.process()

### DIFF
--- a/kernle/protocols.py
+++ b/kernle/protocols.py
@@ -1756,13 +1756,30 @@ class CoreProtocol(Protocol):
         transition: Optional[str] = None,
         *,
         force: bool = False,
+        allow_no_inference_override: bool = False,
         auto_promote: bool = False,
     ) -> list:
         """Run memory processing sessions.
 
         By default, creates suggestions for review rather than directly
         promoting memories. Set auto_promote=True to directly write memories.
-        Returns list of ProcessingResult for each transition that ran.
+
+        When no model is bound (inference unavailable), identity-layer
+        transitions are blocked by the no-inference safety policy.
+        Values can never be created without inference. Other identity
+        layers require explicit override with force=True and
+        allow_no_inference_override=True.
+
+        Args:
+            transition: Specific layer transition to process (None = check all)
+            force: Process even if triggers aren't met
+            allow_no_inference_override: Allow identity-layer writes without
+                inference (except values). Only effective with force=True.
+            auto_promote: If True, directly write memories. If False (default),
+                create suggestions for review.
+
+        Returns:
+            List of ProcessingResult for each transition that ran.
         """
         ...
 


### PR DESCRIPTION
## Summary
- Adds missing `allow_no_inference_override: bool = False` parameter to `CoreProtocol.process()` in `protocols.py`
- Both `Entity.process()` and `WritersMixin.process()` already accept this parameter, but the protocol definition was missing it — an API contract drift
- Updates the docstring to match the implementations, documenting the no-inference safety policy

## Test plan
- [x] All 4930 tests pass (2 skipped), no regressions
- [x] Pre-commit hooks pass (ruff, black, secrets checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)