### PR TITLE
Narrow devtools import gate (#573)

### DIFF
--- a/tests/test_cli_main_coverage.py
+++ b/tests/test_cli_main_coverage.py
@@ -500,57 +500,38 @@ class TestDispatchBranches:
 
     def test_dispatch_doctor_session_start_gate(self, k, capsys):
         """Dispatch 'doctor session start' shows devtools install message when not installed."""
-        import builtins
-
-        real_import = builtins.__import__
-
-        def mock_import(name, *args, **kwargs):
-            if name.startswith("kernle_devtools"):
-                raise ModuleNotFoundError(name=name)
-            return real_import(name, *args, **kwargs)
-
-        with patch.object(builtins, "__import__", side_effect=mock_import):
+        with patch(
+            "kernle.cli.__main__._import_devtools",
+            side_effect=SystemExit(2),
+        ):
             with pytest.raises(SystemExit) as exc:
                 self._run_main(["doctor", "session", "start"], k)
         assert exc.value.code == 2
-        captured = capsys.readouterr().out
-        assert "kernle-devtools" in captured
 
     def test_dispatch_doctor_session_list_gate(self, k, capsys):
         """Dispatch 'doctor session list' shows devtools install message when not installed."""
-        import builtins
-
-        real_import = builtins.__import__
-
-        def mock_import(name, *args, **kwargs):
-            if name.startswith("kernle_devtools"):
-                raise ModuleNotFoundError(name=name)
-            return real_import(name, *args, **kwargs)
-
-        with patch.object(builtins, "__import__", side_effect=mock_import):
+        with patch(
+            "kernle.cli.__main__._import_devtools",
+            side_effect=SystemExit(2),
+        ):
             with pytest.raises(SystemExit) as exc:
                 self._run_main(["doctor", "session", "list"], k)
         assert exc.value.code == 2
-        captured = capsys.readouterr().out
-        assert "kernle-devtools" in captured
 
-    def test_dispatch_doctor_session_start_import_error_gate(self, k, capsys):
-        """Dispatch 'doctor session start' handles incompatible devtools (ImportError)."""
-        import builtins
+    def test_dispatch_doctor_session_start_import_error_propagates(self, k):
+        """Dispatch 'doctor session start' propagates bare ImportError (not swallowed).
 
-        real_import = builtins.__import__
-
-        def mock_import(name, *args, **kwargs):
-            if name.startswith("kernle_devtools"):
-                raise ImportError("kernle-devtools requires kernle>=0.12.4")
-            return real_import(name, *args, **kwargs)
-
-        with patch.object(builtins, "__import__", side_effect=mock_import):
+        Bare ImportError is NOT caught by the devtools gate (exit 2). Instead it
+        propagates to main()'s general exception handler (exit 1).
+        """
+        with patch(
+            "kernle.cli.__main__._import_devtools",
+            side_effect=ImportError("kernle-devtools requires kernle>=0.12.4"),
+        ):
             with pytest.raises(SystemExit) as exc:
                 self._run_main(["doctor", "session", "start"], k)
-        assert exc.value.code == 2
-        captured = capsys.readouterr().out
-        assert "kernle-devtools" in captured
+            # Exit code 1 (general error), NOT 2 (missing devtools)
+            assert exc.value.code == 1
 
     def test_dispatch_doctor_session_no_action(self, k, capsys):
         """Dispatch 'doctor session' without start/list shows usage."""
@@ -560,21 +541,13 @@ class TestDispatchBranches:
 
     def test_dispatch_doctor_report_gate(self, k, capsys):
         """Dispatch 'doctor report' shows devtools install message when not installed."""
-        import builtins
-
-        real_import = builtins.__import__
-
-        def mock_import(name, *args, **kwargs):
-            if name.startswith("kernle_devtools"):
-                raise ModuleNotFoundError(name=name)
-            return real_import(name, *args, **kwargs)
-
-        with patch.object(builtins, "__import__", side_effect=mock_import):
+        with patch(
+            "kernle.cli.__main__._import_devtools",
+            side_effect=SystemExit(2),
+        ):
             with pytest.raises(SystemExit) as exc:
                 self._run_main(["doctor", "report", "latest"], k)
         assert exc.value.code == 2
-        captured = capsys.readouterr().out
-        assert "kernle-devtools" in captured
 
     def test_dispatch_trust(self, k, capsys):
         """Dispatch 'trust' command."""

--- a/tests/test_devtools_gate.py
+++ b/tests/test_devtools_gate.py
@@ -1,0 +1,215 @@
+"""Tests for the narrowed devtools import gate in CLI __main__.py.
+
+The _import_devtools() helper must:
+- Show "pip install kernle-devtools" only when kernle_devtools is genuinely missing
+- Propagate ImportError from inside devtools (real bugs, not missing package)
+- Propagate ModuleNotFoundError for non-devtools packages
+- Show upgrade message for DevtoolsVersionError
+- Behave identically across all three gate sites (session start, session list, report)
+"""
+
+import importlib
+from types import ModuleType
+from unittest.mock import patch
+
+import pytest
+
+from kernle.cli.__main__ import _import_devtools
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_devtools_module():
+    """Create a fake kernle_devtools module with the expected symbols."""
+    mod = ModuleType("kernle_devtools.admin_health.diagnostics")
+    mod.cmd_doctor_session_start = lambda args, k: None
+    mod.cmd_doctor_session_list = lambda args, k: None
+    mod.cmd_doctor_report = lambda args, k: None
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# _import_devtools unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestImportDevtoolsMissing:
+    """ModuleNotFoundError for kernle_devtools → exit(2) + install message."""
+
+    def test_devtools_missing_shows_install_message(self, capsys):
+        with patch.object(
+            importlib,
+            "import_module",
+            side_effect=ModuleNotFoundError(name="kernle_devtools"),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                _import_devtools(
+                    "kernle_devtools.admin_health.diagnostics",
+                    "cmd_doctor_session_start",
+                )
+            assert exc.value.code == 2
+        captured = capsys.readouterr().out
+        assert "pip install kernle-devtools" in captured
+
+    def test_devtools_submodule_missing_shows_install_message(self, capsys):
+        """ModuleNotFoundError with name='kernle_devtools.foo' still shows install msg."""
+        with patch.object(
+            importlib,
+            "import_module",
+            side_effect=ModuleNotFoundError(name="kernle_devtools.admin_health.diagnostics"),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                _import_devtools(
+                    "kernle_devtools.admin_health.diagnostics",
+                    "cmd_doctor_session_start",
+                )
+            assert exc.value.code == 2
+        captured = capsys.readouterr().out
+        assert "pip install kernle-devtools" in captured
+
+
+class TestImportDevtoolsPropagates:
+    """Errors that are NOT 'devtools missing' must propagate, not be swallowed."""
+
+    def test_devtools_internal_import_error_propagates(self):
+        """ImportError from inside devtools (e.g. bad internal import) raises."""
+        with patch.object(
+            importlib,
+            "import_module",
+            side_effect=ImportError("cannot import name 'foo' from 'kernle_devtools.bar'"),
+        ):
+            with pytest.raises(ImportError, match="cannot import name 'foo'"):
+                _import_devtools(
+                    "kernle_devtools.admin_health.diagnostics",
+                    "cmd_doctor_session_start",
+                )
+
+    def test_non_devtools_module_not_found_propagates(self):
+        """ModuleNotFoundError for a non-devtools package raises."""
+        err = ModuleNotFoundError(name="some_other_pkg")
+        with patch.object(
+            importlib,
+            "import_module",
+            side_effect=err,
+        ):
+            with pytest.raises(ModuleNotFoundError) as exc:
+                _import_devtools(
+                    "kernle_devtools.admin_health.diagnostics",
+                    "cmd_doctor_session_start",
+                )
+            assert exc.value.name == "some_other_pkg"
+
+
+class TestDevtoolsVersionError:
+    """DevtoolsVersionError (subclass of ImportError) → exit(2) + upgrade message."""
+
+    def test_devtools_version_error_shows_upgrade_message(self, capsys):
+        # Create a DevtoolsVersionError class that looks like it comes from kernle_devtools
+        devtools_version_error_cls = type(
+            "DevtoolsVersionError",
+            (ImportError,),
+            {"__module__": "kernle_devtools"},
+        )
+        err = devtools_version_error_cls("kernle-devtools requires kernle>=0.13.0")
+        with patch.object(importlib, "import_module", side_effect=err):
+            with pytest.raises(SystemExit) as exc:
+                _import_devtools(
+                    "kernle_devtools.admin_health.diagnostics",
+                    "cmd_doctor_session_start",
+                )
+            assert exc.value.code == 2
+        captured = capsys.readouterr().out
+        assert "upgrade" in captured.lower() or "Upgrade" in captured
+
+
+class TestImportDevtoolsSuccess:
+    """When devtools is available, _import_devtools returns the requested symbol."""
+
+    def test_returns_symbol(self, fake_devtools_module):
+        with patch.object(importlib, "import_module", return_value=fake_devtools_module):
+            fn = _import_devtools(
+                "kernle_devtools.admin_health.diagnostics",
+                "cmd_doctor_session_start",
+            )
+        assert fn is fake_devtools_module.cmd_doctor_session_start
+
+    def test_missing_symbol_raises_attribute_error(self, fake_devtools_module):
+        with patch.object(importlib, "import_module", return_value=fake_devtools_module):
+            with pytest.raises(AttributeError):
+                _import_devtools(
+                    "kernle_devtools.admin_health.diagnostics",
+                    "nonexistent_function",
+                )
+
+
+# ---------------------------------------------------------------------------
+# Integration: all three gate sites behave identically
+# ---------------------------------------------------------------------------
+
+
+class TestAllThreeGatesConsistent:
+    """Session start, session list, and report all use _import_devtools consistently."""
+
+    def _run_main(self, argv, k):
+        from kernle.cli.__main__ import main
+
+        with patch("sys.argv", ["kernle"] + argv):
+            with patch("kernle.cli.__main__.Kernle", return_value=k):
+                with patch("kernle.cli.__main__.resolve_stack_id", return_value="test-main"):
+                    main()
+
+    @pytest.fixture
+    def k(self, tmp_path):
+        from kernle.core import Kernle
+        from kernle.storage import SQLiteStorage
+
+        s = SQLiteStorage(stack_id="test-main", db_path=tmp_path / "main.db")
+        inst = Kernle(stack_id="test-main", storage=s, strict=False)
+        yield inst
+        s.close()
+
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            ["doctor", "session", "start"],
+            ["doctor", "session", "list"],
+            ["doctor", "report", "latest"],
+        ],
+        ids=["session-start", "session-list", "report"],
+    )
+    def test_all_three_gates_missing_devtools(self, k, capsys, argv):
+        """All three gates show install message when devtools is missing."""
+        with patch(
+            "kernle.cli.__main__._import_devtools",
+            side_effect=SystemExit(2),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                self._run_main(argv, k)
+            assert exc.value.code == 2
+
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            ["doctor", "session", "start"],
+            ["doctor", "session", "list"],
+            ["doctor", "report", "latest"],
+        ],
+        ids=["session-start", "session-list", "report"],
+    )
+    def test_all_three_gates_propagate_internal_error(self, k, argv):
+        """All three gates propagate ImportError (not swallowed as 'install devtools').
+
+        Internal ImportError bubbles up through _import_devtools to main()'s
+        general exception handler, which exits with code 1 (not 2).
+        """
+        with patch(
+            "kernle.cli.__main__._import_devtools",
+            side_effect=ImportError("bad internal import"),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                self._run_main(argv, k)
+            # Exit code 1 (general error), NOT 2 (missing devtools)
+            assert exc.value.code == 1


### PR DESCRIPTION
## Summary
- Extract `_import_devtools()` helper to avoid triple-duplicated import gates in CLI
- Gate now distinguishes between "not installed" (`ModuleNotFoundError` with devtools name) and "internal import error" (propagated)
- Adds support for typed `DevtoolsVersionError` from kernle-devtools for version incompatibility messages
- Non-devtools `ModuleNotFoundError` and internal `ImportError` now propagate instead of being swallowed

## Test plan
- [x] `test_devtools_missing_shows_install_message` — exit(2) + install hint
- [x] `test_devtools_internal_import_error_propagates` — real errors not swallowed
- [x] `test_non_devtools_module_not_found_propagates` — unrelated modules propagate
- [x] `test_devtools_version_error_shows_upgrade` — typed version error handled
- [x] `test_all_three_gates_consistent` — session start, list, report all use helper
- [x] Updated existing test that expected ImportError to be swallowed

Closes #573

🤖 Generated with [Claude Code](https://claude.com/claude-code)