### PR TITLE
fix: suggestion acceptance broken under strict/provenance mode

### DIFF
--- a/kernle/stack/sqlite_stack.py
+++ b/kernle/stack/sqlite_stack.py
@@ -768,8 +768,8 @@ class SQLiteStack(
         memory_id = None
         memory_type = suggestion.memory_type
 
-        # Build provenance: derived_from the source raw entries
-        derived_from = suggestion.source_raw_ids or []
+        # Build provenance: derived_from the source raw entries with raw: prefix
+        derived_from = [f"raw:{rid}" for rid in (suggestion.source_raw_ids or [])]
 
         if memory_type == "episode":
             ep = Episode(
@@ -781,7 +781,8 @@ class SQLiteStack(
                 lessons=content.get("lessons", []),
                 tags=["auto-suggested"],
                 derived_from=derived_from,
-                source_type="suggestion",
+                source_type="processing",
+                source_entity="kernle:suggestion-promotion",
                 created_at=datetime.now(timezone.utc),
             )
             memory_id = self.save_episode(ep)
@@ -793,7 +794,8 @@ class SQLiteStack(
                 belief_type=content.get("belief_type", "fact"),
                 confidence=content.get("confidence", 0.7),
                 derived_from=derived_from,
-                source_type="suggestion",
+                source_type="processing",
+                source_entity="kernle:suggestion-promotion",
                 created_at=datetime.now(timezone.utc),
             )
             memory_id = self.save_belief(belief)
@@ -807,7 +809,8 @@ class SQLiteStack(
                 reason=content.get("reason"),
                 tags=["auto-suggested"],
                 derived_from=derived_from,
-                source_type="suggestion",
+                source_type="processing",
+                source_entity="kernle:suggestion-promotion",
                 created_at=datetime.now(timezone.utc),
             )
             memory_id = self.save_note(note)


### PR DESCRIPTION
## Summary
- **P0 fix**: `accept_suggestion()` was raising `ProvenanceError` when `enforce_provenance=True` (the default since v0.10.0)
- Three root causes: bare UUIDs in `derived_from` (missing `raw:` prefix), invalid `source_type="suggestion"` (not in `SourceType` enum), and beliefs promoted from raw entries violating the provenance hierarchy
- Fix uses `source_entity="kernle:suggestion-promotion"` to mark suggestion acceptance as a system operation, `source_type="processing"` (canonical value), and properly prefixed `raw:` refs
- Kernle compat layer now delegates to the stack's `accept_suggestion` in strict mode

## Files changed
- `kernle/stack/sqlite_stack.py` — fix `derived_from` prefix, `source_type`, add `source_entity`
- `kernle/features/suggestions.py` — add strict-mode delegation, fix `derived_from`/`source_type` for non-strict path
- `tests/test_suggestion_resolution.py` — 11 new tests covering provenance-enforced acceptance for all memory types, modifications, multiple source raws, and Kernle strict mode

## Test plan
- [x] All 3 memory types (episode, belief, note) pass with `enforce_provenance=True`
- [x] Modifications work with provenance enforced
- [x] Multiple source_raw_ids properly prefixed
- [x] Kernle compat layer with `strict=True` delegates correctly
- [x] Full test suite passes (4954 tests, 0 failures)

Generated with [Claude Code](https://claude.com/claude-code)