### PR TITLE
Add suggestion lifecycle APIs to StackProtocol (#539)

### DIFF
--- a/kernle/protocols.py
+++ b/kernle/protocols.py
@@ -820,6 +820,44 @@ class StackProtocol(Protocol):
         """Get any single memory by type and ID."""
         ...
 
+    # ---- Suggestion Lifecycle ----
+
+    def get_suggestion(self, suggestion_id: str) -> Optional[MemorySuggestion]:
+        """Retrieve a single suggestion by ID."""
+        ...
+
+    def get_suggestions(
+        self,
+        status: Optional[str] = None,
+        memory_type: Optional[str] = None,
+        limit: int = 100,
+        min_confidence: Optional[float] = None,
+        max_age_hours: Optional[float] = None,
+        source_raw_id: Optional[str] = None,
+    ) -> list[MemorySuggestion]:
+        """Retrieve suggestions with optional filters."""
+        ...
+
+    def accept_suggestion(
+        self,
+        suggestion_id: str,
+        modifications: Optional[dict[str, Any]] = None,
+    ) -> Optional[str]:
+        """Accept a pending suggestion and promote it to a structured memory.
+
+        Returns the ID of the created memory, or None if the suggestion
+        was not found or not pending.
+        """
+        ...
+
+    def dismiss_suggestion(
+        self,
+        suggestion_id: str,
+        reason: Optional[str] = None,
+    ) -> bool:
+        """Dismiss a pending suggestion (will not be promoted)."""
+        ...
+
     # ---- Search ----
 
     def search(


### PR DESCRIPTION
## Summary
- Adds `get_suggestion`, `get_suggestions`, `accept_suggestion`, `dismiss_suggestion` to `StackProtocol` in `protocols.py`
- Signatures match existing `SQLiteStack` implementation exactly to prevent protocol drift
- Adds 9 contract tests for the full suggestion lifecycle (get, filter, accept, dismiss)
- One test (`test_accept_unknown_type_raises`) is marked `xfail` pending #538

Closes #539

## Test plan
- [x] 9 new contract tests pass (8 pass, 1 xfail)
- [x] Full suite: 5264 passed, 2 skipped, 1 xfailed
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)