### PR TITLE
fix: add missing 'modified' status to MCP suggestion schemas

### DIFF
--- a/kernle/mcp/handlers/sync.py
+++ b/kernle/mcp/handlers/sync.py
@@ -9,6 +9,7 @@ from kernle.mcp.sanitize import (
     validate_enum,
     validate_number,
 )
+from kernle.types import VALID_SUGGESTION_STATUSES
 
 # ---------------------------------------------------------------------------
 # Validators
@@ -29,7 +30,7 @@ def _validate_suggestion_list_args(
         sanitized["status"] = None
     else:
         sanitized["status"] = validate_enum(
-            status, "status", ["pending", "promoted", "rejected", "dismissed", "expired"], "pending"
+            status, "status", sorted(VALID_SUGGESTION_STATUSES), "pending"
         )
     memory_type = arguments.get("memory_type")
     if memory_type:
@@ -162,6 +163,8 @@ def handle_memory_suggestions_list(args: Dict[str, Any], k: Kernle) -> str:
             "promoted": "+",
             "modified": "*",
             "rejected": "x",
+            "dismissed": "-",
+            "expired": "~",
         }
         icon = status_icons.get(s["status"], "?")
         type_label = s["memory_type"][:3].upper()

--- a/kernle/mcp/tool_definitions.py
+++ b/kernle/mcp/tool_definitions.py
@@ -701,7 +701,15 @@ TOOLS = [
             "properties": {
                 "status": {
                     "type": "string",
-                    "enum": ["pending", "promoted", "rejected", "dismissed", "expired", "all"],
+                    "enum": [
+                        "pending",
+                        "promoted",
+                        "modified",
+                        "rejected",
+                        "dismissed",
+                        "expired",
+                        "all",
+                    ],
                     "description": "Filter by status (default: pending)",
                     "default": "pending",
                 },
@@ -807,7 +815,15 @@ TOOLS = [
             "properties": {
                 "status": {
                     "type": "string",
-                    "enum": ["pending", "promoted", "rejected", "dismissed", "expired", "all"],
+                    "enum": [
+                        "pending",
+                        "promoted",
+                        "modified",
+                        "rejected",
+                        "dismissed",
+                        "expired",
+                        "all",
+                    ],
                     "description": "Filter by status (default: pending)",
                     "default": "pending",
                 },

--- a/kernle/types.py
+++ b/kernle/types.py
@@ -824,6 +824,13 @@ class MemorySuggestion:
     deleted: bool = False
 
 
+# Canonical set of valid suggestion status values.
+# Use this for validation instead of maintaining separate lists.
+VALID_SUGGESTION_STATUSES = frozenset(
+    ["pending", "promoted", "modified", "rejected", "dismissed", "expired"]
+)
+
+
 @dataclass
 class SearchResult:
     """A search result with relevance score."""


### PR DESCRIPTION
## Summary
- Storage sets suggestion status to `modified` when promoted with content changes, but MCP tool definition enums and the shared validator omitted it — clients couldn't filter by that state
- Added `modified` to status enums in both `memory_suggestions_list` and `suggestion_list` tool schemas
- Added `VALID_SUGGESTION_STATUSES` canonical constant in `types.py` (mirrors `VALID_SOURCE_TYPE_VALUES` pattern) and wired the validator to use it
- Added `dismissed`/`expired` icons to handler `status_icons` dict for complete display coverage
- Added 3 consistency tests verifying schema enums match `VALID_SUGGESTION_STATUSES`; updated existing validator test to cover all 6 statuses

## Test plan
- [x] 3 new tests in `TestMCPSuggestionStatusConsistency` verify schema/validator alignment with canonical constant
- [x] Existing validator test updated to cover all 6 statuses
- [x] Full test suite passes (4949 passed, 2 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)