### PR TITLE
fix: resolve ordering starvation in check_triggers and _gather_sources

### DIFF
--- a/kernle/processing.py
+++ b/kernle/processing.py
@@ -585,8 +585,7 @@ class MemoryProcessor:
             "episode_to_relationship",
             "episode_to_drive",
         ):
-            episodes = self._stack.get_episodes(limit=config.quantity_threshold + 1)
-            unprocessed = [e for e in episodes if not e.processed]
+            unprocessed = backend.get_episodes(limit=config.quantity_threshold + 1, processed=False)
             cumulative_valence = _cumulative_arousal(unprocessed)
             hours_since_last = _hours_since_oldest_episode(unprocessed, now)
             return evaluate_triggers(
@@ -598,8 +597,7 @@ class MemoryProcessor:
             )
 
         if transition == "belief_to_value":
-            beliefs = self._stack.get_beliefs(limit=config.quantity_threshold + 1)
-            unprocessed = [b for b in beliefs if not getattr(b, "processed", False)]
+            unprocessed = backend.get_beliefs(limit=config.quantity_threshold + 1, processed=False)
             hours_since_last = _hours_since_oldest_belief(unprocessed, now)
             return evaluate_triggers(
                 transition,
@@ -885,12 +883,10 @@ class MemoryProcessor:
             "episode_to_relationship",
             "episode_to_drive",
         ):
-            episodes = self._stack.get_episodes(limit=batch_size * 2)
-            return [e for e in episodes if not e.processed][:batch_size]
+            return backend.get_episodes(limit=batch_size, processed=False)
 
         if transition == "belief_to_value":
-            beliefs = self._stack.get_beliefs(limit=batch_size * 2)
-            return [b for b in beliefs if not getattr(b, "processed", False)][:batch_size]
+            return backend.get_beliefs(limit=batch_size, processed=False)
 
         return []
 

--- a/kernle/storage/base.py
+++ b/kernle/storage/base.py
@@ -71,9 +71,20 @@ class Storage(Protocol):
 
     @abstractmethod
     def get_episodes(
-        self, limit: int = 100, since: Optional[datetime] = None, tags: Optional[List[str]] = None
+        self,
+        limit: int = 100,
+        since: Optional[datetime] = None,
+        tags: Optional[List[str]] = None,
+        processed: Optional[bool] = None,
     ) -> List[Episode]:
-        """Get episodes, optionally filtered."""
+        """Get episodes, optionally filtered.
+
+        Args:
+            limit: Maximum number of episodes to return
+            since: Only return episodes created after this time
+            tags: Filter by tags
+            processed: If True, only processed; if False, only unprocessed; None = all
+        """
         ...
 
     @abstractmethod
@@ -142,12 +153,18 @@ class Storage(Protocol):
         ...
 
     @abstractmethod
-    def get_beliefs(self, limit: int = 100, include_inactive: bool = False) -> List[Belief]:
+    def get_beliefs(
+        self,
+        limit: int = 100,
+        include_inactive: bool = False,
+        processed: Optional[bool] = None,
+    ) -> List[Belief]:
         """Get beliefs.
 
         Args:
             limit: Maximum number of beliefs to return
             include_inactive: If True, include superseded/archived beliefs
+            processed: If True, only processed; if False, only unprocessed; None = all
         """
         ...
 


### PR DESCRIPTION
## Summary
- `check_triggers()` and `_gather_sources()` fetched recent records with a SQL LIMIT, then filtered for `processed=False` in Python. If the most recent items were already processed, older unprocessed records were invisible (ordering starvation).
- Added `processed` filter parameter to `Storage.get_episodes()` and `Storage.get_beliefs()` backend methods, enabling SQL-level filtering.
- Updated `check_triggers()` and `_gather_sources()` to query unprocessed items directly via `backend.get_episodes(processed=False)` and `backend.get_beliefs(processed=False)`, matching the existing pattern for `list_raw(processed=False)`.

## Test plan
- [x] 6 new integration tests in `TestOrderingStarvation` class verifying:
  - `check_triggers` finds old unprocessed episodes/beliefs even with many processed recent ones
  - `_gather_sources` returns old unprocessed episodes/beliefs correctly
  - `SQLiteStorage.get_episodes(processed=True/False/None)` filters correctly
  - `SQLiteStorage.get_beliefs(processed=True/False/None)` filters correctly
- [x] Updated 11 existing mock-based tests in `test_trigger_wiring.py` to use `backend.get_episodes` instead of `stack.get_episodes`
- [x] Updated existing mock-based tests in `test_processing.py` for consistency
- [x] Full suite: 4951 passed, 2 skipped

Generated with [Claude Code](https://claude.com/claude-code)