### PR TITLE
Add offset/pagination to list_raw (#533)

### DIFF
--- a/kernle/core/writers.py
+++ b/kernle/core/writers.py
@@ -302,17 +302,20 @@ class WritersMixin:
             return self._write_backend.save_raw(raw_entry)
         return self._storage.save_raw(blob=blob, source=source)
 
-    def list_raw(self, processed: Optional[bool] = None, limit: int = 100) -> List[Dict[str, Any]]:
+    def list_raw(
+        self, processed: Optional[bool] = None, limit: int = 100, offset: int = 0
+    ) -> List[Dict[str, Any]]:
         """List raw entries, optionally filtered by processed state.
 
         Args:
             processed: Filter by processed state (None = all, True = processed, False = unprocessed)
             limit: Maximum entries to return
+            offset: Number of entries to skip
 
         Returns:
             List of raw entry dicts with blob as primary content field
         """
-        entries = self._storage.list_raw(processed=processed, limit=limit)
+        entries = self._storage.list_raw(processed=processed, limit=limit, offset=offset)
         return [
             {
                 "id": e.id,

--- a/kernle/stack/sqlite_stack.py
+++ b/kernle/stack/sqlite_stack.py
@@ -2011,9 +2011,11 @@ class SQLiteStack(
 
     # ---- Stack-level helpers ----
 
-    def list_raw(self, processed: Optional[bool] = None, limit: int = 100) -> List[Any]:
+    def list_raw(
+        self, processed: Optional[bool] = None, limit: int = 100, offset: int = 0
+    ) -> List[Any]:
         """List raw entries."""
-        return self._backend.list_raw(processed=processed, limit=limit)
+        return self._backend.list_raw(processed=processed, limit=limit, offset=offset)
 
     def get_identity_confidence(self) -> float:
         """Get identity confidence from values and beliefs.

--- a/kernle/storage/base.py
+++ b/kernle/storage/base.py
@@ -436,7 +436,9 @@ class Storage(Protocol):
         ...
 
     @abstractmethod
-    def list_raw(self, processed: Optional[bool] = None, limit: int = 100) -> List[RawEntry]:
+    def list_raw(
+        self, processed: Optional[bool] = None, limit: int = 100, offset: int = 0
+    ) -> List[RawEntry]:
         """Get raw entries, optionally filtered by processed state."""
         ...
 

--- a/kernle/storage/sqlite.py
+++ b/kernle/storage/sqlite.py
@@ -3291,10 +3291,10 @@ class SQLiteStorage:
         with self._connect() as conn:
             return _get_raw(conn, self.stack_id, raw_id)
 
-    def list_raw(self, processed=None, limit=100):
+    def list_raw(self, processed=None, limit=100, offset=0):
         """List raw entries. Delegates to raw_entries.list_raw()."""
         with self._connect() as conn:
-            return _list_raw(conn, self.stack_id, processed, limit)
+            return _list_raw(conn, self.stack_id, processed, limit, offset)
 
     def search_raw_fts(self, query, limit=50):
         """Search raw entries via FTS5. Delegates to raw_entries.search_raw_fts()."""

--- a/tests/test_dedup_pagination.py
+++ b/tests/test_dedup_pagination.py
@@ -1,0 +1,159 @@
+"""Tests for dedup pagination (load_raw_content_hashes with offset)."""
+
+from unittest.mock import MagicMock
+
+import kernle.dedup as dedup_mod
+from kernle.dedup import load_raw_content_hashes
+
+
+def _make_entry(blob_text, source="cli"):
+    e = MagicMock()
+    e.blob = blob_text
+    e.content = None
+    e.source = source
+    return e
+
+
+class TestLoadHashesPaginates:
+    """load_raw_content_hashes should paginate through multiple batches."""
+
+    def test_multiple_batches_no_gaps_no_dupes(self, monkeypatch):
+        """With batch_size=2, 5 entries should require 3 batches with correct offsets."""
+        monkeypatch.setattr(dedup_mod, "_DEDUP_BATCH_SIZE", 2)
+
+        all_entries = [_make_entry(f"unique content {i}") for i in range(5)]
+        mock_storage = MagicMock()
+        mock_storage.list_raw.side_effect = [
+            all_entries[0:2],  # batch 1: full (2 == batch_size), offset=0
+            all_entries[2:4],  # batch 2: full (2 == batch_size), offset=2
+            all_entries[4:5],  # batch 3: partial (1 < 2), offset=4
+        ]
+
+        result = load_raw_content_hashes(mock_storage, limit=100)
+
+        assert result.rows_scanned == 5
+        assert result.rows_matched == 5
+        assert len(result.hashes) == 5
+
+        # Verify 3 calls with correct offsets
+        assert mock_storage.list_raw.call_count == 3
+        calls = mock_storage.list_raw.call_args_list
+        assert calls[0].kwargs["offset"] == 0
+        assert calls[1].kwargs["offset"] == 2
+        assert calls[2].kwargs["offset"] == 4
+
+    def test_limit_stops_pagination_mid_batch(self, monkeypatch):
+        """Pagination should stop when rows_scanned reaches limit, even mid-page."""
+        monkeypatch.setattr(dedup_mod, "_DEDUP_BATCH_SIZE", 3)
+
+        all_entries = [_make_entry(f"content {i}") for i in range(10)]
+        mock_storage = MagicMock()
+        # limit=5, batch_size=3
+        # batch 1: 3 entries, rows_scanned=3 < 5, continue
+        # batch 2: remaining=2, fetch_size=min(3,2)=2, returns 2, rows_scanned=5
+        mock_storage.list_raw.side_effect = [
+            all_entries[0:3],  # offset=0, limit=3
+            all_entries[3:5],  # offset=3, limit=2 (remaining)
+        ]
+
+        result = load_raw_content_hashes(mock_storage, limit=5)
+
+        assert result.rows_scanned == 5
+        assert result.rows_matched == 5
+        assert mock_storage.list_raw.call_count == 2
+        # Second call should request only 2 (remaining)
+        assert calls_kwargs(mock_storage, 1)["limit"] == 2
+
+    def test_single_batch_partial(self):
+        """When all entries fit in one batch, only one call is made."""
+        mock_storage = MagicMock()
+        mock_storage.list_raw.side_effect = [
+            [_make_entry(f"content {i}") for i in range(3)],
+        ]
+
+        result = load_raw_content_hashes(mock_storage, limit=100)
+
+        assert result.rows_scanned == 3
+        assert mock_storage.list_raw.call_count == 1
+
+    def test_source_filter_corpus(self, monkeypatch):
+        """Source filter 'corpus' should only match entries with [corpus:] prefix."""
+        monkeypatch.setattr(dedup_mod, "_DEDUP_BATCH_SIZE", 3)
+
+        mock_storage = MagicMock()
+        mock_storage.list_raw.side_effect = [
+            [
+                _make_entry("[corpus:repo] [file:x.py]\ncontent", source="corpus"),
+                _make_entry("plain entry", source="cli"),
+            ],
+        ]
+
+        result = load_raw_content_hashes(mock_storage, source_filter="corpus")
+        assert result.rows_scanned == 2
+        assert result.rows_matched == 1
+        assert len(result.hashes) == 1
+
+    def test_empty_storage(self):
+        """Empty storage should return zero counts."""
+        mock_storage = MagicMock()
+        mock_storage.list_raw.return_value = []
+
+        result = load_raw_content_hashes(mock_storage)
+        assert result.rows_scanned == 0
+        assert result.rows_matched == 0
+        assert len(result.hashes) == 0
+
+    def test_warns_when_limit_hit(self, monkeypatch, caplog):
+        """Should log a warning when scan hits the limit (possible truncation)."""
+        monkeypatch.setattr(dedup_mod, "_DEDUP_BATCH_SIZE", 3)
+
+        mock_storage = MagicMock()
+        # limit=3, batch_size=3, returns exactly 3 (full batch) => rows_scanned==limit
+        mock_storage.list_raw.side_effect = [
+            [_make_entry(f"content {i}") for i in range(3)],
+        ]
+
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="kernle.dedup"):
+            result = load_raw_content_hashes(mock_storage, limit=3)
+
+        assert result.rows_scanned == 3
+        assert "hit limit" in caplog.text
+
+    def test_no_warning_when_under_limit(self, monkeypatch, caplog):
+        """Should not warn when all entries are scanned before hitting limit."""
+        monkeypatch.setattr(dedup_mod, "_DEDUP_BATCH_SIZE", 10)
+
+        mock_storage = MagicMock()
+        mock_storage.list_raw.side_effect = [
+            [_make_entry(f"content {i}") for i in range(3)],
+        ]
+
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="kernle.dedup"):
+            result = load_raw_content_hashes(mock_storage, limit=100)
+
+        assert result.rows_scanned == 3
+        assert "hit limit" not in caplog.text
+
+    def test_duplicate_content_deduped_in_hashes(self, monkeypatch):
+        """Entries with identical content should produce the same hash (set dedupes)."""
+        monkeypatch.setattr(dedup_mod, "_DEDUP_BATCH_SIZE", 2)
+
+        mock_storage = MagicMock()
+        mock_storage.list_raw.side_effect = [
+            [_make_entry("same content"), _make_entry("same content")],
+            [_make_entry("different content")],
+        ]
+
+        result = load_raw_content_hashes(mock_storage, limit=100)
+        assert result.rows_scanned == 3
+        assert result.rows_matched == 3
+        assert len(result.hashes) == 2  # "same content" deduped
+
+
+def calls_kwargs(mock_storage, call_index):
+    """Helper to get kwargs from a specific mock call."""
+    return mock_storage.list_raw.call_args_list[call_index].kwargs

--- a/tests/test_diagnostic_sessions.py
+++ b/tests/test_diagnostic_sessions.py
@@ -327,7 +327,7 @@ class TestSchemaVersion:
     def test_schema_version_is_22(self):
         from kernle.storage.sqlite import SCHEMA_VERSION
 
-        assert SCHEMA_VERSION == 24
+        assert SCHEMA_VERSION == 25
 
     def test_tables_in_allowed_list(self):
         from kernle.storage.sqlite import ALLOWED_TABLES

--- a/tests/test_fractal_summarization.py
+++ b/tests/test_fractal_summarization.py
@@ -386,4 +386,4 @@ class TestSchemaVersion:
     def test_schema_version_updated(self):
         from kernle.storage.sqlite import SCHEMA_VERSION
 
-        assert SCHEMA_VERSION == 24
+        assert SCHEMA_VERSION == 25

--- a/tests/test_self_narrative.py
+++ b/tests/test_self_narrative.py
@@ -301,4 +301,4 @@ class TestSchemaVersion:
     def test_schema_version_updated(self):
         from kernle.storage.sqlite import SCHEMA_VERSION
 
-        assert SCHEMA_VERSION == 24
+        assert SCHEMA_VERSION == 25


### PR DESCRIPTION
## Summary

- Adds `offset` parameter to `list_raw` through the full call chain with input validation (`ValueError` on negative offset or non-positive limit)
- Switches to deterministic ordering (`captured_at DESC, id DESC`) for stable pagination
- Schema v25 migration: backfills `captured_at` from `timestamp`, replaces single-column index with compound `(stack_id, captured_at DESC, id DESC)`
- `_collect_all_corpus_entries` now paginates in 10k batches — eliminates silent 100k truncation for status counts
- `_load_existing_hashes` (corpus dedup) now uses full pagination via `_collect_all_corpus_entries` — no more hard cap
- `load_raw_content_hashes` paginates internally with configurable batch size; logs a warning when the scan limit is hit (other callers like `import_cmd.py` benefit)

Closes #533

## Test plan

- [x] `TestListRawOffset` — offset skips entries, offset beyond total returns empty, paginate-all no-gaps-no-dupes, deterministic ordering, negative offset raises, zero limit raises
- [x] `TestCollectAllPaginates` — mocked multi-batch corpus pagination with monkeypatched batch size
- [x] `TestLoadHashesPaginates` — multi-batch no-gaps-no-dupes with offset verification, limit stops mid-batch, source filter, empty storage, warns when limit hit, no warning under limit, duplicate content deduped
- [x] `TestMigrateSchemaV25` — backfills captured_at, preserves existing captured_at, replaces legacy single-column index with compound index
- [x] Full suite: 5290 passed, 2 skipped, 0 failed
- [x] Ruff + Black clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)