### PR TITLE
fix: replace tautological test assertion (#534)

### DIFF
--- a/tests/test_stack_components.py
+++ b/tests/test_stack_components.py
@@ -287,7 +287,8 @@ class TestNoStorage:
         component.attach("stack-001")
         result = component.on_maintenance()
         assert isinstance(result, dict)
-        assert result.get("skipped") is True or "reason" in result.get("skipped", "") or True
+        assert result.get("skipped") is True
+        assert isinstance(result.get("reason"), str) and result["reason"]
 
     @pytest.mark.parametrize("cls", ALL_COMPONENTS)
     def test_on_save_without_storage(self, cls):


### PR DESCRIPTION
## Summary

- Fixed `test_stack_components.py` line 290 where `... or True` made the assertion always pass
- Replaced with proper checks: `result.get("skipped") is True` and `isinstance(result.get("reason"), str)`
- All 7 parameterized `test_on_maintenance_without_storage` cases verified

Closes #534

## Test plan

- [x] `test_on_maintenance_without_storage` — 7/7 pass
- [x] Full suite: 5,076 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)