### PR TITLE
fix: reject non-local HTTP URLs in CLI sync (#536)

### DIFF
--- a/tests/test_sync_url_validation.py
+++ b/tests/test_sync_url_validation.py
@@ -1,0 +1,37 @@
+"""Tests for _validate_backend_url in CLI sync module."""
+
+from kernle.cli.commands.sync import _validate_backend_url
+
+
+class TestValidateBackendUrl:
+    """URL validation prevents bearer tokens leaking over plaintext HTTP."""
+
+    def test_https_url_passes(self):
+        assert _validate_backend_url("https://api.example.com") == "https://api.example.com"
+
+    def test_http_localhost_passes(self):
+        assert _validate_backend_url("http://localhost:8000") == "http://localhost:8000"
+
+    def test_http_127_0_0_1_passes(self):
+        assert _validate_backend_url("http://127.0.0.1:8000") == "http://127.0.0.1:8000"
+
+    def test_http_localhost_no_port_passes(self):
+        assert _validate_backend_url("http://localhost") == "http://localhost"
+
+    def test_http_remote_rejected(self):
+        assert _validate_backend_url("http://evil.example.com") is None
+
+    def test_ftp_scheme_rejected(self):
+        assert _validate_backend_url("ftp://example.com") is None
+
+    def test_empty_string_returns_none(self):
+        assert _validate_backend_url("") is None
+
+    def test_none_returns_none(self):
+        assert _validate_backend_url(None) is None
+
+    def test_https_with_port_passes(self):
+        assert _validate_backend_url("https://api.example.com:443") == "https://api.example.com:443"
+
+    def test_http_remote_with_port_rejected(self):
+        assert _validate_backend_url("http://evil.example.com:8080") is None


### PR DESCRIPTION
## Summary

- Added `_validate_backend_url()` to `cli/commands/sync.py`, mirroring `CloudClient._validate_backend_url()` from `storage/cloud.py`
- Non-localhost `http://` URLs are now rejected before any auth headers are sent
- 10 new tests in `tests/test_sync_url_validation.py`

Closes #536

## Test plan

- [x] HTTPS URLs pass validation
- [x] `http://localhost` and `http://127.0.0.1` pass
- [x] `http://evil.example.com` rejected
- [x] Invalid schemes (`ftp://`) rejected
- [x] Full suite: 5,083 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)