### PR TITLE
fix: promotion gates no longer consume sources when blocked

### DIFF
--- a/kernle/processing.py
+++ b/kernle/processing.py
@@ -843,9 +843,10 @@ class MemoryProcessor:
         result.gate_blocked = getattr(self, "_last_gate_blocked", 0)
         result.gate_details = getattr(self, "_last_gate_details", [])
 
-        # 8. Mark sources as processed
+        # 8. Mark sources as processed (only if something was actually created)
         created_or_suggested = result.created or result.suggestions
-        self._mark_processed(transition, sources, created_or_suggested)
+        if created_or_suggested:
+            self._mark_processed(transition, sources, created_or_suggested)
 
         # 9. Log audit
         self._stack.log_audit(

--- a/tests/test_pipeline_golden.py
+++ b/tests/test_pipeline_golden.py
@@ -64,9 +64,9 @@ EXPECTED_COUNTS_INFERENCE_ON = {
     "notes": 2,  # mock model produces 2 notes from raw_to_note
     "beliefs": 0,  # blocked by promotion gate (evidence < belief_min_evidence=3)
     "values": 0,  # blocked: no beliefs exist to promote to values
-    "goals": 0,  # episodes already processed by episode_to_belief (none left for goals)
-    "relationships": 0,  # episodes already processed (none left for relationships)
-    "drives": 0,  # episodes already processed (none left for drives)
+    "goals": 1,  # gate-blocked episodes stay unprocessed, available for goal promotion
+    "relationships": 0,  # episodes consumed by episode_to_goal (none left)
+    "drives": 0,  # episodes consumed by episode_to_goal (none left)
 }
 
 # Expected memory counts when inference is off (no model bound).


### PR DESCRIPTION
## Summary
- **Bug:** When promotion gate checks failed (e.g., insufficient evidence for belief creation), sources were still marked as processed, permanently removing them from future promotion attempts
- **Fix:** Sources are only marked processed when at least one memory or suggestion is actually created, allowing gate-blocked sources to be retried when conditions improve
- **Updated golden snapshot:** `episode_to_goal` now correctly produces 1 goal from episodes that were previously consumed by the gate-blocked `episode_to_belief` transition

## Test plan
- [x] Gate blocks all items -> sources remain unprocessed (integration test with real stack)
- [x] Gate allows promotion -> sources marked processed as before
- [x] Previously blocked sources can be promoted after conditions improve (relaxed gate)
- [x] Suggestion mode: gate-blocked items also leave sources unprocessed
- [x] Unit test: `_mark_processed` not called when gate blocks all items
- [x] Existing `TestMarkProcessed` test updated to use `_NO_GATES` (was relying on buggy behavior)
- [x] Golden pipeline snapshot updated for correct new behavior
- [x] Full test suite: 4951 passed, 2 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)