### PR TITLE
feat: dev dashboard for local memory stack inspection

### DIFF
--- a/dev/dashboard.py
+++ b/dev/dashboard.py
@@ -99,7 +99,7 @@ class DashboardHandler(BaseHTTPRequestHandler):
                 return self._send_html(DASHBOARD_HTML)
 
             elif path == "/api/stats":
-                stats = k._storage.get_stats()
+                stats = k.stack.get_stats()
                 return self._send_json(serialize(stats))
 
             elif path == "/api/anxiety":
@@ -109,12 +109,12 @@ class DashboardHandler(BaseHTTPRequestHandler):
             elif path == "/api/raw":
                 limit = self._get_int_param(params, "limit", 200)
                 processed = self._get_bool_param(params, "processed")
-                entries = k._storage.list_raw(processed=processed, limit=limit)
+                entries = k.stack.list_raw(processed=processed, limit=limit)
                 return self._send_json(serialize(entries))
 
             elif m := re.match(r"^/api/raw/([^/]+)$", path):
                 raw_id = m.group(1)
-                entry = k._storage.get_raw(raw_id)
+                entry = k.stack.get_raw(raw_id)
                 if entry is None:
                     return self._send_error(404, "Not found")
                 return self._send_json(serialize(entry))


### PR DESCRIPTION
## Summary

- Single-file dev dashboard (`dev/dashboard.py`) for visually inspecting kernle memory stacks
- Stdlib-only HTTP server (`http.server`, `json`) — no pip dependencies beyond kernle
- 16 JSON API endpoints covering stats, anxiety, raw entries, all memory types, suggestions, provenance, audit log, settings, and processing config
- Embedded HTML/CSS/JS frontend with dark theme, 6 tabs, sub-tabs for memory types, click-to-expand detail panels, strength bars, anxiety dimension visualization, provenance chains, and auto-refresh

**Usage:**
```bash
python dev/dashboard.py --stack corpus-test
# → opens http://localhost:8420
```

## Audit Fixes Applied

- XSS: replaced `statusIcon` string heuristic with `__safeHtml` sentinel pattern
- Removed wildcard CORS header (same-origin dashboard doesn't need it)
- Added `X-Content-Type-Options: nosniff` headers
- Generic error messages for 404/500 (no internal detail leakage)
- Tightened regex patterns (`[^/]+` instead of `.+`)
- Memory type validation on provenance endpoint
- Fixed stale cache in overview tab
- Unhandled promise rejection fix

## Test plan

- [x] Syntax check passes
- [x] All 16 API endpoints tested with curl against `corpus-test` stack (144 raw, 19 episodes, 21 notes)
- [x] Empty stack handling verified (`dashboard-test`)
- [x] 404 and error responses return generic messages
- [x] Provenance type validation rejects invalid types
- [x] Response headers verified (nosniff present, no CORS)
- [x] Security audit: 0 critical, 0 high (all fixed), 0 medium (all fixed)

Closes #544, #545, #546, #547

🤖 Generated with [Claude Code](https://claude.com/claude-code)