### PR TITLE
Route raw promote through process_raw (#835)

### DIFF
--- a/kernle/cli/commands/raw.py
+++ b/kernle/cli/commands/raw.py
@@ -341,58 +341,30 @@ def cmd_raw(args, k: "Kernle"):
             print(f"\n✓ Deleted {deleted} {label} raw entries.")
 
     elif args.raw_action == "promote":
-        # Alias for process - simpler UX
-        args.raw_action = "process"
-        # Fall through to process handler would require refactor, so duplicate minimal logic
+        # Resolve the raw entry ID
         try:
             full_id = resolve_raw_id(k, args.id)
         except ValueError as e:
             print(f"✗ {e}")
             return
 
-        entry = k.get_raw(full_id)
-        if not entry:
-            print(f"✗ Raw entry {args.id} not found.")
-            return
-
         target_type = args.type
-        # Use blob (new) with content (legacy) as fallback
-        blob = entry.get("blob") or entry.get("content") or ""
 
-        raw_ref = f"raw:{full_id}"
-
+        # Build kwargs for process_raw — only pass episode-specific args
+        kwargs = {}
         if target_type == "episode":
-            objective = args.objective or blob[:100]
-            outcome = args.outcome or "Promoted from raw capture"
-            result_id = k.episode(
-                objective=objective,
-                outcome=outcome,
-                tags=["promoted"],
-                source="cli-promote",
-                derived_from=[raw_ref],
-            )
-            print(f"✓ Promoted to episode: {result_id[:8]}...")
-        elif target_type == "note":
-            result_id = k.note(
-                content=blob,
-                type="note",
-                tags=["promoted"],
-                source="cli-promote",
-                derived_from=[raw_ref],
-            )
-            print(f"✓ Promoted to note: {result_id[:8]}...")
-        elif target_type == "belief":
-            result_id = k.belief(
-                statement=blob,
-                confidence=0.7,
-                source="cli-promote",
-                derived_from=[raw_ref],
-            )
-            print(f"✓ Promoted to belief: {result_id[:8]}...")
+            if args.objective:
+                kwargs["objective"] = args.objective
+            if args.outcome:
+                kwargs["outcome"] = args.outcome
 
-        # Mark as processed
-        k._storage.mark_raw_processed(full_id, [f"{target_type}:{result_id}"])
-        print("  Raw entry marked as processed.")
+        try:
+            result_id = k.process_raw(raw_id=full_id, as_type=target_type, **kwargs)
+            print(f"✓ Promoted to {target_type}: {result_id[:8]}...")
+            print("  Raw entry marked as processed.")
+        except ValueError as e:
+            print(f"✗ {e}")
+            return
 
     elif args.raw_action == "triage":
         # Guided triage of unprocessed entries

--- a/kernle/core/writers.py
+++ b/kernle/core/writers.py
@@ -446,13 +446,14 @@ class WritersMixin:
             memory_ref = f"episode:{memory_id}"
 
         elif as_type == "note":
+            content = entry.blob or entry.content or ""
             note_type = kwargs.get("type", "note")
             tags = kwargs.get("tags") or entry.tags or []
             if "raw" not in tags:
                 tags.append("raw")
 
             memory_id = self.note(
-                content=entry.content,
+                content=content,
                 type=note_type,
                 speaker=kwargs.get("speaker"),
                 reason=kwargs.get("reason"),
@@ -463,11 +464,12 @@ class WritersMixin:
             memory_ref = f"note:{memory_id}"
 
         elif as_type == "belief":
+            content = entry.blob or entry.content or ""
             confidence = kwargs.get("confidence", 0.7)
             belief_type = kwargs.get("type", "observation")
 
             memory_id = self.belief(
-                statement=entry.content,
+                statement=content,
                 type=belief_type,
                 confidence=confidence,
                 source="raw-processing",

--- a/tests/test_cli_raw.py
+++ b/tests/test_cli_raw.py
@@ -793,41 +793,50 @@ class TestCmdRawClean:
 
 
 class TestCmdRawPromote:
-    """Test raw promote command."""
+    """Test raw promote command — should delegate to process_raw (#835)."""
 
-    def test_promote_to_episode(self, capsys):
-        """Promote to episode."""
+    def test_promote_delegates_to_process_raw(self, capsys):
+        """Promote should call k.process_raw(), not manual k.episode/note/belief."""
         k = MagicMock()
-        k.get_raw.side_effect = [
-            {"id": "abc12345", "content": "test"},  # For resolve
-            {"id": "abc12345", "content": "Episode content", "tags": []},
-        ]
-        k.episode.return_value = "ep123456"
-        k._storage.mark_raw_processed.return_value = True
+        k.get_raw.return_value = {"id": "abc12345", "content": "test"}
+        k.process_raw.return_value = "ep123456"
 
         args = Namespace(
             raw_action="promote",
             id="abc12345",
             type="episode",
-            objective=None,
-            outcome=None,
+            objective="Test obj",
+            outcome="Test out",
         )
 
         cmd_raw(args, k)
 
-        k.episode.assert_called_once()
-        captured = capsys.readouterr()
-        assert "✓ Promoted to episode" in captured.out
+        # Should delegate to process_raw
+        k.process_raw.assert_called_once()
+        call_kwargs = k.process_raw.call_args
+        assert (
+            call_kwargs.kwargs.get("raw_id") == "abc12345"
+            or call_kwargs[1].get("raw_id") == "abc12345"
+        )
+        assert (
+            call_kwargs.kwargs.get("as_type") == "episode"
+            or call_kwargs[1].get("as_type") == "episode"
+        )
+        # Should NOT call manual creation methods
+        k.episode.assert_not_called()
+        k.note.assert_not_called()
+        k.belief.assert_not_called()
+        # Should NOT call mark_raw_processed manually
+        k._storage.mark_raw_processed.assert_not_called()
 
-    def test_promote_to_note(self, capsys):
-        """Promote to note."""
+        captured = capsys.readouterr()
+        assert "Promoted to episode" in captured.out
+
+    def test_promote_note_delegates_to_process_raw(self, capsys):
+        """Promote to note should also delegate to process_raw."""
         k = MagicMock()
-        k.get_raw.side_effect = [
-            {"id": "abc12345", "content": "test"},
-            {"id": "abc12345", "content": "Note content", "tags": []},
-        ]
-        k.note.return_value = "note123"
-        k._storage.mark_raw_processed.return_value = True
+        k.get_raw.return_value = {"id": "abc12345", "content": "test"}
+        k.process_raw.return_value = "note123"
 
         args = Namespace(
             raw_action="promote",
@@ -839,19 +848,17 @@ class TestCmdRawPromote:
 
         cmd_raw(args, k)
 
-        k.note.assert_called_once()
+        k.process_raw.assert_called_once()
+        k.note.assert_not_called()
+        k._storage.mark_raw_processed.assert_not_called()
         captured = capsys.readouterr()
-        assert "✓ Promoted to note" in captured.out
+        assert "Promoted to note" in captured.out
 
-    def test_promote_to_belief(self, capsys):
-        """Promote to belief."""
+    def test_promote_belief_delegates_to_process_raw(self, capsys):
+        """Promote to belief should also delegate to process_raw."""
         k = MagicMock()
-        k.get_raw.side_effect = [
-            {"id": "abc12345", "content": "test"},
-            {"id": "abc12345", "content": "Belief statement", "tags": []},
-        ]
-        k.belief.return_value = "belief123"
-        k._storage.mark_raw_processed.return_value = True
+        k.get_raw.return_value = {"id": "abc12345", "content": "test"}
+        k.process_raw.return_value = "belief123"
 
         args = Namespace(
             raw_action="promote",
@@ -863,15 +870,75 @@ class TestCmdRawPromote:
 
         cmd_raw(args, k)
 
-        k.belief.assert_called_once()
+        k.process_raw.assert_called_once()
+        k.belief.assert_not_called()
+        k._storage.mark_raw_processed.assert_not_called()
         captured = capsys.readouterr()
-        assert "✓ Promoted to belief" in captured.out
+        assert "Promoted to belief" in captured.out
 
-    def test_promote_not_found(self, capsys):
-        """Promote non-existent entry."""
+    def test_promote_episode_passes_objective_and_outcome(self, capsys):
+        """Episode promote should pass objective and outcome kwargs."""
+        k = MagicMock()
+        k.get_raw.return_value = {"id": "abc12345", "content": "test"}
+        k.process_raw.return_value = "ep123456"
+
+        args = Namespace(
+            raw_action="promote",
+            id="abc12345",
+            type="episode",
+            objective="My objective",
+            outcome="My outcome",
+        )
+
+        cmd_raw(args, k)
+
+        call_kwargs = k.process_raw.call_args[1]
+        assert call_kwargs.get("objective") == "My objective"
+        assert call_kwargs.get("outcome") == "My outcome"
+
+    def test_promote_already_processed_fails(self, capsys):
+        """Already-processed raw entry should show error message."""
+        k = MagicMock()
+        k.get_raw.return_value = {"id": "abc12345", "content": "test"}
+        k.process_raw.side_effect = ValueError("Raw entry abc12345 already processed")
+
+        args = Namespace(
+            raw_action="promote",
+            id="abc12345",
+            type="note",
+            objective=None,
+            outcome=None,
+        )
+
+        cmd_raw(args, k)
+
+        captured = capsys.readouterr()
+        assert "already processed" in captured.out
+
+    def test_promote_unknown_type_fails(self, capsys):
+        """Unknown target type should show error from process_raw."""
+        k = MagicMock()
+        k.get_raw.return_value = {"id": "abc12345", "content": "test"}
+        k.process_raw.side_effect = ValueError("Invalid as_type: bogus")
+
+        args = Namespace(
+            raw_action="promote",
+            id="abc12345",
+            type="bogus",
+            objective=None,
+            outcome=None,
+        )
+
+        cmd_raw(args, k)
+
+        captured = capsys.readouterr()
+        assert "Invalid as_type" in captured.out
+
+    def test_promote_missing_raw_entry_fails(self, capsys):
+        """Nonexistent ID should show resolve error."""
         k = MagicMock()
         k.get_raw.return_value = None
-        k.list_raw.return_value = []
+        k._storage.find_raw_by_prefix.return_value = []
 
         args = Namespace(
             raw_action="promote",
@@ -884,8 +951,26 @@ class TestCmdRawPromote:
         cmd_raw(args, k)
 
         captured = capsys.readouterr()
-        assert "✗" in captured.out
         assert "not found" in captured.out
+
+    def test_promote_shows_processed_status(self, capsys):
+        """Successful promote should show that raw entry was marked as processed."""
+        k = MagicMock()
+        k.get_raw.return_value = {"id": "abc12345", "content": "test"}
+        k.process_raw.return_value = "note12345"
+
+        args = Namespace(
+            raw_action="promote",
+            id="abc12345",
+            type="note",
+            objective=None,
+            outcome=None,
+        )
+
+        cmd_raw(args, k)
+
+        captured = capsys.readouterr()
+        assert "Raw entry marked as processed" in captured.out
 
 
 class TestCmdRawTriage:

--- a/tests/test_writer_methods.py
+++ b/tests/test_writer_methods.py
@@ -1032,3 +1032,92 @@ class TestRelationshipSourceType:
         )
         saved_rel = mock_wb.save_relationship.call_args[0][0]
         assert saved_rel.source_entity == "user:bob"
+
+
+# =========================================================================
+# process_raw: blob/content field usage (#835)
+# =========================================================================
+
+
+class TestProcessRawBlobUsage:
+    """process_raw() should use entry.blob (preferred) with content as fallback."""
+
+    def test_process_raw_note_uses_blob(self, mocked_kernle):
+        """When a raw entry has blob set, process_raw should use blob as note content."""
+        k, mock_wb, mock_storage = mocked_kernle
+
+        raw_entry = MagicMock()
+        raw_entry.blob = "This is the blob content"
+        raw_entry.content = "This is the old content field"
+        raw_entry.processed = False
+        raw_entry.tags = []
+        mock_storage.get_raw.return_value = raw_entry
+
+        k.process_raw(raw_id="raw-123", as_type="note")
+
+        saved_note = mock_wb.save_note.call_args[0][0]
+        assert "blob content" in saved_note.content
+
+    def test_process_raw_note_falls_back_to_content(self, mocked_kernle):
+        """When blob is None, process_raw should fall back to content for notes."""
+        k, mock_wb, mock_storage = mocked_kernle
+
+        raw_entry = MagicMock()
+        raw_entry.blob = None
+        raw_entry.content = "Legacy content value"
+        raw_entry.processed = False
+        raw_entry.tags = []
+        mock_storage.get_raw.return_value = raw_entry
+
+        k.process_raw(raw_id="raw-123", as_type="note")
+
+        saved_note = mock_wb.save_note.call_args[0][0]
+        assert "Legacy content value" in saved_note.content
+
+    def test_process_raw_belief_uses_blob(self, mocked_kernle):
+        """When a raw entry has blob set, process_raw should use blob as belief statement."""
+        k, mock_wb, mock_storage = mocked_kernle
+
+        raw_entry = MagicMock()
+        raw_entry.blob = "Testing always improves quality"
+        raw_entry.content = "Old content"
+        raw_entry.processed = False
+        raw_entry.tags = []
+        mock_storage.get_raw.return_value = raw_entry
+
+        k.process_raw(raw_id="raw-123", as_type="belief")
+
+        saved_belief = mock_wb.save_belief.call_args[0][0]
+        assert saved_belief.statement == "Testing always improves quality"
+
+    def test_process_raw_belief_falls_back_to_content(self, mocked_kernle):
+        """When blob is None, process_raw should fall back to content for beliefs."""
+        k, mock_wb, mock_storage = mocked_kernle
+
+        raw_entry = MagicMock()
+        raw_entry.blob = None
+        raw_entry.content = "Legacy belief statement"
+        raw_entry.processed = False
+        raw_entry.tags = []
+        mock_storage.get_raw.return_value = raw_entry
+
+        k.process_raw(raw_id="raw-123", as_type="belief")
+
+        saved_belief = mock_wb.save_belief.call_args[0][0]
+        assert saved_belief.statement == "Legacy belief statement"
+
+    def test_process_raw_episode_uses_blob(self, mocked_kernle):
+        """Episode path should already use blob - verify it works correctly."""
+        k, mock_wb, mock_storage = mocked_kernle
+
+        raw_entry = MagicMock()
+        raw_entry.blob = "Completed the deployment with zero downtime"
+        raw_entry.content = "Old content"
+        raw_entry.processed = False
+        raw_entry.tags = []
+        mock_storage.get_raw.return_value = raw_entry
+
+        k.process_raw(raw_id="raw-123", as_type="episode")
+
+        saved_episode = mock_wb.save_episode.call_args[0][0]
+        assert "Completed the deployment" in saved_episode.objective


### PR DESCRIPTION
## Summary

- **Fix blob/content bug** in `process_raw()`: The note and belief code paths used the deprecated `entry.content` field instead of `entry.blob`. Now uses `entry.blob or entry.content or ""` for backward compatibility, matching the episode path that was already correct.
- **Refactor promote handler** in `raw.py`: Replaced inline memory creation (calling `k.episode()`, `k.note()`, `k.belief()` directly + manual `mark_raw_processed()`) with delegation to `k.process_raw()`. This eliminates code duplication and ensures promote/process follow identical behavior.
- **Add 13 new tests**: 5 for process_raw blob/content usage, 8 for CLI promote delegation.

## Intentional behavior changes

| Aspect | Before (promote) | After (promote) |
|--------|------------------|-----------------|
| source | `"cli-promote"` | `"raw-processing"` |
| tags | `["promoted"]` | `["raw"]` |
| enrichment | No outcome_type inference | outcome_type inferred for episodes |

## Files changed

- `kernle/core/writers.py` — Fix `process_raw()` note/belief paths to use blob
- `kernle/cli/commands/raw.py` — Refactor promote to delegate to `process_raw()`
- `tests/test_writer_methods.py` — Add `TestProcessRawBlobUsage` (5 tests)
- `tests/test_cli_raw.py` — Rewrite `TestCmdRawPromote` (8 tests)

## Test plan

- [x] `TestProcessRawBlobUsage::test_process_raw_note_uses_blob` — blob is used as note content
- [x] `TestProcessRawBlobUsage::test_process_raw_note_falls_back_to_content` — backward compat
- [x] `TestProcessRawBlobUsage::test_process_raw_belief_uses_blob` — blob is used as belief statement
- [x] `TestProcessRawBlobUsage::test_process_raw_belief_falls_back_to_content` — backward compat
- [x] `TestProcessRawBlobUsage::test_process_raw_episode_uses_blob` — episode path verified
- [x] `TestCmdRawPromote::test_promote_delegates_to_process_raw` — calls process_raw, not manual creation
- [x] `TestCmdRawPromote::test_promote_note_delegates_to_process_raw` — note delegation
- [x] `TestCmdRawPromote::test_promote_belief_delegates_to_process_raw` — belief delegation
- [x] `TestCmdRawPromote::test_promote_episode_passes_objective_and_outcome` — kwargs forwarded
- [x] `TestCmdRawPromote::test_promote_already_processed_fails` — ValueError handled
- [x] `TestCmdRawPromote::test_promote_unknown_type_fails` — ValueError handled
- [x] `TestCmdRawPromote::test_promote_missing_raw_entry_fails` — resolve error handled
- [x] `TestCmdRawPromote::test_promote_shows_processed_status` — success message correct
- [x] 277 raw-related tests pass (full regression sweep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)