### PR TITLE
Fix stale deduplicated metric leak in suggestions mode

### DIFF
--- a/kernle/processing.py
+++ b/kernle/processing.py
@@ -1335,6 +1335,7 @@ class MemoryProcessor:
         from kernle.types import MemorySuggestion
 
         suggestions_created: List[Dict[str, str]] = []
+        self._last_deduplicated = 0
         self._last_gate_blocked = 0
         self._last_gate_details: List[str] = []
         now = datetime.now(timezone.utc)


### PR DESCRIPTION
## Summary
- `_write_suggestions()` reset `_last_gate_blocked` and `_last_gate_details` but not `_last_deduplicated`, causing subsequent suggestion-mode runs to report stale dedup counts from a previous `auto_promote=True` run
- Added `self._last_deduplicated = 0` reset in `_write_suggestions()` to match the existing pattern for other counters
- Added 2 regression tests: unit test on `_write_suggestions()` directly, and full integration test (promote with dedup -> suggestions mode -> verify deduplicated==0)

## Test plan
- [x] Unit test: `_write_suggestions()` resets `_last_deduplicated` to 0 after prior `_write_memories()` set it > 0
- [x] Integration test: full pipeline — auto_promote run with dedup, then suggestions run reports `deduplicated=0`
- [x] All 4948 tests pass (2 skipped), no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)