### PR TITLE
docs: fix stale memory_suggestions_* references

### DIFF
--- a/docs-site/integration/mcp.mdx
+++ b/docs-site/integration/mcp.mdx
@@ -193,10 +193,10 @@ Playbooks are currently available via CLI only. MCP tools for playbook operation
 
 | Tool | Description |
 |------|-------------|
-| `memory_suggestions_list` | List pending memory suggestions |
-| `memory_suggestions_promote` | Approve and promote a suggestion to structured memory |
-| `memory_suggestions_reject` | Reject a suggestion |
-| `memory_suggestions_extract` | Extract suggestions from unprocessed raw entries |
+| `suggestion_list` | List and filter memory suggestions by status, type, confidence, age |
+| `suggestion_accept` | Accept a suggestion and create structured memory (with optional modifications) |
+| `suggestion_dismiss` | Dismiss a suggestion with an optional reason |
+| `suggestion_extract` | Extract suggestions from unprocessed raw entries |
 
 ## Client Configuration
 

--- a/kernle/mcp/handlers/processing.py
+++ b/kernle/mcp/handlers/processing.py
@@ -114,7 +114,9 @@ def handle_memory_process(args: Dict[str, Any], k: Kernle) -> str:
             )
             if suggestion_summary:
                 lines.append(f"    Suggestions: {suggestion_summary}")
-            lines.append("    Use memory_suggestions to review and accept/reject.")
+            lines.append(
+                "    Use suggestion_list to review and suggestion_accept/suggestion_dismiss."
+            )
             if r.gate_blocked:
                 lines.append(f"    Gate blocked: {r.gate_blocked} item(s)")
                 for detail in r.gate_details:


### PR DESCRIPTION
## Summary
- Updated `processing.py` handler help text: `memory_suggestions` → `suggestion_list`/`suggestion_accept`/`suggestion_dismiss`
- Updated `mcp.mdx` tool table: replaced 4 old `memory_suggestions_*` tool names with current `suggestion_*` names

Follow-up to PR #542 which removed the duplicate tool family from runtime code but missed these doc references.

## Test plan
- [x] 145 targeted tests pass (test_mcp.py + test_cli_suggestions.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)