### PR TITLE
Bump version to 0.13.09

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kernle"
-version = "0.13.08"
+version = "0.13.09"
 description = "Stratified memory for synthetic intelligences"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bumps `pyproject.toml` version from `0.13.08` to `0.13.09`
- Follows the merge of PR #798 which included all v0.13.09 audit fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)