### PR TITLE
fix: remove duplicate MCP suggestion tool families (#535)

### DIFF
--- a/kernle/mcp/handlers/sync.py
+++ b/kernle/mcp/handlers/sync.py
@@ -1,4 +1,4 @@
-"""Handlers for sync/suggestion tools: sync, suggestions_list/promote/reject/extract."""
+"""Handlers for sync/suggestion tools: sync, suggestion_list/accept/dismiss/extract."""
 
 import json
 from typing import Any, Dict
@@ -66,185 +66,6 @@ def _validate_suggestion_list_args(
     return sanitized
 
 
-def validate_memory_suggestions_list(arguments: Dict[str, Any]) -> Dict[str, Any]:
-    return _validate_suggestion_list_args(arguments, include_format=True)
-
-
-def validate_memory_suggestions_promote(arguments: Dict[str, Any]) -> Dict[str, Any]:
-    sanitized: Dict[str, Any] = {}
-    sanitized["suggestion_id"] = sanitize_string(
-        arguments.get("suggestion_id"), "suggestion_id", 100, required=True
-    )
-    sanitized["objective"] = (
-        sanitize_string(arguments.get("objective"), "objective", 1000, required=False) or None
-    )
-    sanitized["outcome"] = (
-        sanitize_string(arguments.get("outcome"), "outcome", 1000, required=False) or None
-    )
-    sanitized["statement"] = (
-        sanitize_string(arguments.get("statement"), "statement", 1000, required=False) or None
-    )
-    sanitized["content"] = (
-        sanitize_string(arguments.get("content"), "content", 2000, required=False) or None
-    )
-    return sanitized
-
-
-def validate_memory_suggestions_reject(arguments: Dict[str, Any]) -> Dict[str, Any]:
-    sanitized: Dict[str, Any] = {}
-    sanitized["suggestion_id"] = sanitize_string(
-        arguments.get("suggestion_id"), "suggestion_id", 100, required=True
-    )
-    sanitized["reason"] = (
-        sanitize_string(arguments.get("reason"), "reason", 500, required=False) or None
-    )
-    return sanitized
-
-
-def validate_memory_suggestions_extract(arguments: Dict[str, Any]) -> Dict[str, Any]:
-    sanitized: Dict[str, Any] = {}
-    sanitized["limit"] = int(validate_number(arguments.get("limit"), "limit", 1, 200, 50))
-    return sanitized
-
-
-# ---------------------------------------------------------------------------
-# Handlers
-# ---------------------------------------------------------------------------
-
-
-def handle_memory_sync(args: Dict[str, Any], k: Kernle) -> str:
-    sync_result = k.sync()
-    lines = ["Sync complete:"]
-    lines.append(f"  Pushed: {sync_result.get('pushed', 0)}")
-    lines.append(f"  Pulled: {sync_result.get('pulled', 0)}")
-    if sync_result.get("conflicts"):
-        lines.append(f"  Conflicts: {sync_result['conflicts']}")
-    if sync_result.get("errors"):
-        lines.append(f"  Errors: {len(sync_result['errors'])}")
-        for err in sync_result["errors"][:3]:
-            lines.append(f"    - {err}")
-    return "\n".join(lines)
-
-
-def handle_memory_suggestions_list(args: Dict[str, Any], k: Kernle) -> str:
-    status = args.get("status")
-    memory_type = args.get("memory_type")
-    limit = args.get("limit", 20)
-    format_type = args.get("format", "text")
-
-    suggestions = k.get_suggestions(
-        status=status,
-        memory_type=memory_type,
-        limit=limit,
-        min_confidence=args.get("min_confidence"),
-        max_age_hours=args.get("max_age_hours"),
-        source_raw_id=args.get("source_raw_id"),
-    )
-
-    if not suggestions:
-        status_str = f" {status}" if status else ""
-        return f"No{status_str} suggestions found."
-
-    if format_type == "json":
-        return json.dumps(suggestions, indent=2, default=str)
-
-    # Group counts
-    pending = sum(1 for s in suggestions if s["status"] == "pending")
-    promoted = sum(1 for s in suggestions if s["status"] in ("promoted", "modified"))
-    rejected = sum(1 for s in suggestions if s["status"] == "rejected")
-
-    lines = [f"Memory Suggestions ({len(suggestions)} total)\n"]
-    if not status:  # Show breakdown only for unfiltered list
-        lines.append(f"Pending: {pending} | Approved: {promoted} | Rejected: {rejected}\n")
-
-    for s in suggestions:
-        status_icons = {
-            "pending": "?",
-            "promoted": "+",
-            "modified": "*",
-            "rejected": "x",
-            "dismissed": "-",
-            "expired": "~",
-        }
-        icon = status_icons.get(s["status"], "?")
-        type_label = s["memory_type"][:3].upper()
-
-        content = s.get("content", {})
-        if s["memory_type"] == "episode":
-            preview = content.get("objective", "")[:50]
-        elif s["memory_type"] == "belief":
-            preview = content.get("statement", "")[:50]
-        else:
-            preview = content.get("content", "")[:50]
-
-        lines.append(f"[{icon}] {s['id'][:8]} [{type_label}] {s['confidence']:.0%}: {preview}...")
-
-        if s.get("promoted_to"):
-            lines.append(f"    -> {s['promoted_to']}")
-
-    return "\n".join(lines)
-
-
-def handle_memory_suggestions_promote(args: Dict[str, Any], k: Kernle) -> str:
-    suggestion_id = args["suggestion_id"]
-
-    modifications = {}
-    if args.get("objective"):
-        modifications["objective"] = args["objective"]
-    if args.get("outcome"):
-        modifications["outcome"] = args["outcome"]
-    if args.get("statement"):
-        modifications["statement"] = args["statement"]
-    if args.get("content"):
-        modifications["content"] = args["content"]
-
-    memory_id = k.promote_suggestion(
-        suggestion_id,
-        modifications if modifications else None,
-    )
-
-    if memory_id:
-        status = "modified" if modifications else "promoted"
-        return f"Suggestion {suggestion_id[:8]}... {status} to memory {memory_id[:8]}..."
-    return f"Could not promote suggestion {suggestion_id[:8]}... (not found or not pending)"
-
-
-def handle_memory_suggestions_reject(args: Dict[str, Any], k: Kernle) -> str:
-    suggestion_id = args["suggestion_id"]
-    reason = args.get("reason")
-
-    if k.reject_suggestion(suggestion_id, reason):
-        result = f"Suggestion {suggestion_id[:8]}... rejected"
-        if reason:
-            result += f" (reason: {reason})"
-        return result
-    return f"Could not reject suggestion {suggestion_id[:8]}... (not found or not pending)"
-
-
-def handle_memory_suggestions_extract(args: Dict[str, Any], k: Kernle) -> str:
-    limit = args.get("limit", 50)
-    suggestions = k.extract_suggestions_from_unprocessed(limit=limit)
-
-    if not suggestions:
-        return "No suggestions extracted from raw entries."
-
-    by_type = {}
-    for s in suggestions:
-        t = s["memory_type"]
-        by_type[t] = by_type.get(t, 0) + 1
-
-    lines = [f"Extracted {len(suggestions)} suggestion(s):\n"]
-    for t, count in by_type.items():
-        lines.append(f"  {t}: {count}")
-    lines.append("\nUse memory_suggestions_list to review pending suggestions.")
-    return "\n".join(lines)
-
-
-# ---------------------------------------------------------------------------
-# New suggestion resolution tools
-# ---------------------------------------------------------------------------
-
-
 def validate_suggestion_list(arguments: Dict[str, Any]) -> Dict[str, Any]:
     return _validate_suggestion_list_args(arguments, include_format=False)
 
@@ -278,6 +99,31 @@ def validate_suggestion_dismiss(arguments: Dict[str, Any]) -> Dict[str, Any]:
         sanitize_string(arguments.get("reason"), "reason", 500, required=False) or None
     )
     return sanitized
+
+
+def validate_suggestion_extract(arguments: Dict[str, Any]) -> Dict[str, Any]:
+    sanitized: Dict[str, Any] = {}
+    sanitized["limit"] = int(validate_number(arguments.get("limit"), "limit", 1, 200, 50))
+    return sanitized
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+
+def handle_memory_sync(args: Dict[str, Any], k: Kernle) -> str:
+    sync_result = k.sync()
+    lines = ["Sync complete:"]
+    lines.append(f"  Pushed: {sync_result.get('pushed', 0)}")
+    lines.append(f"  Pulled: {sync_result.get('pulled', 0)}")
+    if sync_result.get("conflicts"):
+        lines.append(f"  Conflicts: {sync_result['conflicts']}")
+    if sync_result.get("errors"):
+        lines.append(f"  Errors: {len(sync_result['errors'])}")
+        for err in sync_result["errors"][:3]:
+            lines.append(f"    - {err}")
+    return "\n".join(lines)
 
 
 def handle_suggestion_list(args: Dict[str, Any], k: Kernle) -> str:
@@ -337,28 +183,41 @@ def handle_suggestion_dismiss(args: Dict[str, Any], k: Kernle) -> str:
     return f"Could not dismiss suggestion {suggestion_id[:8]}... (not found or not pending)"
 
 
+def handle_suggestion_extract(args: Dict[str, Any], k: Kernle) -> str:
+    limit = args.get("limit", 50)
+    suggestions = k.extract_suggestions_from_unprocessed(limit=limit)
+
+    if not suggestions:
+        return "No suggestions extracted from raw entries."
+
+    by_type = {}
+    for s in suggestions:
+        t = s["memory_type"]
+        by_type[t] = by_type.get(t, 0) + 1
+
+    lines = [f"Extracted {len(suggestions)} suggestion(s):\n"]
+    for t, count in by_type.items():
+        lines.append(f"  {t}: {count}")
+    lines.append("\nUse suggestion_list to review pending suggestions.")
+    return "\n".join(lines)
+
+
 # ---------------------------------------------------------------------------
 # Registry dicts
 # ---------------------------------------------------------------------------
 
 HANDLERS = {
     "memory_sync": handle_memory_sync,
-    "memory_suggestions_list": handle_memory_suggestions_list,
-    "memory_suggestions_promote": handle_memory_suggestions_promote,
-    "memory_suggestions_reject": handle_memory_suggestions_reject,
-    "memory_suggestions_extract": handle_memory_suggestions_extract,
     "suggestion_list": handle_suggestion_list,
     "suggestion_accept": handle_suggestion_accept,
     "suggestion_dismiss": handle_suggestion_dismiss,
+    "suggestion_extract": handle_suggestion_extract,
 }
 
 VALIDATORS = {
     "memory_sync": validate_memory_sync,
-    "memory_suggestions_list": validate_memory_suggestions_list,
-    "memory_suggestions_promote": validate_memory_suggestions_promote,
-    "memory_suggestions_reject": validate_memory_suggestions_reject,
-    "memory_suggestions_extract": validate_memory_suggestions_extract,
     "suggestion_list": validate_suggestion_list,
     "suggestion_accept": validate_suggestion_accept,
     "suggestion_dismiss": validate_suggestion_dismiss,
+    "suggestion_extract": validate_suggestion_extract,
 }

--- a/kernle/mcp/tool_definitions.py
+++ b/kernle/mcp/tool_definitions.py
@@ -694,120 +694,6 @@ TOOLS = [
     ),
     # Suggestion tools
     Tool(
-        name="memory_suggestions_list",
-        description="List memory suggestions extracted from raw entries. Suggestions are auto-extracted patterns that may be promoted to structured memories after review.",
-        inputSchema={
-            "type": "object",
-            "properties": {
-                "status": {
-                    "type": "string",
-                    "enum": [
-                        "pending",
-                        "promoted",
-                        "modified",
-                        "rejected",
-                        "dismissed",
-                        "expired",
-                        "all",
-                    ],
-                    "description": "Filter by status (default: pending)",
-                    "default": "pending",
-                },
-                "memory_type": {
-                    "type": "string",
-                    "enum": ["episode", "belief", "note"],
-                    "description": "Filter by suggested memory type",
-                },
-                "min_confidence": {
-                    "type": "number",
-                    "description": "Minimum confidence threshold (0.0-1.0)",
-                },
-                "max_age_hours": {
-                    "type": "number",
-                    "description": "Only return suggestions created within this many hours",
-                },
-                "source_raw_id": {
-                    "type": "string",
-                    "description": "Filter to suggestions derived from this raw entry ID",
-                },
-                "limit": {
-                    "type": "integer",
-                    "description": "Maximum suggestions to return (default: 20)",
-                    "default": 20,
-                },
-                "format": {
-                    "type": "string",
-                    "enum": ["text", "json"],
-                    "description": "Output format (default: text)",
-                    "default": "text",
-                },
-            },
-        },
-    ),
-    Tool(
-        name="memory_suggestions_promote",
-        description="Approve and promote a suggestion to a structured memory. Optionally modify the content before promotion.",
-        inputSchema={
-            "type": "object",
-            "properties": {
-                "suggestion_id": {
-                    "type": "string",
-                    "description": "ID of the suggestion to promote",
-                },
-                "objective": {
-                    "type": "string",
-                    "description": "Override objective (for episode suggestions)",
-                },
-                "outcome": {
-                    "type": "string",
-                    "description": "Override outcome (for episode suggestions)",
-                },
-                "statement": {
-                    "type": "string",
-                    "description": "Override statement (for belief suggestions)",
-                },
-                "content": {
-                    "type": "string",
-                    "description": "Override content (for note suggestions)",
-                },
-            },
-            "required": ["suggestion_id"],
-        },
-    ),
-    Tool(
-        name="memory_suggestions_reject",
-        description="Reject a suggestion (it will not be promoted to a memory).",
-        inputSchema={
-            "type": "object",
-            "properties": {
-                "suggestion_id": {
-                    "type": "string",
-                    "description": "ID of the suggestion to reject",
-                },
-                "reason": {
-                    "type": "string",
-                    "description": "Optional reason for rejection",
-                },
-            },
-            "required": ["suggestion_id"],
-        },
-    ),
-    Tool(
-        name="memory_suggestions_extract",
-        description="Extract suggestions from unprocessed raw entries. Analyzes raw captures and creates pending suggestions for review.",
-        inputSchema={
-            "type": "object",
-            "properties": {
-                "limit": {
-                    "type": "integer",
-                    "description": "Maximum raw entries to process (default: 50)",
-                    "default": 50,
-                },
-            },
-        },
-    ),
-    # New suggestion resolution tools
-    Tool(
         name="suggestion_list",
         description="List and filter memory suggestions. Supports filtering by status, type, confidence, age, and source raw entry.",
         inputSchema={
@@ -898,6 +784,20 @@ TOOLS = [
                 },
             },
             "required": ["suggestion_id"],
+        },
+    ),
+    Tool(
+        name="suggestion_extract",
+        description="Extract suggestions from unprocessed raw entries. Analyzes raw captures and creates pending suggestions for review.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum raw entries to process (default: 50)",
+                    "default": 50,
+                },
+            },
         },
     ),
     Tool(


### PR DESCRIPTION
## Summary
- Removed dead `memory_suggestions_list`, `memory_suggestions_promote`, `memory_suggestions_reject` handlers and validators from `sync.py` — these were superseded by `suggestion_list`, `suggestion_accept`, `suggestion_dismiss` in v0.10.0
- Renamed `memory_suggestions_extract` handler/validator to `suggestion_extract` for naming consistency
- Added `suggestion_extract` tool definition to `tool_definitions.py`
- Removed corresponding dead tool definitions and test code (677 lines net removal)
- All 5,049 tests pass

## Test plan
- [x] All 103 MCP tests pass with updated tool names
- [x] Full suite: 5,049 passed, 2 skipped

Closes #535

🤖 Generated with [Claude Code](https://claude.com/claude-code)