### PR TITLE
v0.13.07: Runtime safety, sync integrity, and observability hardening

### DIFF
--- a/kernle/cli/__main__.py
+++ b/kernle/cli/__main__.py
@@ -403,6 +403,7 @@ def cmd_init(args, k: Kernle):
                 print("  ✓ Seeded: memory_sovereignty (priority 90)")
                 print("  ✓ Seeded: continuous_learning (priority 85)")
         except Exception as e:
+            logger.debug("Could not seed values during setup: %s", e)
             print(f"  Warning: Could not seed values: {e}")
         print()
 
@@ -418,6 +419,7 @@ def cmd_init(args, k: Kernle):
         )
         print("  ✓ Checkpoint saved")
     except Exception as e:
+        logger.debug("Could not create initial checkpoint: %s", e)
         print(f"  Warning: Could not create checkpoint: {e}")
     print()
 
@@ -2386,6 +2388,12 @@ Beliefs already present in the agent's memory will be skipped.
                 k.entity.load_plugin(plugin)
                 activated = True
             except Exception as e:
+                logger.warning(
+                    "Failed to activate plugin '%s' for command '%s': %s",
+                    plugin.name,
+                    args.command,
+                    e,
+                )
                 print(
                     f"Failed to activate plugin '{plugin.name}' for "
                     f"command '{args.command}': {e}"

--- a/kernle/cli/commands/credentials.py
+++ b/kernle/cli/commands/credentials.py
@@ -1,11 +1,14 @@
 """Credential management helpers for Kernle CLI."""
 
 import json
+import logging
 import sys
 from pathlib import Path
 from urllib.parse import urlparse
 
 from kernle.utils import get_kernle_home
+
+logger = logging.getLogger(__name__)
 
 
 def get_credentials_path() -> Path:
@@ -54,7 +57,8 @@ def _is_local_http(url: str) -> bool:
         parsed = urlparse(url)
         hostname = parsed.hostname  # Strips port, userinfo, etc.
         return hostname in ("localhost", "127.0.0.1")
-    except Exception:
+    except Exception as exc:
+        logger.debug("Swallowed %s in _is_local_http: %s", type(exc).__name__, exc)
         return False
 
 

--- a/kernle/cli/commands/diagnostic.py
+++ b/kernle/cli/commands/diagnostic.py
@@ -120,7 +120,7 @@ def cmd_resume(args, k: "Kernle"):
 
     # Check anxiety level
     try:
-        anxiety = k.get_anxiety()
+        anxiety = k.anxiety()
         anxiety_score = anxiety.get("overall_score", 0)
         if anxiety_score > 60:
             anxiety_indicator = " 🔴"

--- a/kernle/cli/commands/doctor.py
+++ b/kernle/cli/commands/doctor.py
@@ -279,6 +279,7 @@ def check_seed_beliefs(k: "Kernle") -> Tuple[ComplianceCheck, dict]:
             )
 
     except Exception as e:
+        logger.debug("Seed beliefs compliance check failed: %s", e)
         return (
             ComplianceCheck(
                 name="seed_beliefs",
@@ -369,6 +370,7 @@ def check_openclaw_hook() -> ComplianceCheck:
                 category="recommended",
             )
     except Exception as e:
+        logger.debug("OpenClaw hook config check failed: %s", e)
         return ComplianceCheck(
             name="openclaw_hook",
             passed=False,

--- a/kernle/cli/commands/import_cmd.py
+++ b/kernle/cli/commands/import_cmd.py
@@ -8,6 +8,7 @@ Supports importing from:
 """
 
 import json
+import logging
 import math
 import re
 from pathlib import Path
@@ -21,6 +22,7 @@ if TYPE_CHECKING:
 
     from kernle import Kernle
 
+logger = logging.getLogger(__name__)
 
 _DUPLICATE_SCAN_LIMIT = 100_000
 _IMPORT_FINGERPRINT_SCHEME = "context:import-fingerprint:v1"
@@ -549,6 +551,7 @@ def _import_json(
             if skip_duplicates:
                 _register_seen_signature(import_item, seen_signatures)
         except Exception as e:
+            logger.debug("Import value failed: %s", e)
             errors.append(f"value: {str(e)[:50]}")
 
     # Beliefs
@@ -586,6 +589,7 @@ def _import_json(
             if skip_duplicates:
                 _register_seen_signature(import_item, seen_signatures)
         except Exception as e:
+            logger.debug("Import belief failed: %s", e)
             errors.append(f"belief: {str(e)[:50]}")
 
     # Goals
@@ -622,6 +626,7 @@ def _import_json(
             if skip_duplicates:
                 _register_seen_signature(import_item, seen_signatures)
         except Exception as e:
+            logger.debug("Import goal failed: %s", e)
             errors.append(f"goal: {str(e)[:50]}")
 
     # Episodes
@@ -655,6 +660,7 @@ def _import_json(
             if skip_duplicates:
                 _register_seen_signature(import_item, seen_signatures)
         except Exception as e:
+            logger.debug("Import episode failed: %s", e)
             errors.append(f"episode: {str(e)[:50]}")
 
     # Notes
@@ -691,6 +697,7 @@ def _import_json(
             if skip_duplicates:
                 _register_seen_signature(import_item, seen_signatures)
         except Exception as e:
+            logger.debug("Import note failed: %s", e)
             errors.append(f"note: {str(e)[:50]}")
 
     # Drives
@@ -728,6 +735,7 @@ def _import_json(
             if skip_duplicates:
                 _register_seen_signature(import_item, seen_signatures)
         except Exception as e:
+            logger.debug("Import drive failed: %s", e)
             errors.append(f"drive: {str(e)[:50]}")
 
     # Relationships
@@ -769,6 +777,7 @@ def _import_json(
             if skip_duplicates:
                 _register_seen_signature(import_item, seen_signatures)
         except Exception as e:
+            logger.debug("Import relationship failed: %s", e)
             errors.append(f"relationship: {str(e)[:50]}")
 
     # Raw entries
@@ -793,6 +802,7 @@ def _import_json(
             if skip_duplicates:
                 _register_seen_signature(import_item, seen_signatures)
         except Exception as e:
+            logger.debug("Import raw entry failed: %s", e)
             errors.append(f"raw: {str(e)[:50]}")
 
     # Summary
@@ -837,6 +847,7 @@ def _import_csv(
         reader = csv.DictReader(io.StringIO(content))
         headers = [h.lower().strip() for h in (reader.fieldnames or [])]
     except Exception as e:
+        logger.debug("CSV parsing failed: %s", e)
         print(f"Error: Invalid CSV: {e}")
         return
 
@@ -982,6 +993,7 @@ def _import_pdf(
     try:
         text = extract_text(str(file_path))
     except Exception as e:
+        logger.debug("PDF text extraction failed: %s", e)
         print(f"Error extracting text from PDF: {e}")
         return
 
@@ -1037,6 +1049,7 @@ def _import_pdf(
             k.raw(blob=content, source=source)
             imported += 1
         except Exception as e:
+            logger.debug("Import PDF chunk failed: %s", e)
             errors.append(f"chunk {chunk['chunk_name']}: {str(e)[:50]}")
 
     print(f"Imported {imported} raw entries from PDF")
@@ -1472,6 +1485,7 @@ def _batch_import(
                 _register_seen_signature(item, seen_signatures)
             success += 1
         except Exception as e:
+            logger.debug("Import item %s failed: %s", item.get("type", "unknown"), e)
             errors.append(f"{item['type']}: {str(e)[:50]}")
 
     print(f"Imported {success} items")

--- a/kernle/cli/commands/init.py
+++ b/kernle/cli/commands/init.py
@@ -1,8 +1,11 @@
 """Init command for Kernle CLI - generates CLAUDE.md sections for frictionless adoption."""
 
+import logging
 import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from kernle import Kernle
@@ -140,7 +143,8 @@ def _snapshot_values(k: "Kernle") -> list[str]:
     """Snapshot value names to validate seed-value side effects."""
     try:
         return [value.name for value in k.storage.get_values()]
-    except Exception:
+    except Exception as exc:
+        logger.debug("Swallowed %s in _snapshot_values: %s", type(exc).__name__, exc)
         return []
 
 

--- a/kernle/cli/commands/migrate.py
+++ b/kernle/cli/commands/migrate.py
@@ -2,7 +2,10 @@
 
 import hashlib
 import json as _json
+import logging
 from typing import TYPE_CHECKING, Dict, List
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     import argparse
@@ -336,6 +339,7 @@ def _migrate_seed_beliefs(args: "argparse.Namespace", k: "Kernle") -> None:
             tier_label = f"[Tier {belief['tier']}]" if belief["tier"] > 0 else "[Meta]"
             print(f"  ✓ {tier_label} {belief['statement'][:50]}...")
         except Exception as e:
+            logger.debug("Seed belief failed: %s", e)
             errors.append(f"{belief['statement'][:30]}...: {e}")
 
     print(f"\n{'='*60}")
@@ -742,6 +746,7 @@ def _migrate_backfill_provenance(args: "argparse.Namespace", k: "Kernle") -> Non
                 )
                 applied += 1
         except Exception as e:
+            logger.debug("Provenance backfill failed for %s:%s: %s", u["type"], u["id"][:8], e)
             errors.append(f"{u['type']}:{u['id'][:8]}...: {e}")
 
     if not json_output:
@@ -1120,6 +1125,7 @@ def _migrate_link_raw(args: "argparse.Namespace", k: "Kernle") -> None:
             )
             applied += 1
         except Exception as e:
+            logger.debug("Raw link failed for %s:%s: %s", link["type"], link["id"][:8], e)
             errors.append(f"{link['type']}:{link['id'][:8]}...: {e}")
 
     if not json_output:

--- a/kernle/cli/commands/sync.py
+++ b/kernle/cli/commands/sync.py
@@ -115,6 +115,7 @@ def cmd_sync(args, k: "Kernle"):
                 return True, "Connected"
             return False, f"Backend returned status {response.status_code}"
         except Exception as e:
+            logger.debug("Sync connectivity check failed: %s", e)
             return False, f"Connection failed: {e}"
 
     def get_headers():
@@ -309,7 +310,10 @@ def cmd_sync(args, k: "Kernle"):
         """Serialize to stable JSON for metadata storage/fingerprinting."""
         try:
             return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
-        except Exception:
+        except Exception as exc:
+            logger.debug(
+                "Swallowed %s in _serialize_json, using fallback: %s", type(exc).__name__, exc
+            )
             return json.dumps(str(value))
 
     def _operation_payload_hash(operation):
@@ -907,6 +911,7 @@ def cmd_sync(args, k: "Kernle"):
                 sys.exit(1)
 
         except Exception as e:
+            logger.warning("Push failed: %s", e)
             print(f"✗ Push failed: {e}")
             print("  Tip: changes are queued locally and will be pushed on next `kernle sync push`")
             sys.exit(1)
@@ -1062,6 +1067,7 @@ def cmd_sync(args, k: "Kernle"):
                 sys.exit(1)
 
         except Exception as e:
+            logger.warning("Pull failed: %s", e)
             print(f"✗ Pull failed: {e}")
             print("  Tip: check network connectivity, then retry with `kernle sync pull`")
             sys.exit(1)

--- a/kernle/exhaust.py
+++ b/kernle/exhaust.py
@@ -157,6 +157,7 @@ class ExhaustionRunner:
                                 cycle_result.promotions += len(pr.suggestions)
                             cycle_result.errors.extend(pr.errors)
                     except Exception as e:
+                        logger.warning("Exhaust cycle transition %s failed: %s", transition, e)
                         cycle_result.errors.append(f"{transition}: {e}")
 
                 result.cycle_results.append(cycle_result)

--- a/kernle/importers/csv_importer.py
+++ b/kernle/importers/csv_importer.py
@@ -164,6 +164,7 @@ class CsvImporter:
                 else:
                     counts[item.type] = counts.get(item.type, 0) + 1
             except Exception as e:
+                logger.debug("CSV import row %d (%s) failed: %s", i + 2, item.type, e)
                 errors.append(f"Row {i + 2}: {item.type}: {str(e)[:50]}")
 
         return {

--- a/kernle/importers/json_importer.py
+++ b/kernle/importers/json_importer.py
@@ -155,6 +155,7 @@ class JsonImporter:
                 else:
                     counts[item.type] = counts.get(item.type, 0) + 1
             except Exception as e:
+                logger.debug("JSON import item %s failed: %s", item.type, e)
                 errors.append(f"{item.type}: {str(e)[:50]}")
 
         return {

--- a/kernle/importers/markdown.py
+++ b/kernle/importers/markdown.py
@@ -9,10 +9,13 @@ Parses markdown files with sections like:
 - ## Raw / ## Thoughts
 """
 
+import logging
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from kernle import Kernle
@@ -93,6 +96,7 @@ class MarkdownImporter:
                     _import_item(item, k)
                 counts[item.type] = counts.get(item.type, 0) + 1
             except Exception as e:
+                logger.debug("Markdown import item %s failed: %s", item.type, e)
                 errors.append(f"{item.type}: {str(e)[:50]}")
 
         return counts

--- a/kernle/mcp/handlers/processing.py
+++ b/kernle/mcp/handlers/processing.py
@@ -1,11 +1,14 @@
 """Handlers for memory processing tools: process, process_status."""
 
+import logging
 from typing import Any, Dict
 
 from kernle.core import Kernle
 from kernle.mcp.sanitize import (
     sanitize_string,
 )
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Validators
@@ -168,6 +171,7 @@ def handle_memory_process_status(args: Dict[str, Any], k: Kernle) -> str:
                 status = "READY" if would_fire else "waiting"
                 lines.append(f"  {transition_name}: {count}/{cfg.quantity_threshold} ({status})")
     except Exception as e:
+        logger.warning("Error gathering processing status: %s", e)
         lines.append(f"\nError gathering status: {e}")
 
     return "\n".join(lines)

--- a/kernle/mcp/server.py
+++ b/kernle/mcp/server.py
@@ -39,7 +39,8 @@ try:
     from jsonschema.exceptions import SchemaError
 
     _HAS_JSONSCHEMA = True
-except Exception:
+except Exception as exc:
+    logger.debug("Swallowed %s importing jsonschema (optional): %s", type(exc).__name__, exc)
     Draft7Validator = None  # type: ignore[assignment]
     SchemaError = Exception  # type: ignore[assignment]
     _HAS_JSONSCHEMA = False

--- a/kernle/stack/components/anxiety.py
+++ b/kernle/stack/components/anxiety.py
@@ -187,8 +187,10 @@ class AnxietyComponent:
                     raw_aging_detail = f"{total_unprocessed} unprocessed (all fresh)"
                 else:
                     raw_aging_detail = f"{aging_count}/{total_unprocessed} entries >24h old"
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug(
+                "Swallowed %s computing raw_aging anxiety dimension: %s", type(exc).__name__, exc
+            )
         raw_conf = score_with_confidence(raw_aging_score, raw_sample_count)
         dimensions["raw_aging"] = {
             "score": raw_conf["score"],
@@ -209,8 +211,12 @@ class AnxietyComponent:
                 months = (now - started).total_seconds() / (30.44 * 86400)
                 epoch_staleness_score = compute_epoch_staleness_score(months)
                 epoch_sample_count = 1
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug(
+                "Swallowed %s computing epoch_staleness anxiety dimension: %s",
+                type(exc).__name__,
+                exc,
+            )
         epoch_conf = score_with_confidence(min(100, epoch_staleness_score), epoch_sample_count)
         dimensions["epoch_staleness"] = {
             "score": epoch_conf["score"],

--- a/kernle/stack/components/suggestions.py
+++ b/kernle/stack/components/suggestions.py
@@ -169,7 +169,10 @@ class SuggestionComponent:
         for suggestion in existing:
             try:
                 signatures.add(self._suggestion_signature(raw_id, suggestion))
-            except Exception:
+            except Exception as exc:
+                logger.debug(
+                    "Swallowed %s computing suggestion signature: %s", type(exc).__name__, exc
+                )
                 continue
         return signatures
 

--- a/kernle/storage/beliefs_crud.py
+++ b/kernle/storage/beliefs_crud.py
@@ -1,0 +1,389 @@
+"""Beliefs CRUD operations extracted from SQLiteStorage.
+
+Pilot extraction (#732) — demonstrates the pattern for decomposing
+SQLiteStorage's god-object into focused modules.
+
+All functions receive dependencies explicitly (connection factory,
+serializers, sync callbacks) to avoid circular imports and enable
+independent testing.
+"""
+
+import logging
+import sqlite3
+import uuid
+from typing import Any, Callable, List, Optional
+
+from .base import Belief, VersionConflictError
+from .memory_crud import _row_to_belief as _mc_row_to_belief
+
+logger = logging.getLogger(__name__)
+
+
+def save_belief(
+    connect_fn: Callable,
+    stack_id: str,
+    belief: Belief,
+    now_fn: Callable[[], str],
+    to_json: Callable[[Any], Optional[str]],
+    record_to_dict: Callable,
+    queue_sync: Callable,
+    save_embedding: Callable,
+    sync_to_file: Callable,
+    *,
+    lineage_checker: Optional[Callable] = None,
+) -> str:
+    """Save a belief.
+
+    Args:
+        connect_fn: Context manager returning a DB connection.
+        stack_id: The stack ID for record isolation.
+        belief: The Belief to save.
+        now_fn: Returns current UTC timestamp as ISO string.
+        to_json: Serializes objects to JSON strings.
+        record_to_dict: Converts a dataclass to a dict for sync.
+        queue_sync: Queues a sync operation (conn, table, id, op, data).
+        save_embedding: Saves embedding for search (conn, table, id, content).
+        sync_to_file: Syncs beliefs to flat file (no args).
+        lineage_checker: Optional callable for derived-from cycle detection.
+            Receives (storage, memory_type, id, derived_from).
+    """
+    if not belief.id:
+        belief.id = str(uuid.uuid4())
+
+    if belief.derived_from and lineage_checker:
+        lineage_checker("belief", belief.id, belief.derived_from)
+
+    now = now_fn()
+
+    with connect_fn() as conn:
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO beliefs
+            (id, stack_id, statement, belief_type, confidence, created_at,
+             source_type, source_episodes, derived_from,
+             last_verified, verification_count, confidence_history,
+             supersedes, superseded_by, times_reinforced, is_active,
+             strength,
+             context, context_tags, source_entity, subject_ids, access_grants, consent_grants,
+             processed,
+             belief_scope, source_domain, cross_domain_applications, abstraction_level,
+             epoch_id,
+             local_updated_at, cloud_synced_at, version, deleted)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+            (
+                belief.id,
+                stack_id,
+                belief.statement,
+                belief.belief_type,
+                belief.confidence,
+                belief.created_at.isoformat() if belief.created_at else now,
+                belief.source_type,
+                to_json(belief.source_episodes),
+                to_json(belief.derived_from),
+                belief.last_verified.isoformat() if belief.last_verified else None,
+                belief.verification_count,
+                to_json(belief.confidence_history),
+                belief.supersedes,
+                belief.superseded_by,
+                belief.times_reinforced,
+                1 if belief.is_active else 0,
+                belief.strength,
+                belief.context,
+                to_json(belief.context_tags),
+                getattr(belief, "source_entity", None),
+                to_json(getattr(belief, "subject_ids", None)),
+                to_json(getattr(belief, "access_grants", None)),
+                to_json(getattr(belief, "consent_grants", None)),
+                1 if belief.processed else 0,
+                getattr(belief, "belief_scope", "world"),
+                getattr(belief, "source_domain", None),
+                to_json(getattr(belief, "cross_domain_applications", None)),
+                getattr(belief, "abstraction_level", "specific"),
+                belief.epoch_id,
+                now,
+                belief.cloud_synced_at.isoformat() if belief.cloud_synced_at else None,
+                belief.version,
+                1 if belief.deleted else 0,
+            ),
+        )
+        belief_data = to_json(record_to_dict(belief))
+        queue_sync(conn, "beliefs", belief.id, "upsert", data=belief_data)
+        save_embedding(conn, "beliefs", belief.id, belief.statement)
+        conn.commit()
+
+    sync_to_file()
+    return belief.id
+
+
+def update_belief_atomic(
+    connect_fn: Callable,
+    stack_id: str,
+    belief: Belief,
+    now_fn: Callable[[], str],
+    to_json: Callable[[Any], Optional[str]],
+    record_to_dict: Callable,
+    queue_sync: Callable,
+    save_embedding: Callable,
+    sync_to_file: Callable,
+    expected_version: Optional[int] = None,
+) -> bool:
+    """Update a belief with optimistic concurrency control.
+
+    Returns True if update succeeded.
+    Raises VersionConflictError if the record's version doesn't match expected.
+    """
+    if expected_version is None:
+        expected_version = belief.version
+
+    now = now_fn()
+
+    with connect_fn() as conn:
+        current = conn.execute(
+            "SELECT version FROM beliefs WHERE id = ? AND stack_id = ?",
+            (belief.id, stack_id),
+        ).fetchone()
+
+        if not current:
+            return False
+
+        current_version = current["version"]
+        if current_version != expected_version:
+            raise VersionConflictError("beliefs", belief.id, expected_version, current_version)
+
+        cursor = conn.execute(
+            """
+            UPDATE beliefs SET
+                statement = ?,
+                belief_type = ?,
+                confidence = ?,
+                source_type = ?,
+                source_episodes = ?,
+                derived_from = ?,
+                last_verified = ?,
+                verification_count = ?,
+                confidence_history = ?,
+                supersedes = ?,
+                superseded_by = ?,
+                times_reinforced = ?,
+                is_active = ?,
+                context = ?,
+                context_tags = ?,
+                belief_scope = ?,
+                source_domain = ?,
+                cross_domain_applications = ?,
+                abstraction_level = ?,
+                local_updated_at = ?,
+                deleted = ?,
+                version = version + 1
+            WHERE id = ? AND stack_id = ? AND version = ?
+            """,
+            (
+                belief.statement,
+                belief.belief_type,
+                belief.confidence,
+                belief.source_type,
+                to_json(belief.source_episodes),
+                to_json(belief.derived_from),
+                belief.last_verified.isoformat() if belief.last_verified else None,
+                belief.verification_count,
+                to_json(belief.confidence_history),
+                belief.supersedes,
+                belief.superseded_by,
+                belief.times_reinforced,
+                1 if belief.is_active else 0,
+                belief.context,
+                to_json(belief.context_tags),
+                getattr(belief, "belief_scope", "world"),
+                getattr(belief, "source_domain", None),
+                to_json(getattr(belief, "cross_domain_applications", None)),
+                getattr(belief, "abstraction_level", "specific"),
+                now,
+                1 if belief.deleted else 0,
+                belief.id,
+                stack_id,
+                expected_version,
+            ),
+        )
+
+        if cursor.rowcount == 0:
+            conn.rollback()
+            new_current = conn.execute(
+                "SELECT version FROM beliefs WHERE id = ? AND stack_id = ?",
+                (belief.id, stack_id),
+            ).fetchone()
+            actual = new_current["version"] if new_current else -1
+            raise VersionConflictError("beliefs", belief.id, expected_version, actual)
+
+        belief.version = expected_version + 1
+        belief_data = to_json(record_to_dict(belief))
+        queue_sync(conn, "beliefs", belief.id, "upsert", data=belief_data)
+        save_embedding(conn, "beliefs", belief.id, belief.statement)
+        conn.commit()
+
+    sync_to_file()
+    return True
+
+
+def save_beliefs_batch(
+    connect_fn: Callable,
+    stack_id: str,
+    beliefs: List[Belief],
+    now_fn: Callable[[], str],
+    to_json: Callable[[Any], Optional[str]],
+    record_to_dict: Callable,
+    queue_sync: Callable,
+    save_embedding: Callable,
+    sync_to_file: Callable,
+) -> List[str]:
+    """Save multiple beliefs in a single transaction."""
+    if not beliefs:
+        return []
+    now = now_fn()
+    ids = []
+    with connect_fn() as conn:
+        for belief in beliefs:
+            if not belief.id:
+                belief.id = str(uuid.uuid4())
+            ids.append(belief.id)
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO beliefs
+                (id, stack_id, statement, belief_type, confidence, created_at,
+                 source_type, source_episodes, derived_from,
+                 last_verified, verification_count, confidence_history,
+                 supersedes, superseded_by, times_reinforced, is_active,
+                 times_accessed, last_accessed, is_protected, strength,
+                 context, context_tags, processed,
+                 belief_scope, source_domain, cross_domain_applications, abstraction_level,
+                 epoch_id,
+                 local_updated_at, cloud_synced_at, version, deleted)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+                (
+                    belief.id,
+                    stack_id,
+                    belief.statement,
+                    belief.belief_type,
+                    belief.confidence,
+                    belief.created_at.isoformat() if belief.created_at else now,
+                    belief.source_type,
+                    to_json(belief.source_episodes),
+                    to_json(belief.derived_from),
+                    belief.last_verified.isoformat() if belief.last_verified else None,
+                    belief.verification_count,
+                    to_json(belief.confidence_history),
+                    belief.supersedes,
+                    belief.superseded_by,
+                    belief.times_reinforced,
+                    1 if belief.is_active else 0,
+                    belief.times_accessed,
+                    belief.last_accessed.isoformat() if belief.last_accessed else None,
+                    1 if belief.is_protected else 0,
+                    belief.strength,
+                    belief.context,
+                    to_json(belief.context_tags),
+                    1 if belief.processed else 0,
+                    getattr(belief, "belief_scope", "world"),
+                    getattr(belief, "source_domain", None),
+                    to_json(getattr(belief, "cross_domain_applications", None)),
+                    getattr(belief, "abstraction_level", "specific"),
+                    belief.epoch_id,
+                    now,
+                    belief.cloud_synced_at.isoformat() if belief.cloud_synced_at else None,
+                    belief.version,
+                    1 if belief.deleted else 0,
+                ),
+            )
+            belief_data = to_json(record_to_dict(belief))
+            queue_sync(conn, "beliefs", belief.id, "upsert", data=belief_data)
+            save_embedding(conn, "beliefs", belief.id, belief.statement)
+        conn.commit()
+    sync_to_file()
+    return ids
+
+
+def get_beliefs(
+    connect_fn: Callable,
+    stack_id: str,
+    build_access_filter: Callable,
+    limit: int = 100,
+    include_inactive: bool = False,
+    requesting_entity: Optional[str] = None,
+    processed: Optional[bool] = None,
+) -> List[Belief]:
+    """Get beliefs with optional privacy/processing filters."""
+    access_filter, access_params = build_access_filter(requesting_entity)
+    processed_filter = ""
+    processed_params: List[Any] = []
+    if processed is not None:
+        processed_filter = " AND processed = ?"
+        processed_params = [1 if processed else 0]
+    with connect_fn() as conn:
+        if include_inactive:
+            rows = conn.execute(
+                f"SELECT * FROM beliefs WHERE stack_id = ? AND deleted = 0{access_filter}{processed_filter} ORDER BY created_at DESC LIMIT ?",
+                [stack_id] + access_params + processed_params + [limit],
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                f"SELECT * FROM beliefs WHERE stack_id = ? AND deleted = 0 AND (is_active = 1 OR is_active IS NULL){access_filter}{processed_filter} ORDER BY created_at DESC LIMIT ?",
+                [stack_id] + access_params + processed_params + [limit],
+            ).fetchall()
+
+    return [_mc_row_to_belief(row) for row in rows]
+
+
+def find_belief(
+    connect_fn: Callable,
+    stack_id: str,
+    statement: str,
+) -> Optional[Belief]:
+    """Find a belief by exact statement text."""
+    with connect_fn() as conn:
+        row = conn.execute(
+            "SELECT * FROM beliefs WHERE stack_id = ? AND statement = ? AND deleted = 0",
+            (stack_id, statement),
+        ).fetchone()
+
+    return _mc_row_to_belief(row) if row else None
+
+
+def get_belief(
+    connect_fn: Callable,
+    stack_id: str,
+    belief_id: str,
+    build_access_filter: Callable,
+    requesting_entity: Optional[str] = None,
+) -> Optional[Belief]:
+    """Get a specific belief by ID with optional privacy filter."""
+    query = "SELECT * FROM beliefs WHERE id = ? AND stack_id = ?"
+    params: List[Any] = [belief_id, stack_id]
+
+    access_filter, access_params = build_access_filter(requesting_entity)
+    query += access_filter
+    params.extend(access_params)
+
+    with connect_fn() as conn:
+        row = conn.execute(query, params).fetchone()
+
+    return _mc_row_to_belief(row) if row else None
+
+
+def get_belief_by_id(
+    connect_fn: Callable,
+    stack_id: str,
+    belief_id: str,
+) -> Optional[Belief]:
+    """Get a belief by ID (internal, no privacy filter)."""
+    with connect_fn() as conn:
+        row = conn.execute(
+            "SELECT * FROM beliefs WHERE id = ? AND stack_id = ? AND deleted = 0",
+            (belief_id, stack_id),
+        ).fetchone()
+    return _mc_row_to_belief(row) if row else None
+
+
+def row_to_belief(row: sqlite3.Row) -> Belief:
+    """Convert a database row to a Belief dataclass."""
+    return _mc_row_to_belief(row)

--- a/kernle/storage/cloud.py
+++ b/kernle/storage/cloud.py
@@ -170,6 +170,7 @@ class CloudClient:
                 "error": f"Connection failed: {e.reason}",
             }
         except Exception as e:
+            logger.debug("Cloud health check failed: %s", e)
             return {
                 "healthy": False,
                 "error": str(e),

--- a/kernle/storage/raw_entries.py
+++ b/kernle/storage/raw_entries.py
@@ -362,6 +362,7 @@ def sync_raw_from_files(
                 )
 
         except Exception as e:
+            logger.debug("Raw entry file import failed for %s: %s", file_path.name, e)
             result["errors"].append(f"{file_path.name}: {str(e)}")
 
     return result
@@ -427,6 +428,7 @@ def import_raw_entry(
         result["imported"] += 1
 
     except Exception as e:
+        logger.debug("Raw entry import failed for %s: %s", id_prefix, e)
         result["errors"].append(f"Entry {id_prefix}: {str(e)}")
 
 

--- a/kernle/testing/assertions.py
+++ b/kernle/testing/assertions.py
@@ -113,7 +113,8 @@ class CognitiveAssertions:
                 return self._storage.get_raw(mem_id)
             if hasattr(self._storage, "get_memory"):
                 return self._storage.get_memory(mem_type, mem_id)
-        except Exception:
+        except Exception as exc:
+            logger.debug("Swallowed %s in _get_memory_by_ref(%s): %s", type(exc).__name__, ref, exc)
             return None
         return None
 

--- a/tests/test_beliefs_crud.py
+++ b/tests/test_beliefs_crud.py
@@ -1,0 +1,632 @@
+"""Tests for kernle.storage.beliefs_crud — extracted beliefs CRUD module.
+
+Verifies the extracted functions work correctly with injected dependencies,
+independent of SQLiteStorage.
+"""
+
+import sqlite3
+import uuid
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from kernle.storage.beliefs_crud import (
+    find_belief,
+    get_belief,
+    get_belief_by_id,
+    get_beliefs,
+    save_belief,
+    save_beliefs_batch,
+    update_belief_atomic,
+)
+from kernle.types import Belief
+
+STACK_ID = "test-beliefs-crud"
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return tmp_path / "beliefs_crud_test.db"
+
+
+@pytest.fixture
+def db(db_path):
+    """Create a minimal DB with the beliefs table schema."""
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("""
+        CREATE TABLE beliefs (
+            id TEXT PRIMARY KEY,
+            stack_id TEXT,
+            statement TEXT,
+            belief_type TEXT DEFAULT 'fact',
+            confidence REAL DEFAULT 0.5,
+            created_at TEXT,
+            source_type TEXT,
+            source_episodes TEXT,
+            derived_from TEXT,
+            last_verified TEXT,
+            verification_count INTEGER DEFAULT 0,
+            confidence_history TEXT,
+            supersedes TEXT,
+            superseded_by TEXT,
+            times_reinforced INTEGER DEFAULT 0,
+            is_active INTEGER DEFAULT 1,
+            times_accessed INTEGER DEFAULT 0,
+            last_accessed TEXT,
+            is_protected INTEGER DEFAULT 0,
+            strength REAL DEFAULT 1.0,
+            context TEXT,
+            context_tags TEXT,
+            source_entity TEXT,
+            subject_ids TEXT,
+            access_grants TEXT,
+            consent_grants TEXT,
+            processed INTEGER DEFAULT 0,
+            belief_scope TEXT DEFAULT 'world',
+            source_domain TEXT,
+            cross_domain_applications TEXT,
+            abstraction_level TEXT DEFAULT 'specific',
+            epoch_id TEXT,
+            local_updated_at TEXT,
+            cloud_synced_at TEXT,
+            version INTEGER DEFAULT 1,
+            deleted INTEGER DEFAULT 0
+        )
+    """)
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+@pytest.fixture
+def connect_fn(db):
+    """Connection factory matching SQLiteStorage._connect() pattern."""
+
+    @contextmanager
+    def _connect():
+        conn = sqlite3.connect(str(db))
+        conn.row_factory = sqlite3.Row
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    return _connect
+
+
+@pytest.fixture
+def now_fn():
+    return lambda: "2025-06-01T00:00:00+00:00"
+
+
+@pytest.fixture
+def to_json():
+    import json
+
+    class _Encoder(json.JSONEncoder):
+        def default(self, o):
+            if isinstance(o, datetime):
+                return o.isoformat()
+            return super().default(o)
+
+    def _to_json(obj):
+        if obj is None:
+            return None
+        return json.dumps(obj, cls=_Encoder)
+
+    return _to_json
+
+
+@pytest.fixture
+def record_to_dict():
+    def _record_to_dict(record):
+        from dataclasses import asdict
+
+        return asdict(record)
+
+    return _record_to_dict
+
+
+@pytest.fixture
+def queue_sync():
+    return MagicMock()
+
+
+@pytest.fixture
+def save_embedding():
+    return MagicMock()
+
+
+@pytest.fixture
+def sync_to_file():
+    return MagicMock()
+
+
+@pytest.fixture
+def build_access_filter():
+    def _build(requesting_entity):
+        if requesting_entity is None:
+            return ("", [])
+        return (" AND access_grants LIKE ?", [f'%"{requesting_entity}"%'])
+
+    return _build
+
+
+def _make_belief(**overrides) -> Belief:
+    defaults = {
+        "id": str(uuid.uuid4()),
+        "stack_id": STACK_ID,
+        "statement": "Test belief statement",
+        "belief_type": "fact",
+        "confidence": 0.8,
+        "created_at": datetime.now(timezone.utc),
+    }
+    defaults.update(overrides)
+    return Belief(**defaults)
+
+
+class TestSaveBelief:
+    def test_saves_and_returns_id(
+        self, connect_fn, now_fn, to_json, record_to_dict, queue_sync, save_embedding, sync_to_file
+    ):
+        belief = _make_belief()
+        result = save_belief(
+            connect_fn,
+            STACK_ID,
+            belief,
+            now_fn,
+            to_json,
+            record_to_dict,
+            queue_sync,
+            save_embedding,
+            sync_to_file,
+        )
+        assert result == belief.id
+
+    def test_generates_id_if_missing(
+        self, connect_fn, now_fn, to_json, record_to_dict, queue_sync, save_embedding, sync_to_file
+    ):
+        belief = _make_belief(id="")
+        result = save_belief(
+            connect_fn,
+            STACK_ID,
+            belief,
+            now_fn,
+            to_json,
+            record_to_dict,
+            queue_sync,
+            save_embedding,
+            sync_to_file,
+        )
+        assert result  # non-empty UUID
+        assert belief.id == result
+
+    def test_queues_sync(
+        self, connect_fn, now_fn, to_json, record_to_dict, queue_sync, save_embedding, sync_to_file
+    ):
+        belief = _make_belief()
+        save_belief(
+            connect_fn,
+            STACK_ID,
+            belief,
+            now_fn,
+            to_json,
+            record_to_dict,
+            queue_sync,
+            save_embedding,
+            sync_to_file,
+        )
+        queue_sync.assert_called_once()
+        args = queue_sync.call_args
+        assert args[0][1] == "beliefs"
+        assert args[0][2] == belief.id
+        assert args[0][3] == "upsert"
+
+    def test_saves_embedding(
+        self, connect_fn, now_fn, to_json, record_to_dict, queue_sync, save_embedding, sync_to_file
+    ):
+        belief = _make_belief(statement="Sky is blue")
+        save_belief(
+            connect_fn,
+            STACK_ID,
+            belief,
+            now_fn,
+            to_json,
+            record_to_dict,
+            queue_sync,
+            save_embedding,
+            sync_to_file,
+        )
+        save_embedding.assert_called_once()
+        args = save_embedding.call_args[0]
+        assert args[1] == "beliefs"
+        assert args[3] == "Sky is blue"
+
+    def test_syncs_to_file(
+        self, connect_fn, now_fn, to_json, record_to_dict, queue_sync, save_embedding, sync_to_file
+    ):
+        belief = _make_belief()
+        save_belief(
+            connect_fn,
+            STACK_ID,
+            belief,
+            now_fn,
+            to_json,
+            record_to_dict,
+            queue_sync,
+            save_embedding,
+            sync_to_file,
+        )
+        sync_to_file.assert_called_once()
+
+    def test_calls_lineage_checker(
+        self, connect_fn, now_fn, to_json, record_to_dict, queue_sync, save_embedding, sync_to_file
+    ):
+        checker = MagicMock()
+        belief = _make_belief(derived_from=["episode:abc"])
+        save_belief(
+            connect_fn,
+            STACK_ID,
+            belief,
+            now_fn,
+            to_json,
+            record_to_dict,
+            queue_sync,
+            save_embedding,
+            sync_to_file,
+            lineage_checker=checker,
+        )
+        checker.assert_called_once_with("belief", belief.id, ["episode:abc"])
+
+
+class TestGetBeliefs:
+    def test_returns_empty_for_no_beliefs(self, connect_fn, build_access_filter):
+        result = get_beliefs(connect_fn, STACK_ID, build_access_filter)
+        assert result == []
+
+    def test_returns_saved_beliefs(
+        self,
+        connect_fn,
+        now_fn,
+        to_json,
+        record_to_dict,
+        queue_sync,
+        save_embedding,
+        sync_to_file,
+        build_access_filter,
+    ):
+        b1 = _make_belief(statement="Belief one")
+        b2 = _make_belief(statement="Belief two")
+        for b in [b1, b2]:
+            save_belief(
+                connect_fn,
+                STACK_ID,
+                b,
+                now_fn,
+                to_json,
+                record_to_dict,
+                queue_sync,
+                save_embedding,
+                sync_to_file,
+            )
+
+        result = get_beliefs(connect_fn, STACK_ID, build_access_filter)
+        assert len(result) == 2
+
+    def test_respects_limit(
+        self,
+        connect_fn,
+        now_fn,
+        to_json,
+        record_to_dict,
+        queue_sync,
+        save_embedding,
+        sync_to_file,
+        build_access_filter,
+    ):
+        for i in range(5):
+            save_belief(
+                connect_fn,
+                STACK_ID,
+                _make_belief(statement=f"Belief {i}"),
+                now_fn,
+                to_json,
+                record_to_dict,
+                queue_sync,
+                save_embedding,
+                sync_to_file,
+            )
+
+        result = get_beliefs(connect_fn, STACK_ID, build_access_filter, limit=3)
+        assert len(result) == 3
+
+    def test_excludes_inactive_by_default(
+        self,
+        connect_fn,
+        now_fn,
+        to_json,
+        record_to_dict,
+        queue_sync,
+        save_embedding,
+        sync_to_file,
+        build_access_filter,
+    ):
+        active = _make_belief(statement="Active", is_active=True)
+        inactive = _make_belief(statement="Inactive", is_active=False)
+        for b in [active, inactive]:
+            save_belief(
+                connect_fn,
+                STACK_ID,
+                b,
+                now_fn,
+                to_json,
+                record_to_dict,
+                queue_sync,
+                save_embedding,
+                sync_to_file,
+            )
+
+        result = get_beliefs(connect_fn, STACK_ID, build_access_filter)
+        assert len(result) == 1
+        assert result[0].statement == "Active"
+
+    def test_includes_inactive_when_requested(
+        self,
+        connect_fn,
+        now_fn,
+        to_json,
+        record_to_dict,
+        queue_sync,
+        save_embedding,
+        sync_to_file,
+        build_access_filter,
+    ):
+        active = _make_belief(statement="Active", is_active=True)
+        inactive = _make_belief(statement="Inactive", is_active=False)
+        for b in [active, inactive]:
+            save_belief(
+                connect_fn,
+                STACK_ID,
+                b,
+                now_fn,
+                to_json,
+                record_to_dict,
+                queue_sync,
+                save_embedding,
+                sync_to_file,
+            )
+
+        result = get_beliefs(connect_fn, STACK_ID, build_access_filter, include_inactive=True)
+        assert len(result) == 2
+
+
+class TestFindBelief:
+    def test_finds_by_statement(
+        self, connect_fn, now_fn, to_json, record_to_dict, queue_sync, save_embedding, sync_to_file
+    ):
+        belief = _make_belief(statement="Unique statement")
+        save_belief(
+            connect_fn,
+            STACK_ID,
+            belief,
+            now_fn,
+            to_json,
+            record_to_dict,
+            queue_sync,
+            save_embedding,
+            sync_to_file,
+        )
+
+        result = find_belief(connect_fn, STACK_ID, "Unique statement")
+        assert result is not None
+        assert result.id == belief.id
+
+    def test_returns_none_for_missing(self, connect_fn):
+        result = find_belief(connect_fn, STACK_ID, "Nonexistent")
+        assert result is None
+
+
+class TestGetBelief:
+    def test_gets_by_id(
+        self,
+        connect_fn,
+        now_fn,
+        to_json,
+        record_to_dict,
+        queue_sync,
+        save_embedding,
+        sync_to_file,
+        build_access_filter,
+    ):
+        belief = _make_belief()
+        save_belief(
+            connect_fn,
+            STACK_ID,
+            belief,
+            now_fn,
+            to_json,
+            record_to_dict,
+            queue_sync,
+            save_embedding,
+            sync_to_file,
+        )
+
+        result = get_belief(connect_fn, STACK_ID, belief.id, build_access_filter)
+        assert result is not None
+        assert result.id == belief.id
+
+    def test_returns_none_for_missing_id(self, connect_fn, build_access_filter):
+        result = get_belief(connect_fn, STACK_ID, "no-such-id", build_access_filter)
+        assert result is None
+
+
+class TestGetBeliefById:
+    def test_gets_internal_by_id(
+        self, connect_fn, now_fn, to_json, record_to_dict, queue_sync, save_embedding, sync_to_file
+    ):
+        belief = _make_belief()
+        save_belief(
+            connect_fn,
+            STACK_ID,
+            belief,
+            now_fn,
+            to_json,
+            record_to_dict,
+            queue_sync,
+            save_embedding,
+            sync_to_file,
+        )
+
+        result = get_belief_by_id(connect_fn, STACK_ID, belief.id)
+        assert result is not None
+        assert result.statement == belief.statement
+
+
+class TestUpdateBeliefAtomic:
+    def test_updates_successfully(
+        self, connect_fn, now_fn, to_json, record_to_dict, queue_sync, save_embedding, sync_to_file
+    ):
+        belief = _make_belief(version=1)
+        save_belief(
+            connect_fn,
+            STACK_ID,
+            belief,
+            now_fn,
+            to_json,
+            record_to_dict,
+            queue_sync,
+            save_embedding,
+            sync_to_file,
+        )
+
+        belief.statement = "Updated statement"
+        result = update_belief_atomic(
+            connect_fn,
+            STACK_ID,
+            belief,
+            now_fn,
+            to_json,
+            record_to_dict,
+            queue_sync,
+            save_embedding,
+            sync_to_file,
+            expected_version=1,
+        )
+        assert result is True
+        assert belief.version == 2
+
+    def test_version_conflict_raises(
+        self, connect_fn, now_fn, to_json, record_to_dict, queue_sync, save_embedding, sync_to_file
+    ):
+        from kernle.storage.base import VersionConflictError
+
+        belief = _make_belief(version=1)
+        save_belief(
+            connect_fn,
+            STACK_ID,
+            belief,
+            now_fn,
+            to_json,
+            record_to_dict,
+            queue_sync,
+            save_embedding,
+            sync_to_file,
+        )
+
+        belief.statement = "Conflict test"
+        with pytest.raises(VersionConflictError):
+            update_belief_atomic(
+                connect_fn,
+                STACK_ID,
+                belief,
+                now_fn,
+                to_json,
+                record_to_dict,
+                queue_sync,
+                save_embedding,
+                sync_to_file,
+                expected_version=99,
+            )
+
+    def test_returns_false_for_missing_belief(
+        self, connect_fn, now_fn, to_json, record_to_dict, queue_sync, save_embedding, sync_to_file
+    ):
+        belief = _make_belief()
+        result = update_belief_atomic(
+            connect_fn,
+            STACK_ID,
+            belief,
+            now_fn,
+            to_json,
+            record_to_dict,
+            queue_sync,
+            save_embedding,
+            sync_to_file,
+            expected_version=1,
+        )
+        assert result is False
+
+
+class TestSaveBeliefsBatch:
+    def test_saves_multiple(
+        self,
+        connect_fn,
+        now_fn,
+        to_json,
+        record_to_dict,
+        queue_sync,
+        save_embedding,
+        sync_to_file,
+        build_access_filter,
+    ):
+        beliefs = [_make_belief(statement=f"Batch {i}") for i in range(3)]
+        ids = save_beliefs_batch(
+            connect_fn,
+            STACK_ID,
+            beliefs,
+            now_fn,
+            to_json,
+            record_to_dict,
+            queue_sync,
+            save_embedding,
+            sync_to_file,
+        )
+        assert len(ids) == 3
+        result = get_beliefs(connect_fn, STACK_ID, build_access_filter)
+        assert len(result) == 3
+
+    def test_empty_batch_returns_empty(
+        self, connect_fn, now_fn, to_json, record_to_dict, queue_sync, save_embedding, sync_to_file
+    ):
+        ids = save_beliefs_batch(
+            connect_fn,
+            STACK_ID,
+            [],
+            now_fn,
+            to_json,
+            record_to_dict,
+            queue_sync,
+            save_embedding,
+            sync_to_file,
+        )
+        assert ids == []
+
+    def test_syncs_file_once(
+        self, connect_fn, now_fn, to_json, record_to_dict, queue_sync, save_embedding, sync_to_file
+    ):
+        beliefs = [_make_belief() for _ in range(3)]
+        save_beliefs_batch(
+            connect_fn,
+            STACK_ID,
+            beliefs,
+            now_fn,
+            to_json,
+            record_to_dict,
+            queue_sync,
+            save_embedding,
+            sync_to_file,
+        )
+        sync_to_file.assert_called_once()

--- a/tests/test_sync_race_window.py
+++ b/tests/test_sync_race_window.py
@@ -1,0 +1,574 @@
+"""Tests for sync engine race window between save and queue cleanup (issue #731).
+
+These tests verify that:
+- Calling _merge_generic twice with the same record doesn't create duplicates
+- Queue cleanup is atomic with the synced-at status update
+- Recovery after simulated crash (record saved but queue not cleaned)
+- The _record_already_applied guard detects previously-synced records
+- _mark_synced_and_cleanup_queue consolidates operations into one transaction
+"""
+
+import logging
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from kernle.storage import (
+    Belief,
+    Episode,
+    Note,
+    SQLiteStorage,
+)
+
+
+@pytest.fixture
+def temp_db(tmp_path):
+    """Create a temporary database path."""
+    return tmp_path / "test.db"
+
+
+@pytest.fixture
+def storage(temp_db):
+    """Create a SQLiteStorage instance for testing."""
+    storage = SQLiteStorage(stack_id="test-agent", db_path=temp_db)
+    yield storage
+    storage.close()
+
+
+@pytest.fixture
+def mock_cloud_storage():
+    """Create a mock cloud storage for testing sync."""
+    mock = MagicMock(spec=SQLiteStorage)
+    mock.stack_id = "test-agent"
+    mock.get_stats.return_value = {"episodes": 0, "notes": 0}
+    mock.get_episodes.return_value = []
+    mock.get_notes.return_value = []
+    mock.get_beliefs.return_value = []
+    mock.get_values.return_value = []
+    mock.get_goals.return_value = []
+    mock.get_drives.return_value = []
+    mock.get_relationships.return_value = []
+    return mock
+
+
+@pytest.fixture
+def storage_with_cloud(temp_db, mock_cloud_storage):
+    """Create a SQLiteStorage with a mock cloud storage."""
+    storage = SQLiteStorage(
+        stack_id="test-agent", db_path=temp_db, cloud_storage=mock_cloud_storage
+    )
+    yield storage
+    storage.close()
+
+
+class TestMergeGenericIdempotency:
+    """Test that _merge_generic is idempotent -- calling it twice with the
+    same record must not create duplicates or leave orphaned queue entries."""
+
+    def test_duplicate_merge_no_local_record_does_not_double_save(self, storage):
+        """Calling _merge_generic twice for a new record skips save on the second call."""
+        engine = storage._sync_engine
+        now = datetime.now(timezone.utc)
+
+        cloud = Note(
+            id="idempotent-1",
+            stack_id="test-agent",
+            content="Cloud note",
+            local_updated_at=now,
+            cloud_synced_at=now,
+            version=1,
+        )
+
+        save_call_count = []
+
+        def tracked_save():
+            save_call_count.append(1)
+            storage.save_note(cloud)
+
+        # First merge: local_record is None, save_fn should be called
+        count1, conflict1 = engine._merge_generic("notes", cloud, None, tracked_save)
+        assert count1 == 1
+        assert conflict1 is None
+        assert len(save_call_count) == 1
+
+        # Verify the note was saved
+        with storage._connect() as conn:
+            row = conn.execute(
+                "SELECT id, version, cloud_synced_at FROM notes WHERE id = ?",
+                ("idempotent-1",),
+            ).fetchone()
+        assert row is not None
+
+        # Second merge: same cloud record, local_record is None
+        # The save_fn should NOT be called because _record_already_applied detects it
+        count2, conflict2 = engine._merge_generic("notes", cloud, None, tracked_save)
+        assert count2 == 1
+        assert conflict2 is None
+        assert len(save_call_count) == 1  # Still 1 -- second call was skipped
+
+    def test_duplicate_merge_does_not_leave_queue_entry(self, storage):
+        """After a duplicate merge, no sync queue entry should remain."""
+        engine = storage._sync_engine
+        now = datetime.now(timezone.utc)
+
+        cloud = Note(
+            id="idempotent-2",
+            stack_id="test-agent",
+            content="Cloud note for queue test",
+            local_updated_at=now,
+            cloud_synced_at=now,
+            version=1,
+        )
+
+        # First merge
+        engine._merge_generic("notes", cloud, None, lambda: storage.save_note(cloud))
+
+        # Verify queue is clean after first merge
+        with storage._connect() as conn:
+            queue_count = conn.execute(
+                "SELECT COUNT(*) FROM sync_queue WHERE table_name = 'notes' AND record_id = ?",
+                ("idempotent-2",),
+            ).fetchone()[0]
+        assert queue_count == 0
+
+        # Second merge (simulating recovery)
+        engine._merge_generic("notes", cloud, None, lambda: storage.save_note(cloud))
+
+        # Queue should still be clean
+        with storage._connect() as conn:
+            queue_count = conn.execute(
+                "SELECT COUNT(*) FROM sync_queue WHERE table_name = 'notes' AND record_id = ?",
+                ("idempotent-2",),
+            ).fetchone()[0]
+        assert queue_count == 0
+
+    def test_duplicate_merge_with_cloud_time_no_local_time(self, storage):
+        """The cloud_time-only branch also skips save on duplicate."""
+        engine = storage._sync_engine
+        now = datetime.now(timezone.utc)
+
+        cloud = Note(
+            id="idempotent-3",
+            stack_id="test-agent",
+            content="Cloud only time",
+            local_updated_at=now,
+            cloud_synced_at=now,
+            version=1,
+        )
+        # local_record exists but has no local_updated_at
+        local = Note(
+            id="idempotent-3",
+            stack_id="test-agent",
+            content="Local",
+            local_updated_at=None,
+            cloud_synced_at=None,
+        )
+
+        save_count = []
+
+        def tracked_save():
+            save_count.append(1)
+            storage.save_note(cloud)
+
+        # First call: cloud_time set, local_time None -> save_fn called
+        count1, _ = engine._merge_generic("notes", cloud, local, tracked_save)
+        assert count1 == 1
+        assert len(save_count) == 1
+
+        # Second call with same params (recovery scenario)
+        count2, _ = engine._merge_generic("notes", cloud, local, tracked_save)
+        assert count2 == 1
+        assert len(save_count) == 1  # Skipped on second call
+
+
+class TestQueueCleanupAtomicity:
+    """Test that queue cleanup and synced-at marking happen in a single transaction."""
+
+    def test_mark_synced_and_cleanup_single_transaction(self, storage):
+        """_mark_synced_and_cleanup_queue runs in one transaction."""
+        engine = storage._sync_engine
+        now = datetime.now(timezone.utc)
+
+        # Save a note (creates a queue entry)
+        storage.save_note(
+            Note(
+                id="atomic-cleanup-1",
+                stack_id="test-agent",
+                content="Test",
+                local_updated_at=now,
+            )
+        )
+
+        # Verify queue entry exists
+        with storage._connect() as conn:
+            queue_before = conn.execute(
+                "SELECT COUNT(*) FROM sync_queue WHERE table_name = 'notes' "
+                "AND record_id = 'atomic-cleanup-1'",
+            ).fetchone()[0]
+        assert queue_before >= 1
+
+        # Run cleanup
+        engine._mark_synced_and_cleanup_queue("notes", "atomic-cleanup-1")
+
+        # Both synced-at and queue should be updated
+        with storage._connect() as conn:
+            note_row = conn.execute(
+                "SELECT cloud_synced_at FROM notes WHERE id = 'atomic-cleanup-1'"
+            ).fetchone()
+            queue_after = conn.execute(
+                "SELECT COUNT(*) FROM sync_queue WHERE table_name = 'notes' "
+                "AND record_id = 'atomic-cleanup-1'",
+            ).fetchone()[0]
+
+        assert note_row["cloud_synced_at"] is not None
+        assert queue_after == 0
+
+    def test_cleanup_removes_all_queue_entries_for_record(self, storage):
+        """Cleanup removes ALL queue entries for a table+record pair."""
+        engine = storage._sync_engine
+        now = datetime.now(timezone.utc)
+
+        # Save a note to create a queue entry
+        storage.save_note(
+            Note(
+                id="multi-queue-1",
+                stack_id="test-agent",
+                content="First",
+                local_updated_at=now,
+            )
+        )
+
+        # Manually insert a second queue entry (simulating a race condition)
+        with storage._connect() as conn:
+            conn.execute(
+                """INSERT INTO sync_queue
+                   (table_name, record_id, operation, synced, queued_at, local_updated_at)
+                   VALUES ('notes', 'multi-queue-1', 'upsert', 1, ?, ?)""",
+                (now.isoformat(), now.isoformat()),
+            )
+            conn.commit()
+
+        # Run cleanup -- should delete ALL entries for this record
+        engine._mark_synced_and_cleanup_queue("notes", "multi-queue-1")
+
+        with storage._connect() as conn:
+            remaining = conn.execute(
+                "SELECT COUNT(*) FROM sync_queue WHERE table_name = 'notes' "
+                "AND record_id = 'multi-queue-1'",
+            ).fetchone()[0]
+        assert remaining == 0
+
+
+class TestCrashRecoveryScenario:
+    """Test recovery after simulated crash where record was saved but
+    queue was not cleaned up."""
+
+    def test_recovery_after_save_without_cleanup(self, storage):
+        """Simulate crash: save_fn completes but queue cleanup never runs.
+
+        On recovery (next sync), the record should be detected as already
+        applied, save_fn skipped, and the queue cleaned up.
+        """
+        engine = storage._sync_engine
+        now = datetime.now(timezone.utc)
+
+        cloud = Note(
+            id="crash-recovery-1",
+            stack_id="test-agent",
+            content="Cloud content",
+            local_updated_at=now,
+            cloud_synced_at=now,
+            version=1,
+        )
+
+        # Step 1: Simulate the first half of _merge_generic -- save the record
+        # but do NOT clean up the queue (simulating a crash after save_fn)
+        storage.save_note(cloud)
+
+        # Manually set cloud_synced_at to simulate what _mark_synced would have done
+        # if it had run partially before crash
+        with storage._connect() as conn:
+            conn.execute(
+                "UPDATE notes SET cloud_synced_at = ? WHERE id = ?",
+                (now.isoformat(), "crash-recovery-1"),
+            )
+            conn.commit()
+
+        # Verify queue entry still exists (simulating post-crash state)
+        with storage._connect() as conn:
+            queue_count = conn.execute(
+                "SELECT COUNT(*) FROM sync_queue WHERE record_id = 'crash-recovery-1' AND synced = 0",
+            ).fetchone()[0]
+        assert queue_count >= 1, "Queue entry should exist (crash left it behind)"
+
+        # Step 2: Recovery -- run _merge_generic again
+        save_called = []
+
+        def recovery_save():
+            save_called.append(1)
+            storage.save_note(cloud)
+
+        count, conflict = engine._merge_generic("notes", cloud, None, recovery_save)
+
+        # Should succeed but NOT call save_fn (duplicate detected)
+        assert count == 1
+        assert conflict is None
+        assert len(save_called) == 0, "save_fn should be skipped during recovery"
+
+        # Queue should now be cleaned up
+        with storage._connect() as conn:
+            queue_count = conn.execute(
+                "SELECT COUNT(*) FROM sync_queue WHERE record_id = 'crash-recovery-1'",
+            ).fetchone()[0]
+        assert queue_count == 0, "Queue should be clean after recovery"
+
+    def test_recovery_logs_duplicate_detection(self, storage, caplog):
+        """When a duplicate sync is detected, it should be logged."""
+        engine = storage._sync_engine
+        now = datetime.now(timezone.utc)
+
+        cloud = Note(
+            id="log-dup-1",
+            stack_id="test-agent",
+            content="Duplicate test",
+            local_updated_at=now,
+            cloud_synced_at=now,
+            version=1,
+        )
+
+        # First merge (normal)
+        engine._merge_generic("notes", cloud, None, lambda: storage.save_note(cloud))
+
+        # Second merge (recovery) -- should log
+        with caplog.at_level(logging.INFO, logger="kernle.storage.sync_engine"):
+            engine._merge_generic("notes", cloud, None, lambda: storage.save_note(cloud))
+
+        assert any(
+            "Duplicate sync detected" in msg for msg in caplog.messages
+        ), f"Expected 'Duplicate sync detected' in log, got: {caplog.messages}"
+
+    def test_recovery_works_for_episodes(self, storage):
+        """Recovery scenario works for episodes, not just notes."""
+        engine = storage._sync_engine
+        now = datetime.now(timezone.utc)
+
+        cloud = Episode(
+            id="ep-crash-1",
+            stack_id="test-agent",
+            objective="Cloud episode",
+            outcome="Test outcome",
+            local_updated_at=now,
+            cloud_synced_at=now,
+            version=1,
+        )
+
+        save_count = []
+
+        def tracked_save():
+            save_count.append(1)
+            storage.save_episode(cloud)
+
+        # First merge
+        engine._merge_generic("episodes", cloud, None, tracked_save)
+        assert len(save_count) == 1
+
+        # Second merge (recovery)
+        engine._merge_generic("episodes", cloud, None, tracked_save)
+        assert len(save_count) == 1  # Skipped
+
+        # Queue clean
+        with storage._connect() as conn:
+            queue_count = conn.execute(
+                "SELECT COUNT(*) FROM sync_queue WHERE record_id = 'ep-crash-1'",
+            ).fetchone()[0]
+        assert queue_count == 0
+
+
+class TestRecordAlreadyApplied:
+    """Test the _record_already_applied guard method."""
+
+    def test_returns_false_for_nonexistent_record(self, storage):
+        """Returns False when the record doesn't exist locally."""
+        engine = storage._sync_engine
+        cloud = Note(
+            id="nonexistent-1",
+            stack_id="test-agent",
+            content="Ghost",
+            version=1,
+        )
+        assert engine._record_already_applied("notes", cloud) is False
+
+    def test_returns_false_for_record_without_cloud_synced_at(self, storage):
+        """Returns False when the record exists but hasn't been marked as synced."""
+        engine = storage._sync_engine
+        now = datetime.now(timezone.utc)
+
+        # Save locally without cloud_synced_at
+        storage.save_note(
+            Note(
+                id="no-sync-1",
+                stack_id="test-agent",
+                content="Local only",
+                local_updated_at=now,
+                version=1,
+            )
+        )
+
+        # Clear cloud_synced_at to simulate pre-sync state
+        with storage._connect() as conn:
+            conn.execute("UPDATE notes SET cloud_synced_at = NULL WHERE id = 'no-sync-1'")
+            conn.commit()
+
+        cloud = Note(
+            id="no-sync-1",
+            stack_id="test-agent",
+            content="Cloud version",
+            version=1,
+        )
+        assert engine._record_already_applied("notes", cloud) is False
+
+    def test_returns_true_for_matching_version_and_synced(self, storage):
+        """Returns True when local record matches version and has cloud_synced_at set."""
+        engine = storage._sync_engine
+        now = datetime.now(timezone.utc)
+
+        # Save and mark as synced
+        storage.save_note(
+            Note(
+                id="synced-1",
+                stack_id="test-agent",
+                content="Synced content",
+                local_updated_at=now,
+                cloud_synced_at=now,
+                version=3,
+            )
+        )
+
+        cloud = Note(
+            id="synced-1",
+            stack_id="test-agent",
+            content="Same cloud content",
+            version=3,
+        )
+        assert engine._record_already_applied("notes", cloud) is True
+
+    def test_returns_false_for_version_mismatch(self, storage):
+        """Returns False when local version differs from cloud version."""
+        engine = storage._sync_engine
+        now = datetime.now(timezone.utc)
+
+        # Save version 2 locally
+        storage.save_note(
+            Note(
+                id="version-mismatch-1",
+                stack_id="test-agent",
+                content="V2 content",
+                local_updated_at=now,
+                cloud_synced_at=now,
+                version=2,
+            )
+        )
+
+        # Cloud has version 3
+        cloud = Note(
+            id="version-mismatch-1",
+            stack_id="test-agent",
+            content="V3 content",
+            version=3,
+        )
+        assert engine._record_already_applied("notes", cloud) is False
+
+    def test_works_for_beliefs(self, storage):
+        """_record_already_applied works across different table types."""
+        engine = storage._sync_engine
+        now = datetime.now(timezone.utc)
+
+        storage.save_belief(
+            Belief(
+                id="belief-applied-1",
+                stack_id="test-agent",
+                statement="Test belief",
+                local_updated_at=now,
+                cloud_synced_at=now,
+                version=1,
+            )
+        )
+
+        cloud = Belief(
+            id="belief-applied-1",
+            stack_id="test-agent",
+            statement="Cloud belief",
+            version=1,
+        )
+        assert engine._record_already_applied("beliefs", cloud) is True
+
+
+class TestEndToEndSyncRecovery:
+    """Integration tests that verify the full sync flow handles
+    the race window correctly."""
+
+    def test_full_pull_idempotent_for_same_record(self, storage_with_cloud, mock_cloud_storage):
+        """Pulling the same record twice via full sync does not create duplicates."""
+        now = datetime.now(timezone.utc)
+        cloud_note = Note(
+            id="pull-idem-1",
+            stack_id="test-agent",
+            content="Cloud note",
+            local_updated_at=now,
+            cloud_synced_at=now,
+            version=1,
+        )
+
+        # Configure cloud to return the same note on both pulls
+        mock_cloud_storage.get_notes.return_value = [cloud_note]
+        mock_cloud_storage.list_playbooks.return_value = []
+
+        # First pull
+        result1 = storage_with_cloud.pull_changes()
+        assert result1.pulled >= 1
+
+        # Second pull (simulating repeated sync)
+        storage_with_cloud.pull_changes()
+
+        # The note should exist exactly once
+        with storage_with_cloud._connect() as conn:
+            count = conn.execute("SELECT COUNT(*) FROM notes WHERE id = 'pull-idem-1'").fetchone()[
+                0
+            ]
+        assert count == 1
+
+        # No queue entries should remain
+        with storage_with_cloud._connect() as conn:
+            queue_count = conn.execute(
+                "SELECT COUNT(*) FROM sync_queue WHERE record_id = 'pull-idem-1' AND synced = 0"
+            ).fetchone()[0]
+        assert queue_count == 0
+
+    def test_merge_generic_save_fn_requeue_is_cleaned_up(self, storage):
+        """When save_fn internally re-queues the record, the cleanup
+        step should remove that queue entry."""
+        engine = storage._sync_engine
+        now = datetime.now(timezone.utc)
+
+        cloud = Note(
+            id="requeue-cleanup-1",
+            stack_id="test-agent",
+            content="Will be re-queued by save",
+            local_updated_at=now,
+            cloud_synced_at=now,
+            version=1,
+        )
+
+        # save_note internally calls _queue_sync, creating a new queue entry
+        engine._merge_generic("notes", cloud, None, lambda: storage.save_note(cloud))
+
+        # Despite save_fn creating a queue entry, cleanup should have removed it
+        with storage._connect() as conn:
+            queue_count = conn.execute(
+                "SELECT COUNT(*) FROM sync_queue WHERE record_id = 'requeue-cleanup-1' AND synced = 0"
+            ).fetchone()[0]
+        assert queue_count == 0, (
+            "Queue entry created by save_fn should be cleaned up by "
+            "_mark_synced_and_cleanup_queue"
+        )


### PR DESCRIPTION
## Summary

- **#730**: Fix anxiety hysteresis — per-level enter/exit thresholds replace fixed 75/60 for all transitions
- **#731**: Close sync engine race window — atomic mark-synced-and-delete + duplicate detection guard prevents orphaned queue entries and double-syncs after crash
- **#732**: Pilot extraction of beliefs CRUD from SQLiteStorage into `beliefs_crud.py` — dependency-injected pure functions with 22 new standalone tests
- **#733**: Harden ID generator — RuntimeError at sequence exhaustion (was silent modulo wrap), 90% capacity warning, clock jump detection and recovery
- **#734**: Fix `diagnostic.py` broken `k.get_anxiety()` → `k.anxiety()` call; full anxiety component migration deferred (architecture blockers documented)
- **#735**: Add logging to 69 swallowed `except Exception` blocks across 22 files for failure observability

## Test plan

- [x] 6,263 tests pass, 0 regressions
- [x] 22 new `test_beliefs_crud.py` tests verify extracted module independently of SQLiteStorage
- [x] 15 new `test_sync_race_window.py` tests cover crash recovery, idempotency, duplicate detection
- [x] 28 rewritten anxiety hysteresis tests cover all per-boundary transitions
- [x] 6 new ID generator safety tests cover overflow, clock jump, recovery
- [x] Pre-commit hooks pass (ruff, black, secret detection)

Closes #730, #731, #732, #733, #734, #735

🤖 Generated with [Claude Code](https://claude.com/claude-code)