### PR TITLE
fix: enforce dependency-review now that Dependency graph is enabled

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,9 +22,6 @@ jobs:
 
       - name: Dependency Review
         uses: actions/dependency-review-action@v4
-        # Requires Dependency graph enabled in repo Settings > Code security.
-        # Non-blocking until enabled — results still surface as annotations.
-        continue-on-error: true
         with:
           fail-on-severity: high
           deny-licenses: GPL-3.0, AGPL-3.0


### PR DESCRIPTION
## Summary
- Removes `continue-on-error: true` from the dependency-review step now that the Dependency graph has been enabled in repo settings
- dependency-review will now properly block PRs that introduce high-severity vulnerabilities or GPL-3.0/AGPL-3.0 licensed deps

## Test plan
- [ ] dependency-review check passes on this PR (confirms Dependency graph is working)

🤖 Generated with [Claude Code](https://claude.com/claude-code)