### PR TITLE
docs+tests: v0.13.05 stack alert threshold coverage and command docs sync

### DIFF
--- a/docs-site/cli/memory-commands.mdx
+++ b/docs-site/cli/memory-commands.mdx
@@ -319,23 +319,56 @@ kernle -s my-project drive satisfy curiosity --amount 0.2
 
 ---
 
-## relationship
+## relation
 
-Track relationships with other entities.
+Manage relationships with other entities.
+
+### Add Relationship
 
 ```bash
-kernle -s <stack> relationship NAME [--trust T] [--type TYPE] [--notes NOTES]
+kernle -s <stack> relation add NAME [--type TYPE] [--trust T] [--notes NOTES] [--derived-from ID...]
 ```
 
 | Option | Description |
 |--------|-------------|
-| `--trust T` | Trust level (-1.0 to 1.0) |
-| `--type TYPE` | `si`, `person`, or `organization` |
+| `-t, --type TYPE` | `person`, `si`, `organization`, `system` |
+| `--trust T` | Trust level (0.0 to 1.0) |
 | `--notes NOTES` | Relationship observations |
+| `--derived-from ID` | Source memory ID (repeatable) |
 
 ```bash
-kernle -s my-project relationship "Alice" --trust 0.9 --notes "Great debugging partner"
-kernle -s my-project relationship "DevOps" --type organization --notes "Manages infrastructure"
+kernle -s my-project relation add "Alice" --trust 0.9 --notes "Great debugging partner"
+kernle -s my-project relation add "DevOps Team" --type organization --notes "Owns infrastructure"
+```
+
+### List Relationships
+
+```bash
+kernle -s <stack> relation list
+```
+
+### Show Relationship
+
+```bash
+kernle -s <stack> relation show NAME
+```
+
+### Update Relationship
+
+```bash
+kernle -s <stack> relation update NAME [--type TYPE] [--trust T] [--notes NOTES] [--derived-from ID...]
+```
+
+### Log Interaction
+
+```bash
+kernle -s <stack> relation log NAME --interaction INTERACTION
+```
+
+### Relationship History
+
+```bash
+kernle -s <stack> relation history NAME [--type TYPE] [--limit LIMIT]
 ```
 
 ---

--- a/docs-site/cli/overview.mdx
+++ b/docs-site/cli/overview.mdx
@@ -5,7 +5,7 @@ description: "Complete reference for the Kernle command-line interface"
 
 # CLI Overview
 
-The Kernle CLI provides 28+ commands for managing SI memory.
+The Kernle CLI provides 32+ commands for managing SI memory.
 
 ## Global Options
 
@@ -23,15 +23,17 @@ If no stack ID is provided, Kernle will try to resolve one automatically from en
 
 <CardGroup cols={2}>
   <Card title="Memory Commands" icon="brain" href="/cli/memory-commands">
-    episode, note, raw, belief, value, goal, drive, relationship, playbook
+    episode, note, raw, belief, value, goal, drive, relation, playbook
   </Card>
   <Card title="Utility Commands" icon="wrench" href="/cli/utility-commands">
-    load, checkpoint, search, status, anxiety, identity, promote, process, model, export, export-full
+    load, checkpoint, search, status, anxiety, identity, trust, emotion, promote, process, model, export, export-full
   </Card>
   <Card title="MCP Server" icon="plug" href="/integration/mcp">
     mcp - Start MCP server for tool integration
   </Card>
 </CardGroup>
+
+Additional top-level commands include `auth`, `boot`, `doctor`, `audit`, `export-cache`, `import`, `seed`, `stack`, `migrate`, `entity-model`, `setup`, `hook`, `relation`, `meta`, `narrative`, and `epoch`.
 
 ## Command Quick Reference
 
@@ -55,7 +57,7 @@ If no stack ID is provided, Kernle will try to resolve one automatically from en
 | `value` | Define core values |
 | `goal` | Set active goals |
 | `drive` | Manage intrinsic motivations |
-| `relationship` | Track relationships |
+| `relation` | Track relationships |
 | `playbook` | Procedural memory |
 
 ### Search & Analysis

--- a/docs-site/concepts/identity.mdx
+++ b/docs-site/concepts/identity.mdx
@@ -120,8 +120,8 @@ kernle drive set connection 0.6 --focus "team collaboration"
 ### 6. Model Relationships (up to 10%)
 
 ```bash
-kernle relationship "Alice" --trust 0.8 --notes "Helpful colleague, great at debugging"
-kernle relationship "Bob" --trust 0.9 --notes "Primary collaborator"
+kernle relation add "Alice" --trust 0.8 --notes "Helpful colleague, great at debugging"
+kernle relation add "Bob" --trust 0.9 --notes "Primary collaborator"
 ```
 
 ## Example: Improving a 45% Score

--- a/docs-site/concepts/memory-types.mdx
+++ b/docs-site/concepts/memory-types.mdx
@@ -5,7 +5,7 @@ description: "Complete reference for all Kernle memory types"
 
 # Memory Types
 
-Kernle supports sixteen distinct memory types, each serving a specific purpose in the memory hierarchy.
+Kernle uses fourteen canonical memory record types, plus diagnostic artifacts used by health checks.
 
 ## Raw Entries
 
@@ -255,8 +255,8 @@ Relationships track your connections with others.
 
 **Usage**:
 ```bash
-kernle relationship "Alice" --trust 0.9 --notes "Senior engineer, great mentor"
-kernle relationship "DevOps Team" --type organization --notes "Owns infrastructure"
+kernle relation add "Alice" --trust 0.9 --notes "Senior engineer, great mentor"
+kernle relation add "DevOps Team" --type organization --notes "Owns infrastructure"
 ```
 
 ---
@@ -302,6 +302,33 @@ kernle playbook find "deploying new feature"
 
 # Record usage
 kernle playbook record <id> --success
+```
+
+---
+
+## Suggestions
+
+**Purpose**: Candidate memory extractions from raw entries awaiting human review.
+
+Suggestions are auto-generated from raw signals and promoted to concrete memory records when approved.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | TEXT | Suggestion identifier |
+| `memory_type` | TEXT | Target type (`episode`, `belief`, `note`, `goal`, `relationship`, `value`, `drive`) |
+| `content` | JSON | Structured payload for the target record |
+| `confidence` | FLOAT | System confidence score (0.0 to 1.0) |
+| `source_raw_ids` | JSON | Origin raw entry IDs |
+| `status` | TEXT | `pending`, `promoted`, `modified`, `rejected`, `dismissed`, `expired` |
+| `promoted_to` | TEXT | Optional `type:id` for accepted suggestion |
+| `created_at` | DATETIME | Time created |
+
+**Usage**:
+
+```bash
+kernle raw "I learned that restarting services before deploy reduced incidents"
+kernle suggestions list --pending
+kernle suggestions accept abc123 --objective "..." --outcome "..."
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Synced docs references from `kernle relationship` to `kernle relation` across capabilities and docs-site pages.
- Added threshold regression tests for:
  - `ConsolidationComponent._build_alerts()`
  - `AnxietyComponent._build_alerts()`

## Verification
- `pytest tests/test_stack_components.py -k "AnxietyComponent or ConsolidationComponent"` (42 passed)

Closes #661
