### PR TITLE
Replace tempfile.mktemp() with pytest tmp_path (#583)

### DIFF
--- a/tests/test_confidence_decay.py
+++ b/tests/test_confidence_decay.py
@@ -4,9 +4,7 @@ Tests the confidence decay feature that prevents confidence inflation
 by applying time-based decay to memories that haven't been verified recently.
 """
 
-import tempfile
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 
 import pytest
 
@@ -26,12 +24,9 @@ from kernle.storage import (
 
 
 @pytest.fixture
-def temp_db():
+def temp_db(tmp_path):
     """Create a temporary database path."""
-    path = Path(tempfile.mktemp(suffix=".db"))
-    yield path
-    if path.exists():
-        path.unlink()
+    return tmp_path / "test.db"
 
 
 @pytest.fixture

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -4,7 +4,6 @@ Tests that context and context_tags fields are properly saved and retrieved
 for all memory types, enabling project-specific memory isolation.
 """
 
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -23,12 +22,9 @@ from kernle.storage import (
 
 
 @pytest.fixture
-def temp_db():
+def temp_db(tmp_path):
     """Create a temporary database path."""
-    path = Path(tempfile.mktemp(suffix=".db"))
-    yield path
-    if path.exists():
-        path.unlink()
+    return tmp_path / "test.db"
 
 
 @pytest.fixture

--- a/tests/test_emotional_memory.py
+++ b/tests/test_emotional_memory.py
@@ -7,9 +7,7 @@ Tests the emotional memory features:
 - Mood-congruent memory retrieval
 """
 
-import tempfile
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 
 import pytest
 
@@ -21,12 +19,9 @@ from kernle.storage import (
 
 
 @pytest.fixture
-def temp_db():
+def temp_db(tmp_path):
     """Create a temporary database path."""
-    path = Path(tempfile.mktemp(suffix=".db"))
-    yield path
-    if path.exists():
-        path.unlink()
+    return tmp_path / "test.db"
 
 
 @pytest.fixture

--- a/tests/test_epochs.py
+++ b/tests/test_epochs.py
@@ -4,9 +4,6 @@ Tests epoch CRUD operations at both storage and core API levels,
 including epoch_id propagation to memory types and epoch-filtered loading.
 """
 
-import tempfile
-from pathlib import Path
-
 import pytest
 
 from kernle import Kernle
@@ -14,12 +11,9 @@ from kernle.storage import Belief, Episode, Epoch, Note, SQLiteStorage
 
 
 @pytest.fixture
-def temp_db():
+def temp_db(tmp_path):
     """Create a temporary database path."""
-    path = Path(tempfile.mktemp(suffix=".db"))
-    yield path
-    if path.exists():
-        path.unlink()
+    return tmp_path / "test.db"
 
 
 @pytest.fixture

--- a/tests/test_meta_memory.py
+++ b/tests/test_meta_memory.py
@@ -7,9 +7,7 @@ Tests memory about memory functionality:
 - Lineage tracking
 """
 
-import tempfile
 from datetime import datetime, timezone
-from pathlib import Path
 
 import pytest
 
@@ -27,12 +25,9 @@ from kernle.storage import (
 
 
 @pytest.fixture
-def temp_db():
+def temp_db(tmp_path):
     """Create a temporary database path."""
-    path = Path(tempfile.mktemp(suffix=".db"))
-    yield path
-    if path.exists():
-        path.unlink()
+    return tmp_path / "test.db"
 
 
 @pytest.fixture

--- a/tests/test_metacognition.py
+++ b/tests/test_metacognition.py
@@ -7,9 +7,6 @@ Tests the ability to have awareness of what we know and don't know:
 - Learning opportunity identification
 """
 
-import tempfile
-from pathlib import Path
-
 import pytest
 
 from kernle.core import Kernle
@@ -17,12 +14,9 @@ from kernle.storage import SQLiteStorage
 
 
 @pytest.fixture
-def temp_db():
+def temp_db(tmp_path):
     """Create a temporary database path."""
-    path = Path(tempfile.mktemp(suffix=".db"))
-    yield path
-    if path.exists():
-        path.unlink()
+    return tmp_path / "test.db"
 
 
 @pytest.fixture

--- a/tests/test_sqlite_coverage.py
+++ b/tests/test_sqlite_coverage.py
@@ -11,21 +11,15 @@ Covers:
 - Access tracking: record_access
 """
 
-import tempfile
-from pathlib import Path
-
 import pytest
 
 from kernle.storage import Belief, Episode, SQLiteStorage
 
 
 @pytest.fixture
-def temp_db():
+def temp_db(tmp_path):
     """Create a temporary database path."""
-    path = Path(tempfile.mktemp(suffix=".db"))
-    yield path
-    if path.exists():
-        path.unlink()
+    return tmp_path / "test.db"
 
 
 @pytest.fixture

--- a/tests/test_sqlite_storage.py
+++ b/tests/test_sqlite_storage.py
@@ -7,7 +7,6 @@ Tests local-first SQLite storage with:
 - Embedding management
 """
 
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -26,13 +25,9 @@ from kernle.storage import (
 
 
 @pytest.fixture
-def temp_db():
+def temp_db(tmp_path):
     """Create a temporary database path."""
-    path = Path(tempfile.mktemp(suffix=".db"))
-    yield path
-    # Cleanup
-    if path.exists():
-        path.unlink()
+    return tmp_path / "test.db"
 
 
 @pytest.fixture

--- a/tests/test_sync_engine.py
+++ b/tests/test_sync_engine.py
@@ -18,9 +18,7 @@ Tests:
 """
 
 import logging
-import tempfile
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -43,12 +41,9 @@ from kernle.storage.sync_engine import MAX_SYNC_ARRAY_SIZE
 
 
 @pytest.fixture
-def temp_db():
+def temp_db(tmp_path):
     """Create a temporary database path."""
-    path = Path(tempfile.mktemp(suffix=".db"))
-    yield path
-    if path.exists():
-        path.unlink()
+    return tmp_path / "test.db"
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- Replaces insecure `tempfile.mktemp()` with pytest `tmp_path` fixture in 9 test files
- Eliminates TOCTOU race condition and CodeQL high-severity alerts
- Removes `import tempfile` from all affected files

### Files changed
- tests/test_sqlite_storage.py
- tests/test_sync_engine.py
- tests/test_meta_memory.py
- tests/test_emotional_memory.py
- tests/test_sqlite_coverage.py
- tests/test_context.py
- tests/test_epochs.py
- tests/test_metacognition.py
- tests/test_confidence_decay.py

Closes #583

## Test plan
- [x] All 9 affected test files pass
- [x] No remaining `mktemp` usage in test files
- [x] Full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)