### PR TITLE
ci: use GitHub App token for project board workflows

### DIFF
--- a/.github/workflows/auto-project.yml
+++ b/.github/workflows/auto-project.yml
@@ -11,8 +11,16 @@ jobs:
   add-to-project:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PROJECT_APP_ID }}
+          private-key: ${{ secrets.PROJECT_APP_PRIVATE_KEY }}
+          owner: emergent-instruments
+
       - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/emergent-instruments/projects/1
         env:
-          GITHUB_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/project-status-sync.yml
+++ b/.github/workflows/project-status-sync.yml
@@ -11,10 +11,18 @@ jobs:
   sync-status:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PROJECT_APP_ID }}
+          private-key: ${{ secrets.PROJECT_APP_PRIVATE_KEY }}
+          owner: emergent-instruments
+
       - name: Update project item status
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.PROJECT_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const projectId = 'PVT_kwDOD1h1Qc4BOUxm';
             const fieldId = 'PVTSSF_lADOD1h1Qc4BOUxmzg9D2fw';


### PR DESCRIPTION
## Summary
- Replace `PROJECT_TOKEN` PAT with org-owned GitHub App token via `actions/create-github-app-token`
- Workflows now mint short-lived tokens per run — no personal account exposure
- Uses org secrets `PROJECT_APP_ID` and `PROJECT_APP_PRIVATE_KEY`

## Test plan
- [ ] Create a test issue to trigger `auto-project` workflow
- [ ] Close it to trigger `project-status-sync` workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)