### PR TITLE
docs: update for v0.13.01 suggestion lifecycle and security

### DIFF
--- a/docs-site/cli/utility-commands.mdx
+++ b/docs-site/cli/utility-commands.mdx
@@ -805,33 +805,82 @@ kernle -s my-project init -y --style minimal
 
 ## suggestions
 
-Manage memory suggestions (auto-generated recommendations).
+Manage memory suggestions (auto-generated recommendations from the processing pipeline).
 
 ### suggestions list
 
 ```bash
-kernle -s <stack> suggestions list [--pending] [--approved] [--rejected] [--type TYPE] [--limit L]
+kernle -s <stack> suggestions list [options]
 ```
 
 | Option | Description |
 |--------|-------------|
 | `--pending` | Show only pending suggestions |
-| `--approved` | Show only approved suggestions |
+| `--approved` | Show only approved (promoted) suggestions |
 | `--rejected` | Show only rejected suggestions |
+| `--dismissed` | Show only dismissed suggestions |
+| `--expired` | Show only expired suggestions |
 | `--type TYPE` | Filter by memory type |
-| `-l, --limit L` | Maximum results (default: 20) |
+| `--min-confidence C` | Minimum confidence threshold |
+| `--max-age-hours H` | Maximum age in hours |
+| `--source SOURCE` | Filter by source raw entry ID |
+| `-l, --limit L` | Maximum results (default: 50) |
+| `-j, --json` | Output as JSON |
 
-### suggestions approve
+### suggestions show
+
+Show details for a specific suggestion. Supports partial ID matching.
 
 ```bash
-kernle -s <stack> suggestions approve SUGGESTION_ID
+kernle -s <stack> suggestions show ID [--json]
 ```
 
-### suggestions reject
+### suggestions accept
+
+Accept a suggestion and promote it to structured memory. Supports all 7 memory types (episode, belief, note, goal, value, relationship, drive).
 
 ```bash
-kernle -s <stack> suggestions reject SUGGESTION_ID
+kernle -s <stack> suggestions accept ID [--objective O] [--outcome O] [--statement S] [--content C]
 ```
+
+| Option | Description |
+|--------|-------------|
+| `--objective O` | Override objective (for episodes) |
+| `--outcome O` | Override outcome (for episodes) |
+| `--statement S` | Override statement (for beliefs) |
+| `--content C` | Override content (for notes) |
+
+### suggestions dismiss
+
+Dismiss a suggestion with an optional reason.
+
+```bash
+kernle -s <stack> suggestions dismiss ID [--reason R]
+```
+
+### suggestions expire
+
+Expire stale pending suggestions older than a threshold.
+
+```bash
+kernle -s <stack> suggestions expire [--max-age-hours H]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--max-age-hours H` | Age threshold in hours (default: 168 / 7 days) |
+
+### suggestions extract
+
+Extract new suggestions from unprocessed raw entries.
+
+```bash
+kernle -s <stack> suggestions extract [--limit L]
+```
+
+| Option | Description |
+|--------|-------------|
+| `-l, --limit L` | Maximum raw entries to process (default: 50) |
 
 ---
 

--- a/docs-site/concepts/security.mdx
+++ b/docs-site/concepts/security.mdx
@@ -102,6 +102,17 @@ Authority gating is **advisory, not blocking**. The sovereignty principle means 
 
 ---
 
+## Credential Transport Security *(v0.13.01)*
+
+The auth CLI blocks credential submission over plaintext HTTP to prevent credential interception:
+
+- **Login and register** refuse to send API keys or passwords to non-HTTPS, non-localhost URLs
+- **URL validation** uses proper hostname parsing (`urllib.parse.urlparse`) to prevent bypass via crafted hostnames (e.g., `http://localhost.evil.com`)
+- **Localhost exception**: `http://localhost` and `http://127.0.0.1` are allowed for local development
+- **Sync client** already enforced HTTPS for non-local URLs since v0.12
+
+---
+
 ## Sync Security
 
 ### Stack Isolation

--- a/docs-site/protocol/stack.mdx
+++ b/docs-site/protocol/stack.mdx
@@ -45,6 +45,19 @@ Low-level storage methods. The intended write path is through the core's routed 
 
 All `save_*` methods return the memory ID of the saved record.
 
+### Suggestion Lifecycle *(v0.13.01)*
+
+Methods for reviewing and resolving auto-generated memory suggestions.
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `get_suggestion` | `(suggestion_id: str) -> Optional[MemorySuggestion]` | Retrieve a single suggestion by ID |
+| `get_suggestions` | `(*, status=None, memory_type=None, limit=100, min_confidence=None, max_age_hours=None, source_raw_id=None) -> list[MemorySuggestion]` | List suggestions with filtering |
+| `accept_suggestion` | `(suggestion_id: str, modifications=None) -> Optional[str]` | Accept and promote to structured memory |
+| `dismiss_suggestion` | `(suggestion_id: str, reason=None) -> bool` | Dismiss a suggestion with optional reason |
+
+`accept_suggestion` creates the target memory type (episode, belief, note, goal, value, relationship, or drive) with full provenance (`source_entity="kernle:suggestion-promotion"`), marks the suggestion as promoted, and returns the new memory ID. Returns `None` if the suggestion is not found, not pending, or was lint-rejected.
+
 ### Batch Write
 
 | Method | Signature |


### PR DESCRIPTION
## Summary
- **protocol/stack.mdx**: Add suggestion lifecycle methods (`get_suggestion`, `get_suggestions`, `accept_suggestion`, `dismiss_suggestion`) to StackProtocol reference. Document `accept_suggestion` semantics including all 7 memory types and lint-redirect behavior.
- **cli/utility-commands.mdx**: Expand suggestions CLI reference with all actual commands: `show`, `accept`, `dismiss`, `expire`, `extract`. Add missing filter options (`--dismissed`, `--expired`, `--min-confidence`, `--max-age-hours`, `--source`). Document partial ID matching.
- **concepts/security.mdx**: Add Credential Transport Security section documenting HTTPS enforcement in auth CLI, URL parsing for hostname validation, and localhost development exception.

## Test plan
- [ ] Verify docs render correctly on Mintlify
- [ ] Cross-reference method signatures with `protocols.py` and `sqlite_stack.py`
- [ ] Verify CLI commands match `suggestions.py` argparse definitions

Generated with [Claude Code](https://claude.com/claude-code)