### PR TITLE
style: fix black formatting

### DIFF
--- a/kernle/core/writers.py
+++ b/kernle/core/writers.py
@@ -384,7 +384,9 @@ class WritersMixin:
             for e in entries
         ]
 
-    def process(self, transition=None, force=False, allow_no_inference_override=False, auto_promote=False):
+    def process(
+        self, transition=None, force=False, allow_no_inference_override=False, auto_promote=False
+    ):
         """Run memory processing.
 
         By default, creates suggestions for review rather than directly

--- a/tests/test_process_triggers.py
+++ b/tests/test_process_triggers.py
@@ -44,7 +44,10 @@ class TestKernleProcess:
 
         result = k.process(transition="raw_to_episode", force=True)
         mock_entity.process.assert_called_once_with(
-            transition="raw_to_episode", force=True, allow_no_inference_override=False, auto_promote=False
+            transition="raw_to_episode",
+            force=True,
+            allow_no_inference_override=False,
+            auto_promote=False,
         )
         assert result == []
 


### PR DESCRIPTION
Fix black formatting in `kernle/core/writers.py` and `tests/test_process_triggers.py` — CI failure on main.