### PR TITLE
docs: corpus seeding & dev dashboard guides, auto-project workflow

### DIFF
--- a/.github/workflows/auto-project.yml
+++ b/.github/workflows/auto-project.yml
@@ -1,0 +1,18 @@
+name: Auto-add issues to project
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: read
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/emergent-instruments/projects/1
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROJECT_TOKEN }}

--- a/docs-site/design/roadmap.mdx
+++ b/docs-site/design/roadmap.mdx
@@ -171,6 +171,7 @@ Seed an agent from a corpus (repo, docs), process the full pipeline until exhaus
 - **Process-until-exhaustion runner** — iterative pipeline with intensity scaling (light→medium→heavy across cycles) and convergence detection; stops when no new promotions emerge ([#486](https://github.com/emergent-instruments/kernle/issues/486))
 - **Cognitive quality assertions** — test framework for provenance integrity, contradiction detection, duplicate detection, content quality, and pipeline health metrics ([#487](https://github.com/emergent-instruments/kernle/issues/487))
 - **Golden corpus integration test** — end-to-end test: seed from known corpus → process to exhaustion → assert on cognitive quality; extends golden snapshot test #407 with holistic validation ([#488](https://github.com/emergent-instruments/kernle/issues/488))
+- **Dev dashboard** — self-contained local memory stack inspector (`dev/dashboard.py`); stdlib HTTP server serving an embedded dark-theme HTML/CSS/JS dashboard with 16 API endpoints, 6 tabs (Overview, Raw Entries, Memories, Suggestions, Audit Log, Settings), anxiety visualization, strength bars, and provenance chain display ([#544](https://github.com/emergent-instruments/kernle/issues/544))
 
 ### v0.12.03 — Governance & Observability
 

--- a/docs-site/features/corpus-seeding.mdx
+++ b/docs-site/features/corpus-seeding.mdx
@@ -1,0 +1,178 @@
+---
+title: "Corpus Seeding"
+description: "Seed an agent with structured cognition from a repository or documentation corpus"
+---
+
+Corpus seeding transforms a repository or documentation set into structured cognitive memory. Unlike RAG (retrieval-augmented generation), which fetches raw text at query time, corpus seeding produces actual beliefs, episodes, notes, and values — giving the agent genuine understanding rather than just search results.
+
+## Overview
+
+The pipeline has two stages:
+
+1. **Ingest** — chunk source files into semantically meaningful raw entries
+2. **Process** — iteratively promote raw entries through the memory hierarchy until convergence
+
+```
+Source Files → Raw Entries → Episodes/Notes → Beliefs → Values
+                 (seed)        (process exhaust)
+```
+
+## Ingesting a Corpus
+
+### Source Code
+
+```bash
+kernle -s my-agent seed repo ./path/to/repo
+```
+
+The repo ingestor uses **AST-based chunking** for Python (extracting functions and classes as discrete units) and paragraph-based chunking for other languages. Each chunk becomes a raw entry tagged with file path, chunk type, and semantic name.
+
+**Options:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--extensions, -e` | py,js,ts,jsx,tsx,go,rs,java,rb,c,cpp,h,hpp,cs,swift,kt,scala,sh,bash,zsh | File extensions to include |
+| `--exclude, -x` | (none) | fnmatch patterns to exclude (e.g., `*.test.*,vendor/*`) |
+| `--max-chunk-size` | 2000 | Maximum characters per chunk |
+| `--dry-run, -n` | off | Preview without creating entries |
+| `--json, -j` | off | Output as JSON |
+
+**Example with filters:**
+
+```bash
+kernle -s my-agent seed repo ./myproject \
+  --extensions py,md \
+  --exclude "tests/*,docs/archive/*" \
+  --max-chunk-size 3000
+```
+
+### Documentation
+
+```bash
+kernle -s my-agent seed docs ./path/to/docs
+```
+
+The docs ingestor supports Markdown (heading-based chunking), reStructuredText, plain text (paragraph-based), and PDF (page-based chunking via pdfminer.six or PyPDF2).
+
+**Options:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--extensions, -e` | md,txt,rst,pdf | File extensions to include |
+| `--max-chunk-size` | 2000 | Maximum characters per chunk |
+| `--dry-run, -n` | off | Preview without creating entries |
+| `--json, -j` | off | Output as JSON |
+
+### Chunking Strategies
+
+| File Type | Strategy | Details |
+|-----------|----------|---------|
+| Python | AST-based | Extracts top-level functions and classes; module-level code collected separately |
+| Markdown/RST | Heading-based | Splits on heading boundaries; preamble before first heading preserved |
+| PDF | Page-based | Extracts text per page; large pages fall back to paragraph chunking |
+| All others | Paragraph-based | Splits on double-newlines; merges until max chunk size |
+
+### Deduplication
+
+Chunks are content-hash deduplicated. Re-running `seed repo` or `seed docs` on the same corpus skips already-ingested chunks, making it safe to re-run after adding new files.
+
+### Check Ingestion Status
+
+```bash
+kernle -s my-agent seed status
+```
+
+Returns counts of corpus raw entries (total, repo, docs).
+
+## Processing to Exhaustion
+
+After seeding, process the raw entries through the memory pipeline:
+
+```bash
+kernle -s my-agent process exhaust
+```
+
+This runs the processing pipeline in iterative cycles with **escalating intensity**:
+
+| Cycles | Intensity | Transitions |
+|--------|-----------|-------------|
+| 1-3 | Light | raw → episode, raw → note |
+| 4-6 | Medium | + episode → belief, episode → goal, episode → relationship, episode → drive |
+| 7+ | Heavy | + belief → value |
+
+Processing continues until **convergence** (2 consecutive cycles with 0 new promotions) or the maximum cycle count is reached.
+
+<Warning>Processing requires an inference model (e.g., Anthropic API key configured). Without inference, only basic note extraction and deduplication occur.</Warning>
+
+**Options:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--max-cycles` | 20 | Maximum processing cycles (safety cap) |
+| `--no-auto-promote` | off | Create suggestions instead of directly promoting |
+| `--dry-run, -n` | off | Preview what would run |
+| `--json, -j` | off | Output as JSON |
+
+**Safety:** A checkpoint (`pre-exhaust`) is automatically created before the first cycle.
+
+## Complete Example
+
+```bash
+# Create a fresh stack
+kernle -s project-expert status
+
+# Seed from repo and docs
+kernle -s project-expert seed repo ./my-project --extensions py,ts
+kernle -s project-expert seed docs ./my-project/docs
+
+# Check what was ingested
+kernle -s project-expert seed status
+
+# Process everything
+export ANTHROPIC_API_KEY=sk-...
+kernle -s project-expert process exhaust
+
+# Inspect the result
+kernle -s project-expert status
+kernle -s project-expert anxiety
+```
+
+## Inspecting Results
+
+After seeding and processing, use the [dev dashboard](/features/dev-dashboard) to visually inspect the memory stack:
+
+```bash
+python dev/dashboard.py --stack project-expert
+```
+
+Or use CLI commands:
+
+```bash
+# Memory counts
+kernle -s project-expert status
+
+# List raw entries
+kernle -s project-expert raw list --limit 20
+
+# List beliefs
+kernle -s project-expert belief list
+
+# Check anxiety (pipeline health)
+kernle -s project-expert anxiety
+```
+
+## Provenance
+
+All promoted memories maintain full provenance chains:
+
+```
+Raw Entry (corpus chunk) → Episode/Note → Belief → Value
+```
+
+Every memory records `derived_from` references back to its source. The dev dashboard shows provenance chains for any memory — click a row and check the "Derived from" and "Derived memories (children)" sections.
+
+## Directory Exclusions
+
+The following directories are always excluded from corpus ingestion:
+
+`.git`, `__pycache__`, `node_modules`, `.venv`, `venv`, `.tox`, `.mypy_cache`, `.pytest_cache`, `.ruff_cache`, `dist`, `build`, `.eggs`, `*.egg-info`

--- a/docs-site/features/dev-dashboard.mdx
+++ b/docs-site/features/dev-dashboard.mdx
@@ -1,0 +1,140 @@
+---
+title: "Dev Dashboard"
+description: "Local web dashboard for visually inspecting memory stacks"
+---
+
+The dev dashboard is a self-contained tool for visually inspecting kernle memory stacks. It serves an interactive dark-themed web UI on localhost, giving you a complete view of raw entries, promoted memories, provenance chains, anxiety scores, processing status, and audit trails.
+
+## Quick Start
+
+```bash
+python dev/dashboard.py --stack my-agent
+# Opens http://localhost:8420
+```
+
+The dashboard opens in your browser automatically. No additional dependencies are required beyond kernle itself — the dashboard uses only Python standard library (`http.server`, `json`).
+
+## Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--stack, -s` | (required) | Stack ID to inspect |
+| `--port, -p` | 8420 | Port to serve on |
+| `--no-open` | off | Don't auto-open browser |
+| `--verbose, -v` | off | Verbose server logging |
+
+## Dashboard Tabs
+
+### Overview
+
+Stats cards showing counts for each memory type (raw entries, episodes, beliefs, values, goals, notes, relationships, drives, suggestions). Below: anxiety dimension breakdown with bar charts and processing pipeline configuration.
+
+### Raw Entries
+
+Filterable table of all raw entries with:
+
+- **Status indicator** — green dot (processed) or yellow circle (unprocessed)
+- **Blob preview** — first 120 characters of the raw content
+- **Source** — where the entry came from (cli, mcp, sdk, import)
+- **Processed into** — what memories were created from this entry
+- **Strength bar** — visual indicator of memory strength
+
+Click any row to expand full details including the complete blob text and provenance chain (what memories were derived from this raw entry).
+
+**Filters:** All / Unprocessed / Processed. Adjustable limit (50-500).
+
+### Memories
+
+Sub-tabs for each memory type: Episodes, Beliefs, Values, Goals, Notes, Relationships, Drives. Each shows a table with type-specific fields:
+
+| Memory Type | Key Fields |
+|-------------|-----------|
+| Episodes | Objective, outcome, confidence, emotional valence/arousal |
+| Beliefs | Statement, type, confidence, scope |
+| Values | Name, statement, priority |
+| Goals | Title, type, priority, status |
+| Notes | Content, type, processed status |
+| Relationships | Entity name/type, relationship type, sentiment |
+| Drives | Type, intensity, focus areas |
+
+Click any row to see full detail including all fields and the provenance chain — both what this memory was derived from and what memories were derived from it.
+
+### Suggestions
+
+Pending memory suggestions with status (pending/promoted/rejected), type, confidence score, content preview, source raw IDs, and promotion target.
+
+### Audit Log
+
+Chronological list of all memory operations with timestamp, operation type, memory type, memory ID, and actor. Adjustable limit.
+
+### Settings
+
+Stack settings (enforce_provenance, stack_state, etc.) and processing pipeline configuration showing each transition layer with its enabled status, model, batch size, and thresholds.
+
+## Header Bar
+
+The sticky header shows:
+
+- **Stack ID** — which stack you're inspecting
+- **Memory counts** — quick summary of counts per type
+- **Anxiety badge** — colored badge showing overall anxiety score and level (Calm/Aware/Elevated/High/Critical)
+- **Auto-refresh toggle** — when enabled, refreshes data every 5 seconds
+
+## Typical Workflow
+
+After seeding a corpus and processing it:
+
+```bash
+# 1. Seed
+kernle -s my-agent seed repo ./my-project
+kernle -s my-agent seed docs ./my-project/docs
+
+# 2. Process
+kernle -s my-agent process exhaust
+
+# 3. Inspect
+python dev/dashboard.py --stack my-agent
+```
+
+In the dashboard:
+
+1. **Overview** — verify memory counts match expectations, check anxiety score
+2. **Raw Entries** — filter to "Unprocessed" to see if anything was missed
+3. **Memories → Beliefs** — check that promoted beliefs are sensible
+4. **Memories → Episodes** — verify episode objective/outcome quality
+5. **Audit Log** — trace the processing pipeline's decisions
+
+## API Endpoints
+
+The dashboard exposes a read-only JSON API that can also be used programmatically:
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /api/stats` | Memory counts by type |
+| `GET /api/anxiety` | Anxiety score and dimensions |
+| `GET /api/raw?limit=200&processed=true` | Raw entries (filterable) |
+| `GET /api/raw/{id}` | Single raw entry detail |
+| `GET /api/episodes?limit=100` | Episodes |
+| `GET /api/beliefs?limit=100` | Beliefs |
+| `GET /api/values` | Values |
+| `GET /api/goals` | Goals |
+| `GET /api/notes?limit=100` | Notes |
+| `GET /api/relationships` | Relationships |
+| `GET /api/drives` | Drives |
+| `GET /api/suggestions?limit=100` | Suggestions |
+| `GET /api/processing` | Processing pipeline config |
+| `GET /api/provenance/{type}/{id}` | Provenance tree (derived memories) |
+| `GET /api/audit?limit=100` | Audit trail |
+| `GET /api/settings` | Stack settings |
+
+All memory endpoints include forgotten and weak memories (`include_forgotten=True, include_weak=True`) to give a complete view of the stack.
+
+## Security
+
+The dashboard is designed for local development use:
+
+- Binds to `127.0.0.1` only (not accessible from the network)
+- Read-only — no mutation endpoints (GET only)
+- No CORS headers (same-origin only)
+- `X-Content-Type-Options: nosniff` on all responses
+- Generic error messages (no internal detail leakage)

--- a/docs-site/mint.json
+++ b/docs-site/mint.json
@@ -96,7 +96,9 @@
         "features/narratives",
         "features/summaries",
         "features/diagnostics",
-        "features/subscriptions"
+        "features/subscriptions",
+        "features/corpus-seeding",
+        "features/dev-dashboard"
       ]
     },
     {


### PR DESCRIPTION
## Summary

- **Corpus seeding guide** (`features/corpus-seeding.mdx`) — covers ingestion (`kernle seed repo/docs`), chunking strategies (AST-based, heading-based, page-based, paragraph-based), processing to exhaustion, deduplication, provenance, and complete examples
- **Dev dashboard guide** (`features/dev-dashboard.mdx`) — covers all 6 tabs, 16 API endpoints, typical workflow, and security posture
- **Roadmap update** — added dev dashboard entry under v0.12.02
- **Mint.json update** — added both new pages to Advanced Features navigation
- **Auto-project workflow** (`.github/workflows/auto-project.yml`) — automatically adds all new issues to the [Kernle Roadmap](https://github.com/orgs/emergent-instruments/projects/1) project board

## Setup Required

The `auto-project.yml` workflow requires a `PROJECT_TOKEN` repository secret:
1. Create a **classic Personal Access Token** with `project` and `repo` scopes
2. Add it as a repository secret named `PROJECT_TOKEN` at Settings → Secrets → Actions

## Test plan

- [x] Mintlify config valid JSON (checked syntax)
- [x] New pages referenced correctly in mint.json navigation
- [x] Workflow YAML valid (checked syntax)
- [x] All pre-commit hooks pass
- [x] Doc content verified against actual CLI commands and API signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)